### PR TITLE
Update the checking procedure for teradata migration

### DIFF
--- a/teradata_to_exasol.sql
+++ b/teradata_to_exasol.sql
@@ -61,71 +61,74 @@ with vv_columns as (
     ''tdwm'', ''SQLJ'', ''TD_SYSFNLIB'', ''SYSSPATIAL'') AND
                                 table_schema like '']]..SCHEMA_FILTER..[['' AND
                                 table_name like '']]..TABLE_FILTER..[[''
-		      ') as tableList order by false),
-vv_primary_keys_raw as (
-select   ]]..exa_upper_begin..[["table_schema"]]..exa_upper_end..[[ as "exa_table_schema", 
-	               ]]..exa_upper_begin..[["table_name"]]..exa_upper_end..[[ as "exa_table_name", 
-	               ]]..exa_upper_begin..[["column_name"]]..exa_upper_end..[[ as "exa_column_name",
-	               "table_schema" as "table_schema",
-	               "table_name" as "table_name",
-	               "column_name" as "column_name",
-	               "column_position" as "column_position"
-from (
-
-import from jdbc at ]]..CONNECTION_NAME..[[  
-        statement   '
-SELECT  DatabaseName as table_schema,
-        TableName as table_name,
-        ColumnName as column_name,
-        ColumnPosition as column_position
-FROM    DBC.IndicesV
-WHERE UniqueFlag = ''Y'' AND IndexType IN (''K'')
-and table_schema not in (''All'', ''Crashdumps'', ''DBC'', ''dbcmngr'', 
-    ''Default'', ''External_AP'', ''EXTUSER'', ''LockLogShredder'', ''PUBLIC'',
-    ''Sys_Calendar'', ''SysAdmin'', ''SYSBAR'', ''SYSJDBC'', ''SYSLIB'',
-    ''SystemFe'', ''SYSUDTLIB'', ''SYSUIF'', ''TD_SERVER_DB'', ''TDStats'',
-    ''TD_SYSGPL'', ''TD_SYSXML'', ''TDMaps'', ''TDPUSER'', ''TDQCD'',
-    ''tdwm'', ''SQLJ'', ''TD_SYSFNLIB'', ''SYSSPATIAL'') AND
-table_schema like '']]..SCHEMA_FILTER..[['' AND
-table_name like '']]..TABLE_FILTER..[['' 
-'
-) as primarykeylist
-),
-vv_foreign_keys_raw as (
-select   ]]..exa_upper_begin..[["ChildDB"]]..exa_upper_end..[[ as "exa_table_schema", 
-	 ]]..exa_upper_begin..[["ChildTable"]]..exa_upper_end..[[ as "exa_table_name", 
-	 ]]..exa_upper_begin..[["ChildKeyColumn"]]..exa_upper_end..[[ as "exa_foreign_key_column",
-	 ]]..exa_upper_begin..[["ParentDB"]]..exa_upper_end..[[ as "exa_referenced_table_schema", 
-	 ]]..exa_upper_begin..[["ParentTable"]]..exa_upper_end..[[ as "exa_referenced_table_name"
-from (
-
-import from jdbc at ]]..CONNECTION_NAME..[[  
-    statement   ' 
-    SELECT  ChildDB,
-		ChildTable,
-        ChildKeyColumn,
-        ParentDB ,
-        ParentTable 
-FROM    DBC.All_RI_ChildrenV
-WHERE   ChildDB NOT IN (''All'', ''Crashdumps'', ''DBC'', ''dbcmngr'', 
-    ''Default'', ''External_AP'', ''EXTUSER'', ''LockLogShredder'', ''PUBLIC'',
-    ''Sys_Calendar'', ''SysAdmin'', ''SYSBAR'', ''SYSJDBC'', ''SYSLIB'',
-    ''SystemFe'', ''SYSUDTLIB'', ''SYSUIF'', ''TD_SERVER_DB'', ''TDStats'',
-    ''TD_SYSGPL'', ''TD_SYSXML'', ''TDMaps'', ''TDPUSER'', ''TDQCD'',
-    ''tdwm'', ''SQLJ'', ''TD_SYSFNLIB'', ''SYSSPATIAL'') and
-ChildDB like '']]..SCHEMA_FILTER..[['' AND
-ChildTable like '']]..TABLE_FILTER..[['' 
-'
+		      ') as tableList order by false
 )
 
-),
-vv_create_schemas as(
+, vv_primary_keys_raw as (
+	select	]]..exa_upper_begin..[["table_schema"]]..exa_upper_end..[[ as "exa_table_schema", 
+			]]..exa_upper_begin..[["table_name"]]..exa_upper_end..[[ as "exa_table_name", 
+			]]..exa_upper_begin..[["column_name"]]..exa_upper_end..[[ as "exa_column_name",
+			"table_schema" as "table_schema",
+	        "table_name" as "table_name",
+	        "column_name" as "column_name",
+	        "column_position" as "column_position"
+	from (
+			import from jdbc at ]]..CONNECTION_NAME..[[  
+			statement '
+			SELECT  DatabaseName as table_schema,
+			        TableName as table_name,
+			        ColumnName as column_name,
+			        ColumnPosition as column_position
+			FROM    DBC.IndicesV
+			WHERE UniqueFlag = ''Y'' AND IndexType IN (''K'')
+			and table_schema not in (''All'', ''Crashdumps'', ''DBC'', ''dbcmngr'', 
+			    ''Default'', ''External_AP'', ''EXTUSER'', ''LockLogShredder'', ''PUBLIC'',
+			    ''Sys_Calendar'', ''SysAdmin'', ''SYSBAR'', ''SYSJDBC'', ''SYSLIB'',
+			    ''SystemFe'', ''SYSUDTLIB'', ''SYSUIF'', ''TD_SERVER_DB'', ''TDStats'',
+			    ''TD_SYSGPL'', ''TD_SYSXML'', ''TDMaps'', ''TDPUSER'', ''TDQCD'',
+			    ''tdwm'', ''SQLJ'', ''TD_SYSFNLIB'', ''SYSSPATIAL'') AND
+			table_schema like '']]..SCHEMA_FILTER..[['' AND
+			table_name like '']]..TABLE_FILTER..[['' 
+			'
+	) as primarykeylist
+)
+
+, vv_foreign_keys_raw as (
+	select   ]]..exa_upper_begin..[["ChildDB"]]..exa_upper_end..[[ as "exa_table_schema", 
+		 ]]..exa_upper_begin..[["ChildTable"]]..exa_upper_end..[[ as "exa_table_name", 
+		 ]]..exa_upper_begin..[["ChildKeyColumn"]]..exa_upper_end..[[ as "exa_foreign_key_column",
+		 ]]..exa_upper_begin..[["ParentDB"]]..exa_upper_end..[[ as "exa_referenced_table_schema", 
+		 ]]..exa_upper_begin..[["ParentTable"]]..exa_upper_end..[[ as "exa_referenced_table_name"
+	from (
+			import from jdbc at ]]..CONNECTION_NAME..[[  
+			statement ' 
+			SELECT  ChildDB,
+					ChildTable,
+			        ChildKeyColumn,
+			        ParentDB ,
+			        ParentTable 
+			FROM    DBC.All_RI_ChildrenV
+			WHERE   ChildDB NOT IN (''All'', ''Crashdumps'', ''DBC'', ''dbcmngr'', 
+			    ''Default'', ''External_AP'', ''EXTUSER'', ''LockLogShredder'', ''PUBLIC'',
+			    ''Sys_Calendar'', ''SysAdmin'', ''SYSBAR'', ''SYSJDBC'', ''SYSLIB'',
+			    ''SystemFe'', ''SYSUDTLIB'', ''SYSUIF'', ''TD_SERVER_DB'', ''TDStats'',
+			    ''TD_SYSGPL'', ''TD_SYSXML'', ''TDMaps'', ''TDPUSER'', ''TDQCD'',
+			    ''tdwm'', ''SQLJ'', ''TD_SYSFNLIB'', ''SYSSPATIAL'') and
+			ChildDB like '']]..SCHEMA_FILTER..[['' AND
+			ChildTable like '']]..TABLE_FILTER..[['' 
+			'
+	)
+
+)
+
+, vv_create_schemas as(
 	SELECT 'create schema if not exists "' || "exa_table_schema" || '";' as sql_text 
 	from vv_columns  
 	group by "exa_table_schema" 
 	order by "exa_table_schema"
 )
-,vv_create_tables as (
+
+, vv_create_tables as (
 	select 'create or replace table "' || "exa_table_schema" || '"."' || "exa_table_name" || '" (' || 
 	group_concat(
 	case 
@@ -138,9 +141,7 @@ vv_create_schemas as(
 	else
 	       '"' ||  "exa_column_name" || '" ' 
 	end
-	   
-	    ||
-	        
+	||  
 	case 
 	when "data_type" = 'PD' then ''  --Period is already splitted into two dates before
 	when "data_type" in ('PS', 'PM', 'PT', 'PZ') then ''  --Period is already splitted into two timestamps before
@@ -234,61 +235,64 @@ vv_create_schemas as(
 	group by       "exa_table_schema", "exa_table_name"
 	order by       "exa_table_schema","exa_table_name"
 )
+
 , vv_primary_keys as (
-
-select 'ALTER TABLE "' || "exa_table_schema" || '"."' || "exa_table_name" || '" ADD CONSTRAINT PRIMARY KEY (' || 
-	group_concat('"'||  "exa_column_name" || '"'  order by "column_position")  || ') ;' as sql_text
-from           vv_primary_keys_raw   
-	group by       "exa_table_schema", "exa_table_name"
-	order by       "exa_table_schema","exa_table_name"
-
-), vv_foreign_keys as (
-
-select 'ALTER TABLE "' || "exa_table_schema" || '"."' || "exa_table_name" ||
- '" ADD FOREIGN KEY (' || '"'||  "exa_foreign_key_column" || '") REFERENCES "' || "exa_referenced_table_schema" || '"."' || "exa_referenced_table_name" || '" DISABLE ;' as sql_text
-from vv_foreign_keys_raw   
-order by "exa_table_schema","exa_table_name"
-
+	select 	'ALTER TABLE "' || "exa_table_schema" || '"."' || "exa_table_name" || '" ADD CONSTRAINT PRIMARY KEY (' || 
+			group_concat('"'||  "exa_column_name" || '"'  order by "column_position")  || ') ;' as sql_text
+	from vv_primary_keys_raw   
+	group by "exa_table_schema", "exa_table_name"
+	order by "exa_table_schema","exa_table_name"
 )
+
+, vv_foreign_keys as (
+	select 'ALTER TABLE "' || "exa_table_schema" || '"."' || "exa_table_name" ||
+	 '" ADD FOREIGN KEY (' || '"'||  "exa_foreign_key_column" || '") REFERENCES "' || "exa_referenced_table_schema" || '"."' || "exa_referenced_table_name" || '" DISABLE ;' as sql_text
+	from vv_foreign_keys_raw   
+	order by "exa_table_schema","exa_table_name"
+)
+
 , vv_imports as (
-	select 'import into "' || "exa_table_schema" || '"."' || "exa_table_name" || '" from jdbc at ]]..CONNECTION_NAME..[[ statement ''select ' || group_concat( 
-	case 
-	when "data_type" = 'DA' then "column_name_delimited"
-	when "data_type" = 'D'  then "column_name_delimited"
-	when "data_type" = 'TS' then "column_name_delimited"
-	when "data_type" = 'CF' then "column_name_delimited"
-	when "data_type" = 'I1' then "column_name_delimited"
-	when "data_type" = 'I2' then "column_name_delimited"
-	when "data_type" = 'I8' then "column_name_delimited"
-	when "data_type" = 'AT' then "column_name_delimited"
-	when "data_type" = 'F'  then "column_name_delimited"
-	when "data_type" = 'CV' then "column_name_delimited"
-	when "data_type" = 'I'  then "column_name_delimited"
-	when "data_type" = 'N'  then "column_name_delimited"
-	when "data_type" in ('A1','AN')  then 'cast(' || "column_name_delimited" || ' as varchar(64000)) '  --array datatypes are casted to a varchar in Teradata
-	when "data_type" in ('BF', 'BO', 'BV') then '''''NOT SUPPORTED''''' --binary data types (BYTE, VARBYTE, BLOB) are not supported
-	when "data_type" = 'JN'  then 'CAST(' || "column_name_delimited" ||  ' AS CLOB ) ' --json (max length in Exasol is 2000000 as it is stored as varchar)  
-	when "data_type" = 'PD'  then  'BEGIN('|| "column_name_delimited" || ') , END(' ||  "column_name_delimited" || ')'  --Period(Date) split into begin and end date
-	when "data_type" in ('PS', 'PM')  then  'CAST(  BEGIN('|| "column_name_delimited" || ') AS TIMESTAMP ) , CAST ( END(' ||  "column_name_delimited" || ') AS TIMESTAMP ) '  --Period(Timestamp) split into begin and end timestamp  
-	when "data_type" in ('PT', 'PZ')  then  'CAST(  BEGIN('|| "column_name_delimited" || ') AS TIME ) , CAST ( END(' ||  "column_name_delimited" || ') AS TIME ) '  --Period(Time) split into begin and end time	
-	when "data_type" = 'TZ' then  'cast(' || "column_name_delimited" || ' AS TIME)'  --time with time zone
-	when "data_type" = 'SZ' then  'cast(' || "column_name_delimited" || ' AS TIMESTAMP)'  --timestamp with time zone
-	when "data_type" = 'YR'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL YEAR  TO MONTH ) AS VARCHAR(50))'  --Interval Year
-	when "data_type" = 'YM'  then 'cast('|| "column_name_delimited" || ' AS VARCHAR(50) )'  --Interval Year to Month
-	when "data_type" = 'MO'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL YEAR  TO MONTH ) AS VARCHAR(50))'  --Interval Month
-	when "data_type" = 'DY'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) ' --Interval Day
-	when "data_type" = 'DH'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Day to hour
-	when "data_type" = 'DM'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Day to minute
-	when "data_type" = 'DS'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval day to second
-	when "data_type" = 'HR'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Hour
-	when "data_type" = 'HM'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Day to minute
-	when "data_type" = 'HS'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval day to second
-	when "data_type" = 'MI'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) ' --Interval Minute
-	when "data_type" = 'MS'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval minute to second
-	when "data_type" = 'SC'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval Second
-	else "column_name_delimited"
-	end
-	order by "ordinal_position") || ' from ' || "table_schema"|| '.' || "table_name"|| ''';' as sql_text
+	select 	'import into "' || "exa_table_schema" || '"."' || "exa_table_name" || '" from jdbc at ]]..CONNECTION_NAME..[[ statement ''select ' || 
+			group_concat( 
+				case 
+				when "data_type" = 'DA' then "column_name_delimited"
+				when "data_type" = 'D'  then "column_name_delimited"
+				when "data_type" = 'TS' then "column_name_delimited"
+				when "data_type" = 'CF' then "column_name_delimited"
+				when "data_type" = 'I1' then "column_name_delimited"
+				when "data_type" = 'I2' then "column_name_delimited"
+				when "data_type" = 'I8' then "column_name_delimited"
+				when "data_type" = 'AT' then "column_name_delimited"
+				when "data_type" = 'F'  then "column_name_delimited"
+				when "data_type" = 'CV' then "column_name_delimited"
+				when "data_type" = 'I'  then "column_name_delimited"
+				when "data_type" = 'N'  then "column_name_delimited"
+				when "data_type" in ('A1','AN')  then 'cast(' || "column_name_delimited" || ' as varchar(64000)) '  --array datatypes are casted to a varchar in Teradata
+				when "data_type" in ('BF', 'BO', 'BV') then '''''NOT SUPPORTED''''' --binary data types (BYTE, VARBYTE, BLOB) are not supported
+				when "data_type" = 'JN'  then 'CAST(' || "column_name_delimited" ||  ' AS CLOB ) ' --json (max length in Exasol is 2000000 as it is stored as varchar)  
+				when "data_type" = 'PD'  then  'BEGIN('|| "column_name_delimited" || ') , END(' ||  "column_name_delimited" || ')'  --Period(Date) split into begin and end date
+				when "data_type" in ('PS', 'PM')  then  'CAST(  BEGIN('|| "column_name_delimited" || ') AS TIMESTAMP ) , CAST ( END(' ||  "column_name_delimited" || ') AS TIMESTAMP ) '  --Period(Timestamp) split into begin and end timestamp  
+				when "data_type" in ('PT', 'PZ')  then  'CAST(  BEGIN('|| "column_name_delimited" || ') AS TIME ) , CAST ( END(' ||  "column_name_delimited" || ') AS TIME ) '  --Period(Time) split into begin and end time	
+				when "data_type" = 'TZ' then  'cast(' || "column_name_delimited" || ' AS TIME)'  --time with time zone
+				when "data_type" = 'SZ' then  'cast(' || "column_name_delimited" || ' AS TIMESTAMP)'  --timestamp with time zone
+				when "data_type" = 'YR'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL YEAR  TO MONTH ) AS VARCHAR(50))'  --Interval Year
+				when "data_type" = 'YM'  then 'cast('|| "column_name_delimited" || ' AS VARCHAR(50) )'  --Interval Year to Month
+				when "data_type" = 'MO'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL YEAR  TO MONTH ) AS VARCHAR(50))'  --Interval Month
+				when "data_type" = 'DY'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) ' --Interval Day
+				when "data_type" = 'DH'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Day to hour
+				when "data_type" = 'DM'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Day to minute
+				when "data_type" = 'DS'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval day to second
+				when "data_type" = 'HR'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Hour
+				when "data_type" = 'HM'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Day to minute
+				when "data_type" = 'HS'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval day to second
+				when "data_type" = 'MI'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) ' --Interval Minute
+				when "data_type" = 'MS'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval minute to second
+				when "data_type" = 'SC'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval Second
+				else "column_name_delimited"
+				end
+				order by "ordinal_position"
+			) || 
+			' from ' || "table_schema"|| '.' || "table_name"|| ''';' as sql_text
 	from vv_columns 
 	group by "exa_table_schema","exa_table_name", "table_schema","table_name"
 	order by "exa_table_schema","exa_table_name", "table_schema","table_name"
@@ -451,7 +455,6 @@ order by "exa_table_schema","exa_table_name"
 	                		end
 	                when "metric_id" = 1 then 'not checked ''' || c."exa_column_name" || ''''
 	        end		"metric_column_name"
-	        
 	from vv_columns c 
 	left join vv_primary_keys_raw p
 	on c."exa_table_schema" = p."exa_table_schema"
@@ -476,13 +479,13 @@ order by "exa_table_schema","exa_table_name"
                         case when "db_system" = 'Exasol' then '"' || "exa_table_schema" || '"."' || "exa_table_name" || '"' else '"' || "table_schema" || '"."' || "table_name" || '"' end ||
                         case when "db_system" = 'Teradata' then ''') ' end 
                         as "check_sql"
-                
                 from vv_checks_expr
                 group by "db_system", "exa_table_schema", "exa_table_name", "table_schema", "table_name", "metric_table"
         )
         group by "exa_table_schema", "metric_table"
         order by "exa_table_schema", "metric_table"
 )
