### PR TITLE
Limit "ora_cols" CTE to tables (instead of also including views)

### DIFF
--- a/oracle_to_exasol.sql
+++ b/oracle_to_exasol.sql
@@ -135,7 +135,7 @@ success, res = pquery([[with ora_cols as(
 
 	select * from(
 		import from ]]..CONNECTION_TYPE..[[ at ::c
-		statement 'select ]]..all_tab_cols..[[  from all_tab_columns where owner ]]..SCHEMA_STR..[[ and table_name ]]..TABLE_STR..[['
+		statement 'select ]]..all_tab_cols..[[  from all_tab_columns where table_name in (select table_name from all_tables where owner ]]..SCHEMA_STR..[[ and table_name ]]..TABLE_STR..[[) and owner ]]..SCHEMA_STR..[[ and table_name ]]..TABLE_STR..[['
 				)
 			),
 	ora_base as ( --cast to correct types


### PR DESCRIPTION
in line 138, added " table_name in (select table_name from all_tables where owner ]]..SCHEMA_STR..[[ and table_name ]]..TABLE_STR..[[) and " so that we only get tables - materializing all views ( since those are also part of all_tab_columns ) is normally not what you´d want/expect  in a migration from ora to exa.
If backwards compatibility is an issue I could include this as a switch in the parameter list but I´d normally like to keep the signature lighter and this behavior seemed more appropriate.