+
 , vv_check_summary as (       
         select  'create or replace table database_migration.migration_check (schema_name varchar(128), table_name varchar(128), column_name varchar(128), exasol_metric varchar(50), teradata_metric varchar(50), check_timestamp timestamp default current_timestamp);' as sql_text
         union all
@@ -508,39 +511,6 @@ order by "exa_table_schema","exa_table_name"
         select 'select * from database_migration.migration_check where exasol_metric != teradata_metric;' as sql_text
         from dual
 )
-
-
-
-
-
-, vv_check_summary as (       
-        select  'create or replace table "' || "metric_schema" || '"."' || "exa_table_schema" || '_MIG_CHK" (schema_name varchar(128), table_name varchar(128), column_name varchar(128), metric_schema varchar(128), metric_table varchar(128),  metric_name varchar(128), exasol_metric varchar(50), teradata_metric varchar(50), check_timestamp timestamp default current_timestamp);' as sql_text
-        from vv_checks_expr
-        group by "metric_schema", "exa_table_schema"
-        union all
-        select  'insert into "' || "metric_schema" || '"."' || "exa_table_schema" || '_MIG_CHK" (schema_name, table_name, column_name, metric_schema, metric_table, metric_name, exasol_metric, teradata_metric) ' 
-                || listagg(sql_text, '') within group(order by case when "db_system" = 'Exasol' then 1 else 2 end) || ' '
-                || 'select e.schema_name, e.table_name, e.column_name, e.metric_schema, e.metric_table, e.metric_name, e.exasol_metric, t.teradata_metric from exasol e join teradata t on e.schema_name = t.schema_name and e.table_name = t.table_name and e.column_name = t.column_name; ' as sql_text
-        from (
-        
-                select  "db_system", "exa_table_schema", "exa_table_name", "metric_schema",
-                        case when "db_system" = 'Exasol' then 'with ' else ', ' end || "db_system" || ' as ( '
-                        || listagg(
-                        	'select ''' || "exa_table_schema" || ''' as schema_name, ''' || "exa_table_name" || ''' as table_name,  ''' || "exa_column_name" || ''' column_name, ''' || "metric_schema" || ''' metric_schema, ''' || "metric_table" || ''' metric_table, ''' || "metric_column_name" || ''' as metric_name, to_char(' || "metric_column_name" || ') as ' || "db_system" || '_metric from "' || "exa_table_schema" || '"."' || "metric_table" || '" where DB_SYSTEM = ''' || "db_system" || '''', ' union all ')
-                        || ' )'  as sql_text
-                from vv_checks_expr
-                group by "db_system", "exa_table_schema", "exa_table_name", "metric_schema", "metric_table"
-                order by case when "db_system" = 'Exasol' then 1 else 2 end
-        
-        )
-        group by "exa_table_schema", "exa_table_name", "metric_schema"
-        union all
-        select  '--select * from "' || "metric_schema" || '"."' || "exa_table_schema" || '_MIG_CHK" where exasol_metric != teradata_metric;' as sql_text
-        from vv_checks_expr
-        group by "metric_schema", "exa_table_schema"
-)
-
-
 select * from vv_create_schemas
 UNION ALL
 select * from vv_create_tables

--- a/teradata_to_exasol.sql
+++ b/teradata_to_exasol.sql
@@ -32,116 +32,114 @@ end
 
 res = query([[
 with vv_columns as (
-	select         ]]..exa_upper_begin..[["table_schema"]]..exa_upper_end..[[ as "exa_table_schema", 
-	               ]]..exa_upper_begin..[["table_name"]]..exa_upper_end..[[ as "exa_table_name", 
-	               ]]..exa_upper_begin..[["column_name"]]..exa_upper_end..[[ as "exa_column_name"
-	               , '"' || "column_name" || '"' as "column_name_delimited"
-	               , tableList.* 
-        from            (import from jdbc at ]]..CONNECTION_NAME..[[ 
-        statement      'select trim(c.DatabaseName) as  table_schema, 
-                                trim(c.TableName) as    table_name, 
-                                ColumnName as           column_name,
-                                ColumnId as             ordinal_position, 
-                                trim(ColumnType) as     data_type, 
-                                cast(case when ColumnType in (''CF'', ''CV'') then substr(ColumnFormat, 3, length(ColumnFormat)-3) else ColumnLength end as integer) as character_maximum_length,
-                                DecimalTotalDigits as   numeric_precision, 
-                                DecimalFractionalDigits as numeric_scale,
-                                DecimalFractionalDigits as datetime_precision, 
-                                Nullable as nullable 
-                        from    DBC.ColumnsV c
-                        join    DBC.TablesV t on 
-                                c.databaseName=t.DatabaseName AND 
-                                c.TableName=t.TableName AND 
-                                TableKind=''T''
-                        where   table_schema not in (''All'', ''Crashdumps'', ''DBC'', ''dbcmngr'', 
-    ''Default'', ''External_AP'', ''EXTUSER'', ''LockLogShredder'', ''PUBLIC'',
-    ''Sys_Calendar'', ''SysAdmin'', ''SYSBAR'', ''SYSJDBC'', ''SYSLIB'',
-    ''SystemFe'', ''SYSUDTLIB'', ''SYSUIF'', ''TD_SERVER_DB'', ''TDStats'',
-    ''TD_SYSGPL'', ''TD_SYSXML'', ''TDMaps'', ''TDPUSER'', ''TDQCD'',
-    ''tdwm'', ''SQLJ'', ''TD_SYSFNLIB'', ''SYSSPATIAL'') AND
-                                table_schema like '']]..SCHEMA_FILTER..[['' AND
-                                table_name like '']]..TABLE_FILTER..[[''
-		      ') as tableList order by false
+	select	]]..exa_upper_begin..[["table_schema"]]..exa_upper_end..[[ as "exa_table_schema", 
+        	]]..exa_upper_begin..[["table_name"]]..exa_upper_end..[[ as "exa_table_name", 
+       		]]..exa_upper_begin..[["column_name"]]..exa_upper_end..[[ as "exa_column_name", 
+			'"' || "column_name" || '"' as "column_name_delimited", 
+			tableList.* 
+	from 	(
+		import from jdbc at ]]..CONNECTION_NAME..[[ 
+    	statement '
+		select 	trim(c.DatabaseName) as  table_schema, 
+        		trim(c.TableName) as    table_name, 
+        		ColumnName as           column_name,
+        		ColumnId as             ordinal_position, 
+        		trim(ColumnType) as     data_type, 
+        		cast(case when ColumnType in (''CF'', ''CV'') then substr(ColumnFormat, 3, length(ColumnFormat)-3) else ColumnLength end as integer) as character_maximum_length,
+        		DecimalTotalDigits as   numeric_precision, 
+       			DecimalFractionalDigits as numeric_scale,
+        		DecimalFractionalDigits as datetime_precision, 
+        		Nullable as nullable 
+        from    DBC.ColumnsV c
+        join    DBC.TablesV t
+		on 		c.databaseName=t.DatabaseName 
+		AND 	c.TableName=t.TableName 
+		AND 	TableKind=''T''
+        where   table_schema not in (''All'', ''Crashdumps'', ''DBC'', ''dbcmngr'', 
+				''Default'', ''External_AP'', ''EXTUSER'', ''LockLogShredder'', ''PUBLIC'',
+				''Sys_Calendar'', ''SysAdmin'', ''SYSBAR'', ''SYSJDBC'', ''SYSLIB'',
+				''SystemFe'', ''SYSUDTLIB'', ''SYSUIF'', ''TD_SERVER_DB'', ''TDStats'',
+				''TD_SYSGPL'', ''TD_SYSXML'', ''TDMaps'', ''TDPUSER'', ''TDQCD'',
+				''tdwm'', ''SQLJ'', ''TD_SYSFNLIB'', ''SYSSPATIAL'') 
+		AND 	table_schema like '']]..SCHEMA_FILTER..[['' 
+		AND		table_name like '']]..TABLE_FILTER..[[''
+		') as tableList
 )
 
 , vv_primary_keys_raw as (
 	select	]]..exa_upper_begin..[["table_schema"]]..exa_upper_end..[[ as "exa_table_schema", 
-			]]..exa_upper_begin..[["table_name"]]..exa_upper_end..[[ as "exa_table_name", 
-			]]..exa_upper_begin..[["column_name"]]..exa_upper_end..[[ as "exa_column_name",
-			"table_schema" as "table_schema",
-	        "table_name" as "table_name",
-	        "column_name" as "column_name",
-	        "column_position" as "column_position"
-	from (
-			import from jdbc at ]]..CONNECTION_NAME..[[  
-			statement '
-			SELECT  DatabaseName as table_schema,
-			        TableName as table_name,
-			        ColumnName as column_name,
-			        ColumnPosition as column_position
-			FROM    DBC.IndicesV
-			WHERE UniqueFlag = ''Y'' AND IndexType IN (''K'')
-			and table_schema not in (''All'', ''Crashdumps'', ''DBC'', ''dbcmngr'', 
-			    ''Default'', ''External_AP'', ''EXTUSER'', ''LockLogShredder'', ''PUBLIC'',
-			    ''Sys_Calendar'', ''SysAdmin'', ''SYSBAR'', ''SYSJDBC'', ''SYSLIB'',
-			    ''SystemFe'', ''SYSUDTLIB'', ''SYSUIF'', ''TD_SERVER_DB'', ''TDStats'',
-			    ''TD_SYSGPL'', ''TD_SYSXML'', ''TDMaps'', ''TDPUSER'', ''TDQCD'',
-			    ''tdwm'', ''SQLJ'', ''TD_SYSFNLIB'', ''SYSSPATIAL'') AND
-			table_schema like '']]..SCHEMA_FILTER..[['' AND
-			table_name like '']]..TABLE_FILTER..[['' 
-			'
+            ]]..exa_upper_begin..[["table_name"]]..exa_upper_end..[[ as "exa_table_name", 
+            ]]..exa_upper_begin..[["column_name"]]..exa_upper_end..[[ as "exa_column_name",
+            "table_schema" as "table_schema",
+            "table_name" as "table_name",
+            "column_name" as "column_name",
+           "column_position" as "column_position"
+	from 	(
+		import from jdbc at ]]..CONNECTION_NAME..[[  
+		statement '
+		SELECT  DatabaseName as table_schema,
+		        TableName as table_name,
+		        ColumnName as column_name,
+		        ColumnPosition as column_position
+		FROM    DBC.IndicesV
+		WHERE 	UniqueFlag = ''Y'' AND IndexType IN (''K'')
+		and 	table_schema not in (''All'', ''Crashdumps'', ''DBC'', ''dbcmngr'', 
+		    	''Default'', ''External_AP'', ''EXTUSER'', ''LockLogShredder'', ''PUBLIC'',
+		    	''Sys_Calendar'', ''SysAdmin'', ''SYSBAR'', ''SYSJDBC'', ''SYSLIB'',
+		    	''SystemFe'', ''SYSUDTLIB'', ''SYSUIF'', ''TD_SERVER_DB'', ''TDStats'',
+		    	''TD_SYSGPL'', ''TD_SYSXML'', ''TDMaps'', ''TDPUSER'', ''TDQCD'',
+		    	''tdwm'', ''SQLJ'', ''TD_SYSFNLIB'', ''SYSSPATIAL'') 
+		and		table_schema like '']]..SCHEMA_FILTER..[['' 
+		and		table_name like '']]..TABLE_FILTER..[['' 
+		'
 	) as primarykeylist
 )
 
-, vv_foreign_keys_raw as (
-	select   ]]..exa_upper_begin..[["ChildDB"]]..exa_upper_end..[[ as "exa_table_schema", 
-		 ]]..exa_upper_begin..[["ChildTable"]]..exa_upper_end..[[ as "exa_table_name", 
-		 ]]..exa_upper_begin..[["ChildKeyColumn"]]..exa_upper_end..[[ as "exa_foreign_key_column",
-		 ]]..exa_upper_begin..[["ParentDB"]]..exa_upper_end..[[ as "exa_referenced_table_schema", 
-		 ]]..exa_upper_begin..[["ParentTable"]]..exa_upper_end..[[ as "exa_referenced_table_name"
-	from (
-			import from jdbc at ]]..CONNECTION_NAME..[[  
-			statement ' 
-			SELECT  ChildDB,
-					ChildTable,
-			        ChildKeyColumn,
-			        ParentDB ,
-			        ParentTable 
-			FROM    DBC.All_RI_ChildrenV
-			WHERE   ChildDB NOT IN (''All'', ''Crashdumps'', ''DBC'', ''dbcmngr'', 
-			    ''Default'', ''External_AP'', ''EXTUSER'', ''LockLogShredder'', ''PUBLIC'',
-			    ''Sys_Calendar'', ''SysAdmin'', ''SYSBAR'', ''SYSJDBC'', ''SYSLIB'',
-			    ''SystemFe'', ''SYSUDTLIB'', ''SYSUIF'', ''TD_SERVER_DB'', ''TDStats'',
-			    ''TD_SYSGPL'', ''TD_SYSXML'', ''TDMaps'', ''TDPUSER'', ''TDQCD'',
-			    ''tdwm'', ''SQLJ'', ''TD_SYSFNLIB'', ''SYSSPATIAL'') and
-			ChildDB like '']]..SCHEMA_FILTER..[['' AND
-			ChildTable like '']]..TABLE_FILTER..[['' 
-			'
+,vv_foreign_keys_raw as (
+	select	]]..exa_upper_begin..[["ChildDB"]]..exa_upper_end..[[ as "exa_table_schema", 
+ 			]]..exa_upper_begin..[["ChildTable"]]..exa_upper_end..[[ as "exa_table_name", 
+ 			]]..exa_upper_begin..[["ChildKeyColumn"]]..exa_upper_end..[[ as "exa_foreign_key_column",
+ 			]]..exa_upper_begin..[["ParentDB"]]..exa_upper_end..[[ as "exa_referenced_table_schema", 
+ 			]]..exa_upper_begin..[["ParentTable"]]..exa_upper_end..[[ as "exa_referenced_table_name"
+	from 	(
+		import from jdbc at ]]..CONNECTION_NAME..[[  
+	    statement ' 
+	    SELECT  ChildDB,
+				ChildTable,
+	        	ChildKeyColumn,
+	        	ParentDB ,
+	        	ParentTable 
+		FROM    DBC.All_RI_ChildrenV
+		WHERE   ChildDB NOT IN (''All'', ''Crashdumps'', ''DBC'', ''dbcmngr'', 
+	    		''Default'', ''External_AP'', ''EXTUSER'', ''LockLogShredder'', ''PUBLIC'',
+	    		''Sys_Calendar'', ''SysAdmin'', ''SYSBAR'', ''SYSJDBC'', ''SYSLIB'',
+	    		''SystemFe'', ''SYSUDTLIB'', ''SYSUIF'', ''TD_SERVER_DB'', ''TDStats'',
+	    		''TD_SYSGPL'', ''TD_SYSXML'', ''TDMaps'', ''TDPUSER'', ''TDQCD'',
+	   			''tdwm'', ''SQLJ'', ''TD_SYSFNLIB'', ''SYSSPATIAL'') 
+		and		ChildDB like '']]..SCHEMA_FILTER..[['' 
+		and		ChildTable like '']]..TABLE_FILTER..[['' 
+		'
 	)
-
+),
+vv_create_schemas as(
+		SELECT	'create schema if not exists "' || "exa_table_schema" || '";' as sql_text 
+		from 	vv_columns  
+		group by "exa_table_schema" 
+		order by "exa_table_schema"
 )
-
-, vv_create_schemas as(
-	SELECT 'create schema if not exists "' || "exa_table_schema" || '";' as sql_text 
-	from vv_columns  
-	group by "exa_table_schema" 
-	order by "exa_table_schema"
-)
-
-, vv_create_tables as (
-	select 'create or replace table "' || "exa_table_schema" || '"."' || "exa_table_name" || '" (' || 
+,vv_create_tables as (
+	select 	'create or replace table "' || "exa_table_schema" || '"."' || "exa_table_name" || '" (' || 
 	group_concat(
 	case 
 	when "data_type" = 'PD' then -- a teradata PERIOD(DATE) is splitted into the beginning and end DATE  
-	       '"' ||  "exa_column_name" || '_BEGINNING " DATE,' ||
-	       '"' ||  "exa_column_name" || '_END" DATE' 
+		'"' ||  "exa_column_name" || '_BEGINNING " DATE,' ||
+		'"' ||  "exa_column_name" || '_END" DATE' 
 	when "data_type" in ('PS', 'PM', 'PT', 'PZ')  then  -- a teradata PERIOD(TIMESTAMP) is splitted into the beginning and end TIMESTAMP  
-	       '"' ||  "exa_column_name" || '_BEGINNING " TIMESTAMP,' ||
-	       '"' ||  "exa_column_name" || '_END" TIMESTAMP'        	       
+		'"' ||  "exa_column_name" || '_BEGINNING " TIMESTAMP,' ||
+		'"' ||  "exa_column_name" || '_END" TIMESTAMP'        	       
 	else
-	       '"' ||  "exa_column_name" || '" ' 
-	end
-	||  
+		'"' ||  "exa_column_name" || '" ' 
+	end ||	        
 	case 
 	when "data_type" = 'PD' then ''  --Period is already splitted into two dates before
 	when "data_type" in ('PS', 'PM', 'PT', 'PZ') then ''  --Period is already splitted into two timestamps before
@@ -237,62 +235,59 @@ with vv_columns as (
 )
 
 , vv_primary_keys as (
-	select 	'ALTER TABLE "' || "exa_table_schema" || '"."' || "exa_table_name" || '" ADD CONSTRAINT PRIMARY KEY (' || 
-			group_concat('"'||  "exa_column_name" || '"'  order by "column_position")  || ') ;' as sql_text
-	from vv_primary_keys_raw   
-	group by "exa_table_schema", "exa_table_name"
-	order by "exa_table_schema","exa_table_name"
-)
+	select 'ALTER TABLE "' || "exa_table_schema" || '"."' || "exa_table_name" || '" ADD CONSTRAINT PRIMARY KEY (' || 
+		group_concat('"'||  "exa_column_name" || '"'  order by "column_position")  || ') ;' as sql_text
+	from           vv_primary_keys_raw   
+		group by       "exa_table_schema", "exa_table_name"
+		order by       "exa_table_schema","exa_table_name"
 
-, vv_foreign_keys as (
-	select 'ALTER TABLE "' || "exa_table_schema" || '"."' || "exa_table_name" ||
-	 '" ADD FOREIGN KEY (' || '"'||  "exa_foreign_key_column" || '") REFERENCES "' || "exa_referenced_table_schema" || '"."' || "exa_referenced_table_name" || '" DISABLE ;' as sql_text
-	from vv_foreign_keys_raw   
-	order by "exa_table_schema","exa_table_name"
-)
+), vv_foreign_keys as (
 
+select 'ALTER TABLE "' || "exa_table_schema" || '"."' || "exa_table_name" ||
+ '" ADD FOREIGN KEY (' || '"'||  "exa_foreign_key_column" || '") REFERENCES "' || "exa_referenced_table_schema" || '"."' || "exa_referenced_table_name" || '" DISABLE ;' as sql_text
+from vv_foreign_keys_raw   
+order by "exa_table_schema","exa_table_name"
+
+)
 , vv_imports as (
-	select 	'import into "' || "exa_table_schema" || '"."' || "exa_table_name" || '" from jdbc at ]]..CONNECTION_NAME..[[ statement ''select ' || 
-			group_concat( 
-				case 
-				when "data_type" = 'DA' then "column_name_delimited"
-				when "data_type" = 'D'  then "column_name_delimited"
-				when "data_type" = 'TS' then "column_name_delimited"
-				when "data_type" = 'CF' then "column_name_delimited"
-				when "data_type" = 'I1' then "column_name_delimited"
-				when "data_type" = 'I2' then "column_name_delimited"
-				when "data_type" = 'I8' then "column_name_delimited"
-				when "data_type" = 'AT' then "column_name_delimited"
-				when "data_type" = 'F'  then "column_name_delimited"
-				when "data_type" = 'CV' then "column_name_delimited"
-				when "data_type" = 'I'  then "column_name_delimited"
-				when "data_type" = 'N'  then "column_name_delimited"
-				when "data_type" in ('A1','AN')  then 'cast(' || "column_name_delimited" || ' as varchar(64000)) '  --array datatypes are casted to a varchar in Teradata
-				when "data_type" in ('BF', 'BO', 'BV') then '''''NOT SUPPORTED''''' --binary data types (BYTE, VARBYTE, BLOB) are not supported
-				when "data_type" = 'JN'  then 'CAST(' || "column_name_delimited" ||  ' AS CLOB ) ' --json (max length in Exasol is 2000000 as it is stored as varchar)  
-				when "data_type" = 'PD'  then  'BEGIN('|| "column_name_delimited" || ') , END(' ||  "column_name_delimited" || ')'  --Period(Date) split into begin and end date
-				when "data_type" in ('PS', 'PM')  then  'CAST(  BEGIN('|| "column_name_delimited" || ') AS TIMESTAMP ) , CAST ( END(' ||  "column_name_delimited" || ') AS TIMESTAMP ) '  --Period(Timestamp) split into begin and end timestamp  
-				when "data_type" in ('PT', 'PZ')  then  'CAST(  BEGIN('|| "column_name_delimited" || ') AS TIME ) , CAST ( END(' ||  "column_name_delimited" || ') AS TIME ) '  --Period(Time) split into begin and end time	
-				when "data_type" = 'TZ' then  'cast(' || "column_name_delimited" || ' AS TIME)'  --time with time zone
-				when "data_type" = 'SZ' then  'cast(' || "column_name_delimited" || ' AS TIMESTAMP)'  --timestamp with time zone
-				when "data_type" = 'YR'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL YEAR  TO MONTH ) AS VARCHAR(50))'  --Interval Year
-				when "data_type" = 'YM'  then 'cast('|| "column_name_delimited" || ' AS VARCHAR(50) )'  --Interval Year to Month
-				when "data_type" = 'MO'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL YEAR  TO MONTH ) AS VARCHAR(50))'  --Interval Month
-				when "data_type" = 'DY'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) ' --Interval Day
-				when "data_type" = 'DH'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Day to hour
-				when "data_type" = 'DM'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Day to minute
-				when "data_type" = 'DS'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval day to second
-				when "data_type" = 'HR'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Hour
-				when "data_type" = 'HM'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Day to minute
-				when "data_type" = 'HS'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval day to second
-				when "data_type" = 'MI'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) ' --Interval Minute
-				when "data_type" = 'MS'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval minute to second
-				when "data_type" = 'SC'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval Second
-				else "column_name_delimited"
-				end
-				order by "ordinal_position"
-			) || 
-			' from ' || "table_schema"|| '.' || "table_name"|| ''';' as sql_text
+	select 'import into "' || "exa_table_schema" || '"."' || "exa_table_name" || '" from jdbc at ]]..CONNECTION_NAME..[[ statement ''select ' || group_concat( 
+	case 
+	when "data_type" = 'DA' then "column_name_delimited"
+	when "data_type" = 'D'  then "column_name_delimited"
+	when "data_type" = 'TS' then "column_name_delimited"
+	when "data_type" = 'CF' then "column_name_delimited"
+	when "data_type" = 'I1' then "column_name_delimited"
+	when "data_type" = 'I2' then "column_name_delimited"
+	when "data_type" = 'I8' then "column_name_delimited"
+	when "data_type" = 'AT' then "column_name_delimited"
+	when "data_type" = 'F'  then "column_name_delimited"
+	when "data_type" = 'CV' then "column_name_delimited"
+	when "data_type" = 'I'  then "column_name_delimited"
+	when "data_type" = 'N'  then "column_name_delimited"
+	when "data_type" in ('A1','AN')  then 'cast(' || "column_name_delimited" || ' as varchar(64000)) '  --array datatypes are casted to a varchar in Teradata
+	when "data_type" in ('BF', 'BO', 'BV') then '''''NOT SUPPORTED''''' --binary data types (BYTE, VARBYTE, BLOB) are not supported
+	when "data_type" = 'JN'  then 'CAST(' || "column_name_delimited" ||  ' AS CLOB ) ' --json (max length in Exasol is 2000000 as it is stored as varchar)  
+	when "data_type" = 'PD'  then  'BEGIN('|| "column_name_delimited" || ') , END(' ||  "column_name_delimited" || ')'  --Period(Date) split into begin and end date
+	when "data_type" in ('PS', 'PM')  then  'CAST(  BEGIN('|| "column_name_delimited" || ') AS TIMESTAMP ) , CAST ( END(' ||  "column_name_delimited" || ') AS TIMESTAMP ) '  --Period(Timestamp) split into begin and end timestamp  
+	when "data_type" in ('PT', 'PZ')  then  'CAST(  BEGIN('|| "column_name_delimited" || ') AS TIME ) , CAST ( END(' ||  "column_name_delimited" || ') AS TIME ) '  --Period(Time) split into begin and end time	
+	when "data_type" = 'TZ' then  'cast(' || "column_name_delimited" || ' AS TIME)'  --time with time zone
+	when "data_type" = 'SZ' then  'cast(' || "column_name_delimited" || ' AS TIMESTAMP)'  --timestamp with time zone
+	when "data_type" = 'YR'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL YEAR  TO MONTH ) AS VARCHAR(50))'  --Interval Year
+	when "data_type" = 'YM'  then 'cast('|| "column_name_delimited" || ' AS VARCHAR(50) )'  --Interval Year to Month
+	when "data_type" = 'MO'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL YEAR  TO MONTH ) AS VARCHAR(50))'  --Interval Month
+	when "data_type" = 'DY'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) ' --Interval Day
+	when "data_type" = 'DH'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Day to hour
+	when "data_type" = 'DM'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Day to minute
+	when "data_type" = 'DS'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval day to second
+	when "data_type" = 'HR'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Hour
+	when "data_type" = 'HM'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Day to minute
+	when "data_type" = 'HS'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval day to second
+	when "data_type" = 'MI'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) ' --Interval Minute
+	when "data_type" = 'MS'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval minute to second
+	when "data_type" = 'SC'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval Second
+	else "column_name_delimited"
+	end
+	order by "ordinal_position") || ' from ' || "table_schema"|| '.' || "table_name"|| ''';' as sql_text
 	from vv_columns 
 	group by "exa_table_schema","exa_table_name", "table_schema","table_name"
 	order by "exa_table_schema","exa_table_name", "table_schema","table_name"
@@ -455,6 +450,7 @@ with vv_columns as (
 	                		end
 	                when "metric_id" = 1 then 'not checked ''' || c."exa_column_name" || ''''
 	        end		"metric_column_name"
+	        
 	from vv_columns c 
 	left join vv_primary_keys_raw p
 	on c."exa_table_schema" = p."exa_table_schema"
@@ -479,6 +475,7 @@ with vv_columns as (
                         case when "db_system" = 'Exasol' then '"' || "exa_table_schema" || '"."' || "exa_table_name" || '"' else '"' || "table_schema" || '"."' || "table_name" || '"' end ||
                         case when "db_system" = 'Teradata' then ''') ' end 
                         as "check_sql"
+                
                 from vv_checks_expr
                 group by "db_system", "exa_table_schema", "exa_table_name", "table_schema", "table_name", "metric_table"
         )
@@ -486,31 +483,36 @@ with vv_columns as (
         order by "exa_table_schema", "metric_table"
 )
 
+
+
+
 , vv_check_summary as (       
-        select  'create or replace table database_migration.migration_check (schema_name varchar(128), table_name varchar(128), column_name varchar(128), exasol_metric varchar(50), teradata_metric varchar(50), check_timestamp timestamp default current_timestamp);' as sql_text
+        select  'create or replace table "' || "metric_schema" || '"."' || "exa_table_schema" || '_MIG_CHK" (schema_name varchar(128), table_name varchar(128), column_name varchar(128), metric_schema varchar(128), metric_table varchar(128),  metric_name varchar(128), exasol_metric varchar(50), teradata_metric varchar(50), check_timestamp timestamp default current_timestamp);' as sql_text
+        from vv_checks_expr
+        group by "metric_schema", "exa_table_schema"
         union all
-        select  'insert into "DATABASE_MIGRATION"."MIGRATION_CHECK" (schema_name, table_name, column_name, exasol_metric, teradata_metric) ' /*|| chr(10)*/
-                || listagg(sql_text, '') within group(order by case when db_name = 'Exasol' then 1 else 2 end) || ' ' /*|| chr(10)*/ 
-                || 'select e.schema_name, e.table_name, e.column_name, e.exasol_metric, t.teradata_metric from exasol e join teradata t on e.schema_name = t.schema_name and e.table_name = t.table_name and e.column_name = t.column_name; ' as sql_text
+        select  'insert into "' || "metric_schema" || '"."' || "exa_table_schema" || '_MIG_CHK" (schema_name, table_name, column_name, metric_schema, metric_table, metric_name, exasol_metric, teradata_metric) ' 
+                || listagg(sql_text, '') within group(order by case when "db_system" = 'Exasol' then 1 else 2 end) || ' '
+                || 'select e.schema_name, e.table_name, e.column_name, e.metric_schema, e.metric_table, e.metric_name, e.exasol_metric, t.teradata_metric from exasol e join teradata t on e.schema_name = t.schema_name and e.table_name = t.table_name and e.column_name = t.column_name; ' as sql_text
         from (
         
-                select  db_name, column_schema, column_table,
-                        case when db_name = 'Exasol' then 'with ' else ', ' end || db_name || ' as ( ' /*|| chr(10)*/
-                        || listagg(case when column_name != 'DB_SYSTEM' then 'select ''' || column_schema || ''' as schema_name, ''' || column_table || ''' as table_name, ''' || column_name || ''' as column_name, to_char("' || column_name || '") as ' || db_name || '_metric from "' || column_schema || '"."' || column_table || '" where DB_SYSTEM = ''' || db_name || '''' end, ' union all ' /* || chr(10)*/)
-                        /*|| chr(10)*/
+                select  "db_system", "exa_table_schema", "exa_table_name", "metric_schema",
+                        case when "db_system" = 'Exasol' then 'with ' else ', ' end || "db_system" || ' as ( '
+                        || listagg(
+                        	'select ''' || "exa_table_schema" || ''' as schema_name, ''' || "exa_table_name" || ''' as table_name,  ''' || "exa_column_name" || ''' column_name, ''' || "metric_schema" || ''' metric_schema, ''' || "metric_table" || ''' metric_table, ''' || "metric_column_name" || ''' as metric_name, to_char(' || "metric_column_name" || ') as ' || "db_system" || '_metric from "' || "exa_table_schema" || '"."' || "metric_table" || '" where DB_SYSTEM = ''' || "db_system" || '''', ' union all ')
                         || ' )'  as sql_text
-                from exa_all_columns, (select 'Exasol' db_name union all select 'Teradata' db_name), (select distinct "exa_table_schema", "exa_table_name" from vv_columns)
-                where column_schema = "exa_table_schema"
-                and column_table = "exa_table_name" || '_MIG_CHK'
-                group by db_name, column_schema, column_table
-                order by case when db_name = 'Exasol' then 1 else 2 end
+                from vv_checks_expr
+                group by "db_system", "exa_table_schema", "exa_table_name", "metric_schema", "metric_table"
+                order by case when "db_system" = 'Exasol' then 1 else 2 end
         
         )
-        group by column_schema, column_table
+        group by "exa_table_schema", "exa_table_name", "metric_schema"
         union all
-        select 'select * from database_migration.migration_check where exasol_metric != teradata_metric;' as sql_text
-        from dual
+        select  '--select * from "' || "metric_schema" || '"."' || "exa_table_schema" || '_MIG_CHK" where exasol_metric != teradata_metric;' as sql_text
+        from vv_checks_expr
+        group by "metric_schema", "exa_table_schema"
 )
+
 
 select * from vv_create_schemas
 UNION ALL
@@ -526,6 +528,8 @@ select * from vv_primary_keys
 UNION ALL
 select * from vv_foreign_keys
 ]],{})
+
+--output(res.statement_text)
 return(res)
 /
 ;
@@ -534,7 +538,7 @@ return(res)
 
 -- Create a connection to the Teradata database
 create or replace connection teradata_db to 'jdbc:teradata://192.168.56.103/CHARSET=UTF16' user 'dbc' identified by 'dbc';
--- Depending on your Teradata installation, CHARSET=UTF16 instead of CHARSET=UTF8 could be the better choice - otherwise you get errors like this one:
+-- Depending on your Teradata installation, CHARSET=UTF16  instead of CHARSET=UTF8 could be the better choice - otherwise you get errors like this one:
 -- [42636] ETL-3003: [Column=5 Row=0] [String data right truncation. String length exceeds limit of 2 characters] (Session: 1611884537138472475)
 -- In that case, configure your connection like this:
 -- create connection teradata_db to 'jdbc:teradata://some.teradata.host.internal/CHARSET=UTF16' user 'db_username' identified by 'exasolRocks!';
@@ -552,5 +556,6 @@ execute script database_migration.TERADATA_TO_EXASOL(
     ,'RETAIL_2020'	-- schema filter --> '%' to load all schemas except 'DBC' / '%pub%' to load all schemas like '%pub%'
     ,'%'			--'DimCustomer' -- table filter --> '%' to load all tables
     ,true			-- boolean flag to create checking tables
-)
+) 
+--with output
 ;

--- a/teradata_to_exasol.sql
+++ b/teradata_to_exasol.sql
@@ -533,7 +533,7 @@ return(res)
 
 -- Create a connection to the Teradata database
 create or replace connection teradata_db to 'jdbc:teradata://192.168.56.103/CHARSET=UTF16' user 'dbc' identified by 'dbc';
--- Depending on your Teradata installation, CHARSET=UTF16 could be the better choice - otherwise you get errors like this one:
+-- Depending on your Teradata installation, CHARSET=UTF16 instead of CHARSET=UTF8 could be the better choice - otherwise you get errors like this one:
 -- [42636] ETL-3003: [Column=5 Row=0] [String data right truncation. String length exceeds limit of 2 characters] (Session: 1611884537138472475)
 -- In that case, configure your connection like this:
 -- create connection teradata_db to 'jdbc:teradata://some.teradata.host.internal/CHARSET=UTF16' user 'db_username' identified by 'exasolRocks!';

--- a/teradata_to_exasol.sql
+++ b/teradata_to_exasol.sql
@@ -405,32 +405,6 @@ order by "exa_table_schema","exa_table_name"
         group by "exa_table_schema", "exa_table_name"
         order by "exa_table_schema", "exa_table_name"
 )
-, vv_check_summary as (       
-        select  'create or replace table database_migration.migration_check (schema_name varchar(128), table_name varchar(128), column_name varchar(128), exasol_metric varchar(50), teradata_metric varchar(50), check_timestamp timestamp default current_timestamp);' as sql_text
-        union all
-        select  'insert into "DATABASE_MIGRATION"."MIGRATION_CHECK" (schema_name, table_name, column_name, exasol_metric, teradata_metric) ' /*|| chr(10)*/
-                || listagg(sql_text, '') within group(order by case when db_name = 'Exasol' then 1 else 2 end) || ' ' /*|| chr(10)*/ 
-                || 'select e.schema_name, e.table_name, e.column_name, e.exasol_metric, t.teradata_metric from exasol e join teradata t on e.schema_name = t.schema_name and e.table_name = t.table_name and e.column_name = t.column_name; ' as sql_text
-        from (
-        
-                select  db_name, column_schema, column_table,
-                        case when db_name = 'Exasol' then 'with ' else ', ' end || db_name || ' as ( ' /*|| chr(10)*/
-                        || listagg(case when column_name != 'DB_SYSTEM' then 'select ''' || column_schema || ''' as schema_name, ''' || column_table || ''' as table_name, ''' || column_name || ''' as column_name, to_char("' || column_name || '") as ' || db_name || '_metric from "' || column_schema || '"."' || column_table || '" where DB_SYSTEM = ''' || db_name || '''' end, ' union all ' /* || chr(10)*/)
-                        /*|| chr(10)*/
-                        || ' )'  as sql_text
-                from exa_all_columns, (select 'Exasol' db_name union all select 'Teradata' db_name), (select distinct "exa_table_schema", "exa_table_name" from vv_columns)
-                where column_schema = "exa_table_schema"
-                and column_table = "exa_table_name" || '_MIG_CHK'
-                group by db_name, column_schema, column_table
-                order by case when db_name = 'Exasol' then 1 else 2 end
-        
-        )
-        group by column_schema, column_table
-        union all
-        select 'select * from database_migration.migration_check where exasol_metric != teradata_metric;' as sql_text
-        from dual
-)
-
 
 select * from vv_create_schemas
 UNION ALL
@@ -439,8 +413,6 @@ UNION ALL
 select * from vv_imports
 UNION ALL
 select * from vv_checks
-UNION ALL
-select * from vv_check_summary
 UNION ALL
 select * from vv_primary_keys
 UNION ALL

--- a/teradata_to_exasol.sql
+++ b/teradata_to_exasol.sql
@@ -511,6 +511,7 @@ with vv_columns as (
         select 'select * from database_migration.migration_check where exasol_metric != teradata_metric;' as sql_text
         from dual
 )
+
 select * from vv_create_schemas
 UNION ALL
 select * from vv_create_tables

--- a/teradata_to_exasol.sql
+++ b/teradata_to_exasol.sql
@@ -555,8 +555,6 @@ select * from vv_primary_keys
 UNION ALL
 select * from vv_foreign_keys
 ]],{})
-
---output(res.statement_text)
 return(res)
 /
 ;
@@ -583,6 +581,5 @@ execute script database_migration.TERADATA_TO_EXASOL(
     ,'RETAIL_2020'	-- schema filter --> '%' to load all schemas except 'DBC' / '%pub%' to load all schemas like '%pub%'
     ,'%'			--'DimCustomer' -- table filter --> '%' to load all tables
     ,true			-- boolean flag to create checking tables
-) 
---with output
+)
 ;

--- a/teradata_to_exasol.sql
+++ b/teradata_to_exasol.sql
@@ -490,7 +490,7 @@ order by "exa_table_schema","exa_table_name"
     union all
     select 2 ord2, 'insert into "' || "metric_schema" || '"."' || "exa_table_schema" || '_MIG_CHK" (schema_name, table_name, column_name, metric_schema, metric_table, metric_name, exasol_metric, teradata_metric) ' 
             || listagg(sql_text, '') within group(order by case when "db_system" = 'Exasol' then 1 else 2 end) || ' '
-            || 'select e.schema_name, e.table_name, e.column_name, e.metric_schema, e.metric_table, e.metric_name, e.exasol_metric, t.teradata_metric from exasol e join teradata t on e.schema_name = t.schema_name and e.table_name = t.table_name and e.column_name = t.column_name; ' as sql_text
+            || 'select e.schema_name, e.table_name, e.column_name, e.metric_schema, e.metric_table, e.metric_name, e.exasol_metric, t.teradata_metric from exasol e join teradata t on e.schema_name = t.schema_name and e.table_name = t.table_name and e.metric_name = t.metric_name; ' as sql_text
     from (
     
             select  "db_system", "exa_table_schema", "exa_table_name", "metric_schema",
@@ -554,7 +554,7 @@ execute script database_migration.TERADATA_TO_EXASOL(
     ,true        	-- case sensitivity handling for identifiers -> false: handle them case sensitiv / true: handle them case insensitiv --> recommended: true
     ,'RETAIL_2020'	-- schema filter --> '%' to load all schemas except 'DBC' / '%pub%' to load all schemas like '%pub%'
     ,'%'			--'DimCustomer' -- table filter --> '%' to load all tables
-    ,false			-- boolean flag to create checking tables
+    ,true			-- boolean flag to create checking tables
 ) 
 --with output
 ;

--- a/teradata_to_exasol.sql
+++ b/teradata_to_exasol.sql
@@ -3,8 +3,11 @@ create schema if not exists database_migration;
 /* 
      This script will generate create schema, create table and create import statements 
      to load all needed data from a teradata database. Automatic datatype conversion is 
-     applied whenever needed. Additionally the migration can be checked via generic 
-     standardized metrics to identify deviations between the data in Teradata and Exasol. 
+     applied whenever needed. Additionally the migration can be checked via generic metrics. 
+     For that a checking table will be created and loaded for each individual table being migrated. 
+     The checking table will be created in the same schema with the same name adding '_MIG_CHK' as a suffix. 
+     A summary table for all the checking tables of a specific schema will be created in the database migration schema with the name of the migrated schema adding '_MIG_CHK' as a suffix.
+     Querying the summary tables will help you to identify deviations easily.
      Feel free to adjust it. 
 */
 
@@ -558,9 +561,6 @@ execute script database_migration.TERADATA_TO_EXASOL(
     ,'%'			-- schema filter --> '%' to load all schemas (except system schemas). Examples: 'CORE' (to migrate the 'CORE' schema), 'MART_%' (to migrate all schemas whose name starts with 'MART_')
     ,'%'			-- table filter --> '%' to load all tables in the schemas considered. Examples: 'H_EMPLOYEE' (to migrate all the tables whose name is 'H_EMPLOYEE'), 'H_%' (to migrate all tables whose name starts with 'H_') 
     ,false			-- boolean flag to create checking tables. TRUE -> create/load checking tables / FALSE -> do not create/load checking tables. -> default = FALSE. 
-    				-- When the option is used, a checking table will be created and loaded for each individual table being migrated. 
-    				-- The checking table will be created in the same schema with the same name adding '_MIG_CHK' as a suffix. 
-    				-- A summary table for all the checking tables of a specific schema will be created in the database migration schema with the name of the migrated schema adding '_MIG_CHK' as a suffix.
 ) 
 --with output
 ;


### PR DESCRIPTION
Added / updated the checking procedure for the Teradata migration guide.
When the script parameter CHECK_MIGRATION is set to true, checking tables for each source table will be created in the migrated schema with '_MIG_CHK' as a suffix. Those tables will be filled with the results of standardized test queries executed by Teradata and Exasol.
To generate an overview of all the checking tables, a table with the name of the source schema  and the suffix '_MIG_CHK' will be created in the database migration schema, to allow for easy analysis.