### PR TITLE
Database migration

### DIFF
--- a/oracle_to_exasol.sql
+++ b/oracle_to_exasol.sql
@@ -854,7 +854,7 @@ execute script database_migration.oracle_to_exasol(
 	'ORACLE_OCI', 	-- connection name
 	true, 			-- case insensitivity flag
 	'C##DB_MIG', 	-- schema name filter
-	'DIM_DATE, DIM_PRODUCT, DIM_STORE, SALES, SALES_POSITION',	-- table name filter
+	'%%',			-- table name filter
 	4, 				-- degree of parallelism for the import statements.
 	false, 			-- flag for primary key generation.
 	false, 			-- flag for foreign key generation.

--- a/oracle_to_exasol.sql
+++ b/oracle_to_exasol.sql
@@ -1,16 +1,24 @@
 create schema if not exists database_migration;
-
 /* 
-	This script will generate create schema, create table and create import statements 
-	to load all needed data from an oracle database. Automatic datatype conversion is
+	This script will generate create schema, create table and import statements 
+	to load all needed data from an Oracle database. Automatic datatype conversion is
 	applied whenever needed. Feel free to adjust it. 
+	Primary and foreign key constraints will be generated but can be commented out via script parameters.
+	This script can also create and populate check tables to identify differences.
+	A summary table for all the check tables allows for easy queriying.
 */
+
+;
 --/
 create or replace script database_migration.ORACLE_TO_EXASOL (
 CONNECTION_NAME				 -- name of the database connection inside exasol -> e.g. mysql_db
 ,IDENTIFIER_CASE_INSENSITIVE -- TRUE if identifiers should be put uppercase
 ,SCHEMA_FILTER               -- filter for the schemas to generate and load, e.g. 'my_schema', 'my%', 'schema1, schema2', '%'
 ,TABLE_FILTER                -- filter for the tables to generate and load, e.g. 'my_table', 'my%', 'table1, table2', '%'
+,PARALLEL_STATEMENTS  		 -- number or parallel statements for imports using balanced bin packing with partitions, if partitions are available, else ora_hash partitioning of the rowid will be used.
+,CREATE_PK					 -- TRUE if primary keys should be created, else they will generated but commented out
+,CREATE_FK					 -- TRUE if foreign keys should be created, else they will generated but commented out. NOTE that FKs on tables that do not exist/were not migrated, will fail.
+,CHECK_MIGRATION			 -- TRUE if checking tables and summary should be created
 ) RETURNS TABLE 
 AS
 
@@ -18,6 +26,33 @@ AS
 function string.startsWith(String,word)
    return string.sub(String,1,string.len(word))==word
 end
+
+
+-- checking the parameter types
+if(type(IDENTIFIER_CASE_INSENSITIVE) ~= 'boolean') then 
+	error('expected a boolean value for parameter IDENTIFIER_CASE_INSENSITIVE, but instead got ' .. type(IDENTIFIER_CASE_INSENSITIVE) .. '.')
+end
+
+if(type(CREATE_PK) ~= 'boolean') then 
+	error('expected a boolean value for parameter CREATE_PK, but instead got ' .. type(CREATE_PK) .. '.')
+end
+
+if(type(CREATE_FK) ~= 'boolean') then 
+	error('expected a boolean value for parameter CREATE_FK, but instead got ' .. type(CREATE_FK) .. '.')
+end
+
+ps = 1
+if(type(PARALLEL_STATEMENTS) == 'number') then 
+	ps = math.floor(PARALLEL_STATEMENTS)
+else
+	error('expected an interger value for parameter PARALLEL_STATEMENTS, but instead got ' .. type(PARALLEL_STATEMENTS) .. '.')
+end
+
+if(type(CHECK_MIGRATION) ~= 'boolean') then 
+	error('expected a boolean value for parameter CHECK_MIGRATION, but instead got ' .. type(CHECK_MIGRATION) .. '.')
+end
+
+
 
 
 function get_connection_type_by_testing(CONNECTION_NAME)
@@ -77,13 +112,11 @@ function get_connection_type(CONNECTION_NAME)
 	return CONNECTION_TYPE
 end
 
--- Actual script
-
 -- check whether connection is OCI or JDBC Connection
 CONNECTION_TYPE = get_connection_type(CONNECTION_NAME)
 
 
-
+-- set schema and table filter conditions
 exa_upper_begin=''
 exa_upper_end=''
 if IDENTIFIER_CASE_INSENSITIVE == true then
@@ -103,9 +136,134 @@ else
 	TABLE_STR = [[in ('']]..TABLE_FILTER:gsub("^%s*(.-)%s*$", "%1"):gsub('%s*,%s*',"'',''")..[['')]]		
 end
 
+
+
+
+-- initialize variables for parallel statement
+sql_ora_part_bin = [[]]
+t_part = {}
+s_sn = nil
+s_tn = nil
+t_bin_stat = {}
+t_sql_bin_values = {}
+
+i_bin_idx = nil
+n_bin_sum = 0
+
+-- if statements should run in parallel
+if(ps > 1) then
+	-- generate the sql statement to count the number of rows per partition
+	success, sql_ora_part_res = pquery([[
+	select 	'select ''''' || table_owner || ''''' SN, ''''' || table_name || ''''' TN, ''''' || partition_name || ''''' PN , count(*) cnt from "' || table_owner || '"."' || table_name || '" partition ("' || partition_name || '")' 
+					|| case when rownum != count(*) over() then ' union all ' end SQL_PART_CNT
+	from 	(
+			import from ]] .. CONNECTION_TYPE .. [[ at ]] .. CONNECTION_NAME .. [[ statement
+			'
+			select 	table_owner, table_name, partition_name 
+			from 	all_tab_partitions
+			where 	table_owner ]] .. SCHEMA_STR .. [[ 
+			and		table_name ]] .. TABLE_STR .. [[
+			'
+	)
+	]])
+	--output(sql_ora_part_res.statement_text)
+	if(not success) then
+		error(sql_ora_part_res.error_message)
+	end
+	
+	-- if there are partitions at all
+	if(#sql_ora_part_res >= 1) then 
+	
+		-- generate the import statement to count the number of rows per partition
+		sql_ora_part_res2 = [[import into (SN varchar(128), TN varchar(128), PN varchar(128), CNT decimal(36,0)) from ]] .. CONNECTION_TYPE .. [[ at ]] .. CONNECTION_NAME .. [[ statement ']]
+		for i=1, #sql_ora_part_res do
+			sql_ora_part_res2 = sql_ora_part_res2 .. sql_ora_part_res[i].SQL_PART_CNT
+		end
+		sql_ora_part_res2 = sql_ora_part_res2 .. [[']]
+		
+		-- execute the import statement to count the number of rows per partition. Empty partitions are filtered out.
+		-- NOTE: do not remove the order by clause, as it is necessary.
+		success, ora_part_res3 = pquery([[
+		select	SN, TN, PN, CNT
+		from 	(
+				]] .. sql_ora_part_res2 ..  [[
+		)
+		where CNT > 0
+		order by SN, TN, CNT desc
+		]])
+		--output(ora_part_res3.statement_text)
+		if(not success) then
+			error(ora_part_res3.error_message)
+		end
+		
+		-- populate the lua table from the userdata
+		for i=1, #ora_part_res3 do
+			t_part[#t_part +1] = {
+				['SN'] = ora_part_res3[i].SN,
+				['TN'] = ora_part_res3[i].TN,
+				['PN'] = ora_part_res3[i].PN,
+				['CNT'] = tonumber(ora_part_res3[i].CNT)
+			}
+		end
+		
+		-- iterate over all partitions and decide to which bin / statement they should be assigned to
+		for i=1, #t_part do
+		
+			-- start a new cycle and set / reset variables if a schema name or a table name is nill (initial loop) or changes
+			if(s_sn == nil or t_part[i]['SN'] ~= s_sn or s_tn == nil or t_part[i]['TN'] ~= s_tn) then 
+				s_sn = t_part[i]['SN']
+				s_tn = t_part[i]['TN']
+				t_bin_stat = {}
+				n_bin_sum = 0				
+			end
+			
+			i_bin_idx = 1
+			--iterate over all bins, and save the one with the least sum of rows
+			for bin=1, ps do
+				-- if a bin is not set yet, initialize it, store the bin index and break the loop
+				if(t_bin_stat[bin] == nil) then 
+					i_bin_idx = bin
+					t_bin_stat[bin] = {['PN'] = {}, ['SUM'] = 0}
+					break
+				-- search for the new minimal bin count and set save the bin index
+				elseif(t_bin_stat[bin]['SUM'] <= n_bin_sum) then 
+					i_bin_idx = bin
+					n_bin_sum = t_bin_stat[bin]['SUM']
+				end
+			end
+			
+			-- update the the bin stats and partition assignment per statement for the current schema/table
+			t_bin_stat[i_bin_idx]['SUM'] = t_bin_stat[i_bin_idx]['SUM'] + t_part[i]['CNT']
+			t_bin_stat[i_bin_idx]['PN'][#t_bin_stat[i_bin_idx]['PN'] +1] = t_part[i]['PN']
+			
+			-- add the bin column to the partition table, the updated sum is the value to compare other bin counts with in the next iteration
+			t_part[i]['BIN'] = i_bin_idx
+			n_bin_sum = t_bin_stat[i_bin_idx]['SUM']
+			
+			-- this will form the basis for a "from values" clause
+			t_sql_bin_values[#t_sql_bin_values +1] = [[(']] .. 
+				t_part[i]['SN'] .. [[', ']] .. 
+				t_part[i]['TN'] .. [[', ']] .. 
+				t_part[i]['PN'] .. [[', ]] .. 
+				t_part[i]['CNT'] .. [[, ]] .. 
+				t_part[i]['BIN'] .. 
+			[[)]]
+				
+		end
+		
+		sql_ora_part_bin = [[select * from values ]] .. table.concat(t_sql_bin_values, ', ') .. [[ as t(sn, tn, pn, cnt, bin_nr)]]
+		
+	else 
+		sql_ora_part_bin = [[select cast(null as varchar(128)) sn, cast(null as varchar(128)) tn, cast(null as varchar(128)) pn, cast(null as int) cnt, cast(null as int) bin_nr from dual]]
+	end
+	
+else 
+	sql_ora_part_bin = [[select cast(null as varchar(128)) sn, cast(null as varchar(128)) tn, cast(null as varchar(128)) pn, cast(null as int) cnt, cast(null as int) bin_nr from dual]]
+end
+
+
 --check weather identity_column exists in all_tab_columns for this oracle version
 success, res = pquery([[
-
 select * from(
 		import from ]]..CONNECTION_TYPE..[[ at ::c statement
 			'
@@ -123,175 +281,584 @@ select * from(
 
 if not success then error(res.error_message) end
 
-all_tab_cols = [[]]
 
+all_tab_cols = [[]]
 if #res == 0 then --no identity column
 	all_tab_cols = exa_upper_begin..[[ owner ]]..exa_upper_end..[[ as EXA_SCHEMA_NAME , owner , table_name, ]]..exa_upper_begin..[[ table_name ]]..exa_upper_end..[[ as EXA_TABLE_NAME , COLUMN_NAME, ]]..exa_upper_begin..[[column_name]]..exa_upper_end..[[  as EXA_COLUMN_NAME, data_type, cast(data_length as decimal(9,0)) data_length, cast(data_precision as decimal(9,0)) data_precision, cast(data_scale as decimal(9,0)) data_scale, cast(char_length as decimal(9,0)) char_length , nullable, cast(column_id as decimal(9,0)) column_id, null identity_column]]
 else
   	all_tab_cols = exa_upper_begin..[[ owner ]]..exa_upper_end..[[ as EXA_SCHEMA_NAME , owner , table_name, ]]..exa_upper_begin..[[ table_name ]]..exa_upper_end..[[ as EXA_TABLE_NAME , COLUMN_NAME, ]]..exa_upper_begin..[[column_name]]..exa_upper_end..[[  as EXA_COLUMN_NAME, data_type, cast(data_length as decimal(9,0)) data_length, cast(data_precision as decimal(9,0)) data_precision, cast(data_scale as decimal(9,0)) data_scale, cast(char_length as decimal(9,0)) char_length , nullable, cast(column_id as decimal(9,0)) column_id, identity_column]]
 end
 
-success, res = pquery([[with ora_cols as( 
 
-	select * from(
+success, res = pquery([[
+with ora_cols as ( 
+        select  * 
+        from    (
 		import from ]]..CONNECTION_TYPE..[[ at ::c
-		statement 'select ]]..all_tab_cols..[[  from all_tab_columns where table_name in (select table_name from all_tables where owner ]]..SCHEMA_STR..[[ and table_name ]]..TABLE_STR..[[) and owner ]]..SCHEMA_STR..[[ and table_name ]]..TABLE_STR..[[ AND owner || table_name NOT in
-                        (select owner || view_name from all_views)'
-				)
-			),
-	ora_base as ( --cast to correct types
-		SELECT
-			EXA_SCHEMA_NAME, 
-			OWNER, 
-			TABLE_NAME, 
-			EXA_TABLE_NAME, 
-			COLUMN_NAME, 
-			EXA_COLUMN_NAME, 
-			DATA_TYPE, 
-			cast(DATA_LENGTH as integer) DATA_LENGTH, 
-			cast(DATA_PRECISION as integer) DATA_PRECISION, 
-			cast(DATA_SCALE as integer) DATA_SCALE, 
-			cast(CHAR_LENGTH as integer) CHAR_LENGTH, 
-			NULLABLE, 
-			cast(COLUMN_ID as integer) COLUMN_ID, 
-			IDENTITY_COLUMN
-		FROM
-			ora_cols
-	),
-	nls_format as (
-		select * from (import from ]]..CONNECTION_TYPE..[[ at ::c statement 'select * from nls_database_parameters where parameter in (''NLS_TIMESTAMP_FORMAT'',''NLS_DATE_FORMAT'',''NLS_DATE_LANGUAGE'',''NLS_CHARACTERSET'')')
-	),
-	cr_schema as (
-		with EXA_SCHEMAS as (select distinct EXA_SCHEMA_NAME as EXA_SCHEMA from ora_base )
-			select 'create schema if not exists "' ||  EXA_SCHEMA ||'";' as cr_schema from EXA_SCHEMAS
-	),
-	cr_tables as (
-		select 'create or replace table "' || EXA_SCHEMA_NAME || '"."' || EXA_TABLE_NAME || '" (' || cols || '); ' || cols2 || ''
-as tbls from 
-(select EXA_SCHEMA_NAME, EXA_TABLE_NAME, 
-		group_concat( 
-		case 
-			when data_type in ('CHAR', 'NCHAR') then '"' || EXA_COLUMN_NAME || '"' || ' ' ||  'char(' || char_length || ')'
-			when data_type in ('VARCHAR','VARCHAR2', 'NVARCHAR2') then '"' || EXA_COLUMN_NAME || '"' || ' ' ||  'varchar(' || char_length || ')'
-			when data_type = 'CLOB' then '"' || EXA_COLUMN_NAME || '"' || ' ' ||  'varchar(2000000)'
-			when data_type = 'XMLTYPE' then '"' || EXA_COLUMN_NAME || '"' || ' ' ||  'varchar(2000000)'
-			when data_type in ('DECIMAL') and (data_precision is not null and data_scale is not null) then '"' || EXA_COLUMN_NAME || '"' || ' ' ||  case when data_scale > 36 then 'DECIMAL(' || 36 || ',' || 36 || ')' when data_precision > 36 and data_scale <= 36 then 'DECIMAL(' || 36 || ',' || data_scale || ')' when data_precision <= 36 and data_scale > data_precision then  'DECIMAL(' || data_scale || ',' || data_scale || ')' else 'DECIMAL(' || data_precision || ',' || data_scale || ')' end   
-			when data_type = 'NUMBER' and (data_precision is not null and data_scale is not null) then '"' || EXA_COLUMN_NAME || '"' || ' ' ||  case when data_scale > 36 then 'DECIMAL(' || 36 || ',' || 36 || ')' when data_precision > 36 and data_scale <= 36 then 'DECIMAL(' || 36 || ',' || data_scale || ')' when data_precision <= 36 and data_scale > data_precision then  'DECIMAL(' || data_scale || ',' || data_scale || ')' else 'DECIMAL(' || data_precision || ',' || data_scale || ')' end
-			when data_type = 'NUMBER' and (data_length is not null and data_precision is null and data_scale is not null) then '"' || EXA_COLUMN_NAME || '"' || ' ' ||  'integer' 
-			when data_type = 'NUMBER' and (data_precision is null and data_scale is null) then '"' || EXA_COLUMN_NAME || '"' || ' ' ||  'double precision'
-			when data_type in ('DOUBLE PRECISION', 'FLOAT', 'BINARY_FLOAT', 'BINARY_DOUBLE') then '"' || EXA_COLUMN_NAME || '"' || ' ' ||  'double precision'
-			when data_type = 'DATE' then '"' || EXA_COLUMN_NAME || '"' || ' ' ||  'timestamp'
-			when data_type like 'TIMESTAMP(%)%' or data_type like 'TIMESTAMP' then '"' || EXA_COLUMN_NAME || '"' || ' ' ||  'timestamp'
-			when data_type like 'TIMESTAMP%WITH%TIME%ZONE%' then '"' || EXA_COLUMN_NAME || '"' || ' ' ||  'timestamp' 
-			when data_type = 'BOOLEAN' then '"' || EXA_COLUMN_NAME || '"' || ' ' ||  'boolean'
-			-- Fallback for unsupported data types
-			-- else '"' || EXA_COLUMN_NAME || '"' || ' ' ||  'varchar(2000000) /* UNSUPPORTED DATA TYPE : ' || data_type || ' */ '
-			end
-			
-		|| case when identity_column='YES' then ' IDENTITY' end
-		|| case when nullable='N' then ' NOT NULL' end
-		
-	order by column_id SEPARATOR ', ')
-	as cols,
-                group_concat( 
-                        case 
-                        when data_type not in ('CHAR', 'NCHAR', 'VARCHAR', 'VARCHAR2', 'NVARCHAR2', 'CLOB', 'XMLTYPE', 'DECIMAL', 'NUMBER', 'DOUBLE PRECISION', 'FLOAT', 'BINARY_FLOAT', 'BINARY_DOUBLE', 'DATE', 'BOOLEAN', 'TIMESTAMP') and data_type not like 'TIMESTAMP(%)%' and data_type not like 'TIMESTAMP%WITH%TIME%ZONE%'
-                        then '--UNSUPPORTED DATA TYPE : "'|| EXA_COLUMN_NAME || '" ' || data_type || ''
-                        end
-                ) 
-	as cols2 
-        from ora_base group by EXA_SCHEMA_NAME, EXA_TABLE_NAME)
-	),
-	cr_import_stmts as (
-		select 'import into "' || EXA_SCHEMA_NAME ||'"."' || EXA_TABLE_NAME || '"( ' || 
-		group_concat( 
-		case 
-			when data_type in ('CHAR', 'NCHAR') then '"' || EXA_COLUMN_NAME || '"' 
-			when data_type in ('VARCHAR','VARCHAR2', 'NVARCHAR2') then '"' || EXA_COLUMN_NAME || '"' 
-			when data_type = 'CLOB' then '"' || EXA_COLUMN_NAME || '"' 
-			when data_type = 'XMLTYPE' then '"' || EXA_COLUMN_NAME || '"' 
-			when data_type in ('DECIMAL') and (data_precision is not null and data_scale is not null) then '"' || EXA_COLUMN_NAME || '"' 
-			when data_type = 'NUMBER' and (data_precision is not null and data_scale is not null) then '"' || EXA_COLUMN_NAME || '"'  
-			when data_type = 'NUMBER' and (data_length is not null and data_precision is null and data_scale is not null) then '"' || EXA_COLUMN_NAME || '"' 
-			when data_type = 'NUMBER' and (data_precision is null and data_scale is null) then '"' || EXA_COLUMN_NAME || '"' 
-			when data_type in ('DOUBLE PRECISION', 'FLOAT', 'BINARY_FLOAT', 'BINARY_DOUBLE') then '"' || EXA_COLUMN_NAME || '"' 
-			when data_type = 'DATE' then '"' || EXA_COLUMN_NAME || '"' 
-			when data_type like 'TIMESTAMP(%)%' or data_type like 'TIMESTAMP' then '"' || EXA_COLUMN_NAME || '"' 
-			when data_type like 'TIMESTAMP%WITH%TIME%ZONE%' then '"' || EXA_COLUMN_NAME || '"' 
-			when data_type = 'BOOLEAN' then '"' || EXA_COLUMN_NAME || '"' 
-			/* else '--UNSUPPORTED DATATYPE IN COLUMN ' || COLUMN_NAME || ' Oracle Datatype: ' || data_type  */
-		end
+		statement 
+		        '
+		        select	]]..all_tab_cols..[[  
+		        from	all_tab_columns 
+		        where 	table_name in (
+                				select  table_name 
+                                from    all_tables 
+                                where   owner ]]..SCHEMA_STR..[[ 
+                                and     table_name ]]..TABLE_STR..[[
+                )
+		        and		owner ]]..SCHEMA_STR..[[ 
+		        and 	table_name ]]..TABLE_STR..[[ 
+		        and     owner || ''.'' || table_name NOT IN (
+                				select 	owner || ''.'' || view_name 
+                                from 	all_views
+		                        )
+		        '
+        )
+)
+
+, ora_base as (
+        SELECT  EXA_SCHEMA_NAME, 
+                OWNER, 
+                TABLE_NAME, 
+                EXA_TABLE_NAME, 
+                COLUMN_NAME, 
+                EXA_COLUMN_NAME, 
+                DATA_TYPE, 
+                cast(DATA_LENGTH as integer) DATA_LENGTH, 
+                cast(DATA_PRECISION as integer) DATA_PRECISION, 
+                cast(DATA_SCALE as integer) DATA_SCALE, 
+                cast(CHAR_LENGTH as integer) CHAR_LENGTH, 
+                NULLABLE, 
+                cast(COLUMN_ID as integer) COLUMN_ID, 
+                IDENTITY_COLUMN
+        FROM    ora_cols
+)
+
+, ora_cons_pk as (
+        select  pk.*, count(*) over(partition by owner, table_name) cnt_pk
+        from    (
+                import from ]]..CONNECTION_TYPE..[[ at ::c
+				statement 
+                        '
+                    	select  acc.owner, acc.table_name, acc.column_name, acc.position as pos, ac.status, acc.constraint_name,
+                                ]] .. exa_upper_begin .. [[acc.owner]]          .. exa_upper_end .. [[ as EXA_SCHEMA_NAME,
+                                ]] .. exa_upper_begin .. [[acc.table_name]]     .. exa_upper_end .. [[ as EXA_TABLE_NAME,
+                                ]] .. exa_upper_begin .. [[acc.column_name]]    .. exa_upper_end .. [[ as EXA_COLUMN_NAME
+                        from    all_tables ta
+                        join    all_cons_columns acc 
+                        on      ta.owner ]]..SCHEMA_STR..[[ 
+                        and     ta.table_name ]]..TABLE_STR..[[
+                        and     ta.owner = acc.owner
+                        and     ta.table_name = acc.table_name
+                        join    all_constraints ac 
+                        on      acc.owner = ac.owner
+                        and     acc.table_name = ac.table_name
+                        and     acc.constraint_name = ac.constraint_name
+                        and     ac.constraint_type = ''P''
+                        ' 
+        ) pk
+)
+
+, ora_cons_fk as (
+        select  *
+        from    (
+                import from ]]..CONNECTION_TYPE..[[ at ::c
+				statement 
+                        '
+                        select  acc.owner, acc.table_name, acc.column_name, acc.position as pos, ac.status, acc.constraint_name,
+                                acc_r.owner as r_owner, acc_r.table_name as r_table_name, acc_r.column_name as r_column_name,
+                                ]] .. exa_upper_begin .. [[acc.owner]]          .. exa_upper_end .. [[ as EXA_SCHEMA_NAME,
+                                ]] .. exa_upper_begin .. [[acc.table_name]]     .. exa_upper_end .. [[ as EXA_TABLE_NAME,
+                                ]] .. exa_upper_begin .. [[acc.column_name]]    .. exa_upper_end .. [[ as EXA_COLUMN_NAME,
+                                ]] .. exa_upper_begin .. [[acc_r.owner]]        .. exa_upper_end .. [[ as EXA_REFERENCED_SCHEMA_NAME,
+                                ]] .. exa_upper_begin .. [[acc_r.table_name]]   .. exa_upper_end .. [[ as EXA_REFERENCED_TABLE_NAME,
+                                ]] .. exa_upper_begin .. [[acc_r.column_name]]  .. exa_upper_end .. [[ as EXA_REFERENCED_COLUMN_NAME
+                        from    all_tables ta
+                        join    all_cons_columns acc 
+                        on      ta.owner ]]..SCHEMA_STR..[[ 
+                        and     ta.table_name ]]..TABLE_STR..[[
+                        and     ta.owner = acc.owner
+                        and     ta.table_name = acc.table_name
+                        join    all_constraints ac 
+                        on      acc.owner = ac.owner
+                        and     acc.table_name = ac.table_name
+                        and     acc.constraint_name = ac.constraint_name
+                        and     ac.constraint_type = ''R''
+                        join    all_cons_columns acc_r
+                        on      ac.r_owner = acc_r.owner
+                        and     ac.r_constraint_name = acc_r.constraint_name
+                        and     acc.position = acc_r.position
+                        '
+        )
+)
+
+, nls_format as (
+        select * 
+        from    (
+				import from ]]..CONNECTION_TYPE..[[ at ::c 
+                statement 
+                        'select * 
+                        from    nls_database_parameters 
+                        where   parameter in (''NLS_TIMESTAMP_FORMAT'',''NLS_DATE_FORMAT'',''NLS_DATE_LANGUAGE'',''NLS_CHARACTERSET'', ''NLS_NCHAR_CHARACTERSET'')
+                        '
+        )
+)
+
+, cr_schema as (
+        with EXA_SCHEMAS as (
+                select  distinct EXA_SCHEMA_NAME as EXA_SCHEMA 
+                from    ora_base 
+        )
+        select  'create schema if not exists "' ||  EXA_SCHEMA || '";' as cr_schema 
+        from    EXA_SCHEMAS
+)
+
+, cr_tables as (
+        select  'create or replace table "' || EXA_SCHEMA_NAME || '"."' || EXA_TABLE_NAME || '" (' || cols || '); ' || cols2 || '' as tbls 
+        from    (select EXA_SCHEMA_NAME, EXA_TABLE_NAME, 
+                        group_concat( 
+                            	case 
+                                        when data_type in ('CHAR', 'NCHAR') then 																		'"' || EXA_COLUMN_NAME || '"' || ' ' || 'char(' || char_length || ')'
+                                        when data_type in ('VARCHAR','VARCHAR2', 'NVARCHAR2') then 														'"' || EXA_COLUMN_NAME || '"' || ' ' || 'varchar(' || char_length || ')'
+                                        when data_type in ('CLOB', 'NCLOB') then																		'"' || EXA_COLUMN_NAME || '"' || ' ' || 'varchar(2000000)'
+                                        when data_type = 'XMLTYPE' then 																				'"' || EXA_COLUMN_NAME || '"' || ' ' || 'varchar(2000000)'
+										when data_type = 'RAW' 
+												then 																									'"' || EXA_COLUMN_NAME || '"' || ' ' ||
+														case 	when data_length <= 1024 then 																'hashtype(' || data_length || ' byte)'
+																else 																						'varchar(' || (data_length * 2) || ') ascii'
+														end
+                                        when data_type in ('DECIMAL') and (data_precision is not null and data_scale is not null) 
+                                                then 																									'"' || EXA_COLUMN_NAME || '"' || ' ' ||  
+                                                        case    when data_scale > 36 then 																	'decimal(' || 36 || ',' || 36 || ')' 
+                                                                when data_precision > 36 and data_scale <= 36 then 											'decimal(' || 36 || ',' || data_scale || ')' 
+                                                                when data_precision <= 36 and data_scale > data_precision then  							'decimal(' || data_scale || ',' || data_scale || ')' 
+                                                                else 																						'decimal(' || data_precision || ',' || data_scale || ')' 
+                                                        end
+                                        when data_type = 'NUMBER' and (data_precision is not null and data_scale is not null) 
+                                                then 																									'"' || EXA_COLUMN_NAME || '"' || ' ' ||  
+                                                        case    when data_scale > 36 then 																	'decimal(' || 36 || ',' || 36 || ')' 
+                                                                when data_precision > 36 and data_scale <= 36 then 											'decimal(' || 36 || ',' || data_scale || ')' 
+                                                                when data_precision <= 36 and data_scale > data_precision then  							'decimal(' || data_scale || ',' || data_scale || ')' 
+                                                                else 																						'decimal(' || data_precision || ',' || data_scale || ')' 
+                                                        end
+                                        when data_type = 'NUMBER' and (	data_length is not null and 
+																		data_precision is null and 
+																		data_scale is not null) then 													'"' || EXA_COLUMN_NAME || '"' || ' ' || 'integer' 
+                                        when data_type = 'NUMBER' and (data_precision is null and data_scale is null) then 								'"' || EXA_COLUMN_NAME || '"' || ' ' || 'double precision'
+                                        when data_type in ('DOUBLE PRECISION', 'FLOAT', 'BINARY_FLOAT', 'BINARY_DOUBLE') then 							'"' || EXA_COLUMN_NAME || '"' || ' ' || 'double precision'
+                                        when data_type = 'DATE' then 																					'"' || EXA_COLUMN_NAME || '"' || ' ' || 'timestamp'
+                                        when data_type like 'TIMESTAMP(%)%' or data_type like 'TIMESTAMP%' then											'"' || EXA_COLUMN_NAME || '"' || ' ' || 'timestamp'
+                                        when data_type like 'TIMESTAMP%WITH%TIME%ZONE%' then 															'"' || EXA_COLUMN_NAME || '"' || ' ' || 'timestamp' 
+                                        when data_type like 'INTERVAL YEAR%TO MONTH%' then 																'"' || EXA_COLUMN_NAME || '"' || ' ' || 'interval year(' || case when data_precision = 0 then 1 else data_precision end || ') to month'
+                                        when data_type like 'INTERVAL DAY%TO SECOND%' then 																'"' || EXA_COLUMN_NAME || '"' || ' ' || 'interval day(' || case when data_precision = 0 then 1 else data_precision end || ') to second(' || data_scale || ')'
+                                        when data_type = 'BOOLEAN' then 																				'"' || EXA_COLUMN_NAME || '"' || ' ' || 'boolean'
+                                        -- Fallback for unsupported data types
+                                        -- else '"' || EXA_COLUMN_NAME || '"' || ' ' ||  'varchar(2000000) /* UNSUPPORTED DATA TYPE : ' || data_type
+                                end || 
+                                case    when 	identity_column='YES' and 
+												data_type = 'NUMBER' and 
+												data_precision is not null and 
+												data_scale is not null then 																			' identity' 
+								end || 
+                                case when nullable= 'N' then 																							' not null' 
+									 else ''
+								end
+
+                                order by column_id 
+                                SEPARATOR ', '
+                        ) as cols,
+                        group_concat( 
+                                case    when data_type not in ( 
+													'CHAR', 'NCHAR', 'VARCHAR', 'VARCHAR2', 'NVARCHAR2', 'CLOB', 'NCLOB', 'XMLTYPE', 
+                                                    'DECIMAL', 'NUMBER', 'DOUBLE PRECISION', 'FLOAT', 'BINARY_FLOAT', 'BINARY_DOUBLE', 
+                                                    'DATE', 'BOOLEAN', 'TIMESTAMP', 'RAW') 
+                                        		and data_type not like 'TIMESTAMP(%)%' 
+                                            	and data_type not like 'TIMESTAMP%WITH%TIME%ZONE%' 
+												and data_type not like 'INTERVAL YEAR%TO MONTH%' 
+												and data_type not like 'INTERVAL DAY%TO SECOND%' 
+										then chr(13) || '--UNSUPPORTED DATA TYPE : "' || EXA_COLUMN_NAME || '" ' || data_type
+                                end
+                        ) as cols2 
+                from    ora_base 
+                group   by EXA_SCHEMA_NAME, EXA_TABLE_NAME
+        )
+)
+
+, cr_constraints_pk as (
+        select  'alter table "' || EXA_SCHEMA_NAME || '"."' || EXA_TABLE_NAME || '" add primary key (' || listagg('"' || EXA_COLUMN_NAME ||'"', ', ') within group(order by pos) || ') enable;' as EXA_CONSTRAINT
+        from    ora_cons_pk
+        group   by EXA_SCHEMA_NAME, EXA_TABLE_NAME
+)
+
+, cr_constraints_fk as (
+        select  'alter table "' || EXA_SCHEMA_NAME || '"."' || EXA_TABLE_NAME || '" add foreign key (' || listagg('"' || EXA_COLUMN_NAME || '"', ', ') within group(order by pos) || ') references "' || EXA_REFERENCED_SCHEMA_NAME || '"."' || EXA_REFERENCED_TABLE_NAME || '"(' || listagg('"' || EXA_REFERENCED_COLUMN_NAME ||'"', ', ') within group(order by pos) || ') enable;' as EXA_CONSTRAINT
+        from    ora_cons_fk
+        group   by EXA_SCHEMA_NAME, EXA_TABLE_NAME, EXA_REFERENCED_SCHEMA_NAME, EXA_REFERENCED_TABLE_NAME, constraint_name
+)
+
+, cr_import_stmts as(
+		with cl as (
+				select	exa_schema_name, owner, exa_table_name, table_name,
+						listagg(
+								case 
+		                                when data_type in ('CHAR', 'NCHAR') then 																				'"' || EXA_COLUMN_NAME || '"' 
+		                                when data_type in ('VARCHAR','VARCHAR2', 'NVARCHAR2') then 																'"' || EXA_COLUMN_NAME || '"' 
+		                                when data_type in ('CLOB', 'NCLOB') then 																				'"' || EXA_COLUMN_NAME || '"' 
+		                                when data_type = 'XMLTYPE' then 																						'"' || EXA_COLUMN_NAME || '"'
+										when data_type = 'RAW' then																								'"' || EXA_COLUMN_NAME || '"'
+		                                when data_type in ('DECIMAL') and (data_precision is not null and data_scale is not null) then 							'"' || EXA_COLUMN_NAME || '"' 
+		                                when data_type = 'NUMBER' and (data_precision is not null and data_scale is not null) then 								'"' || EXA_COLUMN_NAME || '"'  
+		                                when data_type = 'NUMBER' and (data_length is not null and data_precision is null and data_scale is not null) then 		'"' || EXA_COLUMN_NAME || '"' 
+		                                when data_type = 'NUMBER' and (data_precision is null and data_scale is null) then 										'"' || EXA_COLUMN_NAME || '"' 
+		                                when data_type in ('DOUBLE PRECISION', 'FLOAT', 'BINARY_FLOAT', 'BINARY_DOUBLE') then 									'"' || EXA_COLUMN_NAME || '"' 
+		                                when data_type = 'DATE' then 																							'"' || EXA_COLUMN_NAME || '"' 
+		                                when data_type like 'TIMESTAMP(%)%' or data_type like 'TIMESTAMP' then 													'"' || EXA_COLUMN_NAME || '"' 
+		                                when data_type like 'TIMESTAMP%WITH%TIME%ZONE%' then 																	'"' || EXA_COLUMN_NAME || '"'
+		                                when data_type like 'INTERVAL YEAR%TO MONTH%' then 																		'"' || EXA_COLUMN_NAME || '"'
+		                                when data_type like 'INTERVAL DAY%TO SECOND%' then 																		'"' || EXA_COLUMN_NAME || '"' 
+		                                when data_type = 'BOOLEAN' then 																						'"' || EXA_COLUMN_NAME || '"' 
+		                                -- else '--UNSUPPORTED DATATYPE IN COLUMN ' || COLUMN_NAME || ' Oracle Datatype: ' || data_type 
+                        		end
+								, ', '
+						) within group(order by column_id) exa_col_list,
+						
+						listagg(
+		                		case 
+		                                when data_type in ('CHAR', 'NCHAR') then 																				'"' || column_name || '"' 
+		                                when data_type in ('VARCHAR','VARCHAR2', 'NVARCHAR2') then 																'"' || column_name || '"' 
+		                                when data_type = 'CLOB' then 																							'"' || column_name || '"'
+										when data_type = 'NCLOB' then 																							'to_clob("' || column_name || '")' 
+		                                when data_type = 'XMLTYPE' then 																						'"' || column_name || '"'
+										when data_type = 'RAW' then																								'rawtohex("' || column_name || '")'
+		                                when data_type in ('DECIMAL') and (data_precision is not null and data_scale is not null) then 							'"' || column_name || '"' 
+		                                when data_type = 'NUMBER' and (data_precision is not null and data_scale is not null) then 								'"' || column_name || '"'  
+		                                when data_type = 'NUMBER' and (data_length is not null and data_precision is null and data_scale is not null) then 		'"' || column_name  || '"'
+		                                when data_type = 'NUMBER' and (data_precision is null and data_scale is null) then 										'"' || column_name || '"' 
+		                                when data_type in ('DOUBLE PRECISION', 'FLOAT', 'BINARY_FLOAT', 'BINARY_DOUBLE') then 									'cast("' || column_name || '" as DOUBLE PRECISION)' 
+		                                when data_type = 'DATE' then 																							'"' || column_name || '"' 
+		                                when data_type like 'TIMESTAMP(%)' or data_type like 'TIMESTAMP' then 													'"' || column_name || '"' 
+		                                when data_type like 'TIMESTAMP%WITH%TIME%ZONE%' then 																	'cast("' || column_name || '" at time zone ''''00:00'''' as TIMESTAMP)'
+		                                when data_type like 'INTERVAL YEAR%TO MONTH%' then 																		
+												case 	when data_precision > 0 then																			'to_char("' || column_name || '")'
+														else																									'substr(cast("' || column_name || '" as varchar2(30)), 10, 5)'
+												end
+		                                when data_type like 'INTERVAL DAY%TO SECOND%' then 																		'to_char("' || column_name || '")'
+		                                when data_type = 'BOOLEAN' then '"' || column_name || '"' 
+		                                -- else '--UNSUPPORTED DATATYPE IN COLUMN ' || column_name || ' Oracle Datatype: ' || data_type  
+		                        end
+		                        , ', '
+		                )  within group (order by column_id) ora_col_list
+						
+		        from    ora_base 
+		        group   by exa_schema_name, owner, exa_table_name, table_name 
+		)
+		, ora_bin_part as (
+				]] .. sql_ora_part_bin .. [[
+
+		)
+		, ora_stmt_part as (
+				select	exa_schema_name, owner, exa_table_name, table_name, bin_nr, 
+						listagg('select /*+parallel*/ ' || ora_col_list || ' from "' || owner || '"."' || table_name || '"' || case when bin_nr is not null then ' partition("' || pn ||'")' end, ' union all ') stmt
+				from 	cl 
+				left 	join ora_bin_part bp
+				on 		cl.owner = bp.sn
+				and 	cl.table_name = bp.tn
+				group	by exa_schema_name, owner, exa_table_name, table_name, bin_nr
+		)
+		, ora_stmt_part_oh as (
+				select 	exa_schema_name, owner, exa_table_name, table_name, 
+						case when sp.bin_nr is null and ]] .. ps .. [[ > 1 then stmt || ' where ora_hash(rowid, ' || ml || ') = ' || l else stmt end stmt
+				from 	ora_stmt_part sp 
+				left 	join (select null bin_nr, level -1 l, ]] .. ps .. [[ -1 ml from dual connect by level <= ]] .. ps .. [[) oh 
+				on  	sp.bin_nr is null and oh.bin_nr is null
+		)
+		, ora_stmt_part_oh_agg as (
+				select	exa_schema_name, owner, exa_table_name, table_name,
+						listagg(' statement ''' || stmt || '''', ' ') stmt_agg
+				from 	ora_stmt_part_oh
+				group 	by exa_schema_name, owner, exa_table_name, table_name
+		)
+		select 	'import into "' || e.exa_schema_name || '"."' || e.exa_table_name || '" (' || e.exa_col_list || ') from  ]]..CONNECTION_TYPE..[[ at ]] .. CONNECTION_NAME .. [[ ' || o.stmt_agg || ';' import_stmt
+		from 	cl e
+		join 	ora_stmt_part_oh_agg o
+		on 		e.owner = o.owner
+		and 	e.table_name = o.table_name		
+)
+
+, check_expr as (
+		select 	db_system,	
+				exa_schema_name,
+				exa_table_name,
+				exa_column_name,
+				owner,
+				table_name,
+				case 	when db_system = 'Exasol' then exa_schema_name
+						else owner
+				end sn, -- schema name
+				case 	when db_system = 'Exasol' then exa_table_name
+						else table_name
+				end tn, -- table name
+				case 	when db_system = 'Exasol' then exa_column_name
+						else column_name
+				end cn, -- column name
+		      	case    when db_system = 'Exasol' then '"' || exa_column_name || '"'
+		                else '"' || column_name || '"'
+		        end qcn, -- quoted column name
+			  	case	when db_system = 'Exasol' then '"' || exa_schema_name || '"."' || exa_table_name || '"'
+		                else '"' || owner || '"."' || table_name || '"'
+		        end qstn, -- quoted schema table name
+		        case    when db_system = 'Exasol' then '"' || exa_table_name || '"."' || exa_column_name || '"'
+		                else '"' || table_name || '"."' || column_name || '"'
+		        end qtcn, -- quoted table column name
+	
+				column_id,
+				data_type,
+				case 	when data_type = 'NUMBER' then 	
+								case 	when data_precision IS NULL AND data_scale IS NULL then 										'double precision'
+				        				when data_precision IS NULL AND data_scale = 0 then 											'decimal(36,0)'
+				        				when data_scale > 36 then 																		'decimal(' || 36 || ',' || 36 || ')'
+										when data_precision > 36 AND data_scale <= 36 then 												'decimal(' || 36 || ',' || data_scale || ')'
+				                    	when data_precision <= 36 AND data_precision >= data_scale then 								'decimal(' || data_precision || ',' || data_scale || ')'
+				            	end
+		            	when data_type in ('BINARY_DOUBLE', 'BINARY_FLOAT', 'FLOAT') then 												'double precision'
+		    	end trg_num_dt,
+				nullable,
 				
-	order by column_id SEPARATOR ', 
-	'
-	)
-|| 
+	        	metric_id,
+	        	'DATABASE_MIGRATION' as metric_schema_name,
+	        	exa_table_name || '_MIG_CHK' as metric_table_name,
+	        	
+	        	case	when metric_id = 0 and column_id = 1 then																		'cast(count(*) as decimal(36,0))'
+	        			when metric_id = 1 and nullable = 'Y' and (
+								data_type in ('CHAR', 'NCHAR', 'VARCHAR','VARCHAR2', 'NVARCHAR2', 'RAW', 'DECIMAL', 'NUMBER', 'DATE') or
+								data_type like 'TIMESTAMP(%)%' or 
+								data_type like 'TIMESTAMP%' or
+								data_type like 'TIMESTAMP%WITH%TIME%ZONE%' or
+								data_type like 'INTERVAL YEAR%TO MONTH%' or
+								data_type like 'INTERVAL DAY%TO SECOND%') then															'cast(sum(case when ' || local.qtcn ||' is null then 1 end) as decimal(36,0))'
+	        			when metric_id = 2 and (
+								data_type in ('CHAR', 'NCHAR', 'VARCHAR','VARCHAR2', 'NVARCHAR2', 'RAW', 'DECIMAL', 'NUMBER', 'DATE') or
+								data_type like 'TIMESTAMP(%)%' or 
+								data_type like 'TIMESTAMP%' or
+								data_type like 'TIMESTAMP%WITH%TIME%ZONE%' or
+								data_type like 'INTERVAL YEAR%TO MONTH%' or
+								data_type like 'INTERVAL DAY%TO SECOND%') then															'cast(count(distinct ' || local.qtcn || ') as decimal(36,0))'
+	        			
+	        			when data_type in ('CHAR', 'VARCHAR', 'VARCHAR2', 'NCHAR', 'NVARCHAR2') then 
+	        					case	when metric_id = 3 then																			'min("C_' || local.cn ||'"."' || local.cn || '_TOP")'
+		                        		when metric_id = 4 then																			'min("C_' || local.cn ||'"."' || local.cn || '_OCC")' 
+				            			when metric_id = 5 then																			'cast(min(length(' || local.qtcn || ')) as decimal(36,0))'
+	        							when metric_id = 6 then																			'cast(avg(length(' || local.qtcn || ')) as double precision)'
+	        							when metric_id = 7 then																			'cast(median(length(' || local.qtcn || ')) as decimal(36,0))'
+	        							when metric_id = 8 then																			'cast(max(length(' || local.qtcn || ')) as decimal(36,0))'
+								end
+						
+						when data_type in ('BINARY_DOUBLE', 'BINARY_FLOAT', 'FLOAT', 'NUMBER') then 
+								case	when metric_id = 3 then																			'cast(min(' || local.qtcn || ') as ' || local.trg_num_dt || ')'
+										when metric_id = 4 then																			'cast(avg(' || local.qtcn || ') as ' || local.trg_num_dt || ')'
+										when metric_id = 5 then																			'cast(median(' || local.qtcn || ') as ' || local.trg_num_dt || ')'
+										when metric_id = 6 then																			'cast(max(' || local.qtcn || ') as ' || local.trg_num_dt || ')'
+								end
+						
+						when data_type = 'DATE' or data_type like 'TIMESTAMP(%)' or (data_type like 'TIMESTAMP%WITH%TIME%ZONE%' and db_system = 'exasol') then 
+								case	when metric_id = 3 then																			'cast(min(' || local.qtcn || ') as timestamp)'
+										when metric_id = 4 then																			'cast(median(' || local.qtcn || ') as timestamp)'
+										when metric_id = 5 then																			'cast(max(' || local.qtcn || ') as timestamp)'
+								end
+						when data_type like 'TIMESTAMP%WITH%TIME%ZONE%' and db_system = 'oracle' then 
+								case	when metric_id = 3 then																			'cast(min(cast(' || local.qtcn || ' at time zone ''00:00'' as timestamp with time zone)) at time zone ''00:00'' as timestamp)'
+										when metric_id = 4 then																			'cast(median(cast(' || local.qtcn || ' at time zone ''00:00'' as timestamp with time zone)) at time zone ''00:00'' as timestamp)'
+										when metric_id = 5 then																			'cast(max(cast(' || local.qtcn || ' at time zone ''00:00'' as timestamp with time zone)) at time zone ''00:00'' as timestamp)'
+								end
+								
+						when data_type like 'INTERVAL DAY% TO SECOND%' or (data_type like 'INTERVAL YEAR% TO MONTH' and data_precision > 0) then 
+								case	when metric_id = 3 then																			'to_char(min(' || local.qtcn || '))'
+										when metric_id = 4 then																			'to_char(median(' || local.qtcn || '))'
+										when metric_id = 5 then																			'to_char(max(' || local.qtcn || '))'
+								end
+						when data_type like 'INTERVAL YEAR% TO MONTH' and data_precision = 0 then
+								case	when metric_id = 3 then																			'substr(cast(min(' || local.qtcn || ') as varchar2(30)), 10, 5)'
+										when metric_id = 4 then																			'substr(cast(median(' || local.qtcn || ') as varchar2(30)), 10, 5)'
+										when metric_id = 5 then																			'substr(cast(max(' || local.qtcn || ') as varchar2(30)), 10, 5)'
+								end
+	        	end metric_column_expression,
 
-') from ]]..CONNECTION_TYPE..[[ at ]]..CONNECTION_NAME..[[ statement 
-''select 
-' || 
-		group_concat(
-		case 
-			when data_type in ('CHAR', 'NCHAR') then '"' || column_name || '"' 
-			when data_type in ('VARCHAR','VARCHAR2', 'NVARCHAR2') then '"' || column_name || '"' 
-			when data_type = 'CLOB' then '"' || column_name || '"' 
-			when data_type = 'XMLTYPE' then '"' || column_name || '"' 
-			when data_type in ('DECIMAL') and (data_precision is not null and data_scale is not null) then '"' || column_name || '"' 
-			when data_type = 'NUMBER' and (data_precision is not null and data_scale is not null) then '"' || column_name || '"'  
-			when data_type = 'NUMBER' and (data_length is not null and data_precision is null and data_scale is not null) then '"' || column_name  || '"'
-			when data_type = 'NUMBER' and (data_precision is null and data_scale is null) then '"' || column_name || '"' 
-			when data_type in ('DOUBLE PRECISION', 'FLOAT', 'BINARY_FLOAT', 'BINARY_DOUBLE') then 'cast("' || column_name || '" as DOUBLE PRECISION)' 
-			when data_type = 'DATE' then '"' || column_name || '"' 
-			when data_type like 'TIMESTAMP(%)' or data_type like 'TIMESTAMP' then '"' || column_name || '"' 
-			when data_type like 'TIMESTAMP%WITH%TIME%ZONE%' then 'cast("' || column_name || '" as TIMESTAMP)' 
-			when data_type = 'BOOLEAN' then '"' || column_name || '"' 
-			/* else '--UNSUPPORTED DATATYPE IN COLUMN ' || column_name || ' Oracle Datatype: ' || data_type  */
-		end
-			
-	order by column_id SEPARATOR ', 
-	'
-	)
+	        	case 	when metric_id = 0 and column_id = 1 then																		'"CNT_' || local.tn || '"'
+	        			when metric_id = 1 and nullable = 'Y' and (
+								data_type in ('CHAR', 'NCHAR', 'VARCHAR','VARCHAR2', 'NVARCHAR2', 'RAW', 'DECIMAL', 'NUMBER', 'DATE') or
+								data_type like 'TIMESTAMP(%)%' or 
+								data_type like 'TIMESTAMP%' or
+								data_type like 'TIMESTAMP%WITH%TIME%ZONE%' or
+								data_type like 'INTERVAL YEAR%TO MONTH%' or
+								data_type like 'INTERVAL DAY%TO SECOND%') then															'"' || local.cn || '_CNT_NULL"'
+	        			when metric_id = 2 and  (
+								data_type in ('CHAR', 'NCHAR', 'VARCHAR','VARCHAR2', 'NVARCHAR2', 'RAW', 'DECIMAL', 'NUMBER', 'DATE') or
+								data_type like 'TIMESTAMP(%)%' or 
+								data_type like 'TIMESTAMP%' or
+								data_type like 'TIMESTAMP%WITH%TIME%ZONE%' or
+								data_type like 'INTERVAL YEAR%TO MONTH%' or
+								data_type like 'INTERVAL DAY%TO SECOND%') then															'"' || local.cn || '_CNT_DST"'
+	        			
+	        			when data_type in ('CHAR', 'VARCHAR', 'VARCHAR2', 'NCHAR', 'NVARCHAR2') then 
+	        					case	when metric_id = 3 then																			'"' || local.cn || '_TOP"' 
+		                        		when metric_id = 4 then																			'"' || local.cn || '_OCC"'
+				            			when metric_id = 5 then																			'"' || local.cn || '_MIN"'
+	        							when metric_id = 6 then																			'"' || local.cn || '_AVG"'
+	        							when metric_id = 7 then																			'"' || local.cn || '_MED"'
+	        							when metric_id = 8 then																			'"' || local.cn || '_MAX"'
+								end
+						
+						when data_type in ('BINARY_DOUBLE', 'BINARY_FLOAT', 'FLOAT', 'NUMBER') then 
+								case	when metric_id = 3 then																			'"' || local.cn || '_MIN"'
+										when metric_id = 4 then																			'"' || local.cn || '_AVG"'
+										when metric_id = 5 then																			'"' || local.cn || '_MED"'
+										when metric_id = 6 then																			'"' || local.cn || '_MAX"'
+								end
+						
+						when data_type = 'DATE' or data_type like 'TIMESTAMP(%)' or (data_type like 'TIMESTAMP%WITH%TIME%ZONE%' and db_system = 'exasol') then 
+								case	when metric_id = 3 then																			'"' || local.cn || '_MIN"'
+										when metric_id = 4 then																			'"' || local.cn || '_MED"'
+										when metric_id = 5 then																			'"' || local.cn || '_MAX"'
+								end
+						when data_type like 'TIMESTAMP%WITH%TIME%ZONE%' and db_system = 'oracle' then 
+								case	when metric_id = 3 then																			'"' || local.cn || '_MIN"'
+										when metric_id = 4 then																			'"' || local.cn || '_MED"'
+										when metric_id = 5 then																			'"' || local.cn || '_MAX"'
+								end
+								
+						when data_type like 'INTERVAL DAY% TO SECOND%' or (data_type like 'INTERVAL YEAR% TO MONTH' and data_precision > 0) then 
+								case	when metric_id = 3 then																			'"' || local.cn || '_MIN"'
+										when metric_id = 4 then																			'"' || local.cn || '_MED"'
+										when metric_id = 5 then																			'"' || local.cn || '_MAX"'
+								end
+						when data_type like 'INTERVAL YEAR% TO MONTH' and data_precision = 0 then
+								case	when metric_id = 3 then																			'"' || local.cn || '_MIN"'
+										when metric_id = 4 then																			'"' || local.cn || '_MED"'
+										when metric_id = 5 then																			'"' || local.cn || '_MAX"'
+								end
+	        	end metric_column_name,
+	        	case 	when data_type in ('CHAR', 'VARCHAR', 'VARCHAR2', 'NCHAR', 'NVARCHAR2')  and metric_id = 1 then
+		                		'(select substr(listagg(' || local.qtcn || ', ' || case when db_system = 'Exasol' then ''',''' else ''''',''''' end || ') within group(order by ' || local.qtcn || '), 1, 2000) as "' || local.cn || '_TOP", cast(min(cnt) as decimal(36,0)) as "' || local.cn || '_OCC" ' ||
+						        'from (' ||
+		                			'select ' || local.qtcn || ', count(*) cnt, max(count(*)) over() max_cnt ' ||
+		                			'from ' || local.qstn || ' ' || 
+		                			'group by ' || local.qtcn || 
+	                			') "' || local.tn || '" ' ||
+		                        'where cnt = max_cnt) "C_' || local.cn || '"' 
+	        	end metric_column_subselect
+		from	ora_base
+		, 		(select 'Oracle' db_system union all select 'Exasol' db_system)
+		,		(select level -1 metric_id from dual connect by level <= 9)
+		where 	local.metric_column_expression is not null
+		and		]] .. tostring(CHECK_MIGRATION) .. [[
+)
 
-|| ' from ' ||  '"' || owner || '"."' || table_name || '"' || ''';'  as imp from ora_base group by owner, table_name, EXA_SCHEMA_NAME, EXA_TABLE_NAME
-	)
-select sql_text from (
-select 1 as ord_hlp,'-- session parameter values are being taken from Oracle systemwide database_parameters and converted. However these should be confirmed before use.' as sql_text
-union all
-select 2, '-- Oracle DB''s NLS_CHARACTERSET is set to : ' || "VALUE" from nls_format where "PARAMETER"='NLS_CHARACTERSET'
-union all
-select 3,'-- ALTER SESSION SET NLS_DATE_LANGUAGE=''' || "VALUE" || ''';' from nls_format where "PARAMETER"='NLS_DATE_LANGUAGE'
-union all
-select 4,'-- ALTER SESSION SET NLS_DATE_FORMAT=''' || replace("VALUE",'R','Y') || ''';' from nls_format where "PARAMETER"='NLS_DATE_FORMAT'
-union all
-select 5,'-- ALTER SESSION SET NLS_TIMESTAMP_FORMAT=''' || replace(regexp_replace("VALUE",'XF+','.FF6'),'R','Y') || ''';' from nls_format where "PARAMETER"='NLS_TIMESTAMP_FORMAT'
-union all
-select 6,a.* from cr_schema a
-union all
-select 7,b.* from cr_tables b
-where b.TBLS not like '%();%'
-union all
-select 8,c.* from cr_import_stmts c
-where c.IMP not like '%( ) from%'
-) order by ord_hlp
+, cr_check_table as (
+	select  db_system, exa_schema_name, exa_table_name, metric_table_name,
+			listagg(metric_column_subselect, ', ') within group(order by column_id, metric_id) sql_subselect,
+			'create or replace table "' || exa_schema_name || '"."' || metric_table_name || '" as ' ||
+	        'select cast(''' || db_system || ''' as varchar2(20)) as "DB_SYSTEM", ' || 
+	        listagg(metric_column_expression || ' as ' || metric_column_name, ', ') within group(order by column_id, metric_id) || 
+	        ' from ' || qstn || case when local.sql_subselect is not null then ', ' || local.sql_subselect end || ';' as sql_text
+	from 	check_expr
+	where 	db_system = 'Exasol'
+	group by db_system, qstn, exa_schema_name, exa_table_name, owner, table_name, metric_table_name
+
+)
+
+, ins_check_table as (
+	select  listagg(metric_column_subselect, ', ') within group(order by column_id, metric_id) sql_subselect,
+			'insert into "' || exa_schema_name || '"."' || metric_table_name || '" ' ||
+			'select * from (import from ]]..CONNECTION_TYPE..[[ at ]] .. CONNECTION_NAME .. [[ statement '''  ||
+	        'select cast(''''' || db_system || ''''' as varchar2(20)) as "DB_SYSTEM", ' || 
+	        listagg(metric_column_expression || ' as ' || metric_column_name, ', ') within group(order by column_id, metric_id) || 
+	        ' from ' || qstn || case when local.sql_subselect is not null then ', ' || local.sql_subselect end ||
+	        case when db_system != 'Exasol' then ''');' end as sql_text
+	from 	check_expr
+	where 	db_system != 'Exasol'
+	group by db_system, qstn, exa_schema_name, exa_table_name, owner, table_name, metric_table_name
+)
+
+, cr_check_summary as (
+    select 	1 ord2, 'create or replace table "' || metric_schema_name || '"."' || exa_schema_name || '_MIG_CHK" (schema_name varchar(128), table_name varchar(128), column_name varchar(128), metric_schema varchar(128), metric_table varchar(128),  metric_name varchar(128), exasol_metric varchar(2000), oracle_metric varchar(2000), check_timestamp timestamp default current_timestamp);' as sql_text
+    from 	check_expr
+    group by metric_schema_name, exa_schema_name
+    union all
+    select 2 ord2, 'insert into "' || metric_schema_name || '"."' || exa_schema_name || '_MIG_CHK" (schema_name, table_name, column_name, metric_schema, metric_table, metric_name, exasol_metric, oracle_metric) ' 
+            || listagg(sql_text, '') within group(order by case when db_system = 'Exasol' then 1 else 2 end) || ' '
+            || 'select e.schema_name, e.table_name, e.column_name, e.metric_schema, e.metric_table, e.metric_name, e.exasol_metric, o.oracle_metric from exasol e join oracle o on e.schema_name = o.schema_name and e.table_name = o.table_name and e.metric_name = o.metric_name; ' as sql_text
+    from (
+    
+            select  db_system, exa_schema_name, exa_table_name, metric_schema_name,
+                    case when db_system = 'Exasol' then 'with ' else ', ' end || db_system || ' as ( '
+                    || listagg(
+                    	'select ''' || exa_schema_name || ''' as schema_name, ''' || exa_table_name || ''' as table_name,  ''' || exa_column_name || ''' column_name, ''' || metric_schema_name || ''' metric_schema, ''' || metric_table_name || ''' metric_table, ''' || metric_column_name || ''' as metric_name, to_char(' || metric_column_name || ') as ' || db_system || '_metric from "' || exa_schema_name || '"."' || metric_table_name || '" where DB_SYSTEM = ''' || db_system || '''', ' union all ')
+                    || ' )'  as sql_text
+            from check_expr
+            group by db_system, exa_schema_name, exa_table_name, metric_schema_name, metric_table_name
+            order by case when db_system = 'Exasol' then 1 else 2 end
+    )
+    group by exa_schema_name, exa_table_name, metric_schema_name
+
+)
+select  sql_text 
+from    (
+        select 1 as ord_hlp,'-- session parameter values are being taken from Oracle systemwide database_parameters and converted. However these should be confirmed before use.' as sql_text
+        union all
+        select 2, '-- Oracle DB''s NLS_CHARACTERSET is set to : ' || "VALUE" from nls_format where "PARAMETER"='NLS_CHARACTERSET'
+		union all
+		select 2.1, '-- Oracle DB''s NLS_NCHAR_CHARACTERSET is set to : ' || "VALUE" from nls_format where "PARAMETER"='NLS_NCHAR_CHARACTERSET'
+        union all
+        select 3,'-- ALTER SESSION SET NLS_DATE_LANGUAGE=''' || "VALUE" || ''';' from nls_format where "PARAMETER"='NLS_DATE_LANGUAGE'
+        union all
+        select 4,'-- ALTER SESSION SET NLS_DATE_FORMAT=''' || replace("VALUE",'R','Y') || ''';' from nls_format where "PARAMETER"='NLS_DATE_FORMAT'
+        union all
+        select 5,'-- ALTER SESSION SET NLS_TIMESTAMP_FORMAT=''' || replace(regexp_replace("VALUE",'XF+','.FF6'),'R','Y') || ''';' from nls_format where "PARAMETER"='NLS_TIMESTAMP_FORMAT'
+		union all
+		select 6, '-- ALTER SESSION SET NLS_NUMERIC_CHARACTERS=''' || session_value || ''';' from exa_parameters where parameter_name = 'NLS_NUMERIC_CHARACTERS'
+        union all
+        select 7, a.* from cr_schema a
+        union all
+        select 8, b.* from cr_tables b where b.TBLS not like '%();%'
+        union all
+        select 9, import_stmt from cr_import_stmts
+		union all
+        select 10, case when not ]] .. tostring(CREATE_PK) .. [[ then '-- ' end || EXA_CONSTRAINT from cr_constraints_pk
+        union all
+        select 11, case when not ]] .. tostring(CREATE_FK) .. [[ then '-- ' end || EXA_CONSTRAINT from cr_constraints_fk
+		union all
+		select 12, sql_text from cr_check_table
+		union all
+		select 13, sql_text from ins_check_table
+		union all
+		select 14, sql_text from cr_check_summary
+) 
+order by ord_hlp
 ]],{c=CONNECTION_NAME, s=SCHEMA_FILTER, t=TABLE_FILTER})
 
+--output(res.statement_text)
 if not success then error(res.error_message) end
-
 return(res)
+
 /
+;
 
--- For JDBC Connection
-CREATE CONNECTION JDBC_ORACLE  --Install JDBC driver first via EXAoperation, see https://www.exasol.com/support/browse/SOL-179
-	TO 'jdbc:oracle:thin:@//192.168.99.100:1521/xe'
-	USER 'system'
-	IDENTIFIED BY '********';
 
-EXECUTE SCRIPT database_migration.ORACLE_TO_EXASOL('JDBC_ORACLE', true, '%APEX%','%');
 
--- For OCI Connection
-CREATE OR REPLACE CONNECTION OCI_ORACLE
-	TO '192.168.99.100:1521/xe'
-	USER 'system'
-IDENTIFIED BY '********';
+create or replace connection oracle_jdbc	to	'jdbc:oracle:thin:@192.168.56.106:1521/cdb2' user 'C##DB_MIG' identified by 'C##DB_MIG';
+create or replace connection oracle_oci		to					  '192.168.56.106:1521/cdb2' user 'C##DB_MIG' identified by 'C##DB_MIG';
+import from JDBC at ORACLE_JDBC statement 	'select ''Connection works'' from dual';
+import from ORA at ORACLE_OCI statement 	'select ''Connection works'' from dual';
 
-EXECUTE SCRIPT database_migration.ORACLE_TO_EXASOL('OCI_ORACLE', true, '%APEX%','%');
+
+execute script database_migration.oracle_to_exasol(
+	'ORACLE_OCI', 	-- connection name
+	true, 			-- case insensitivity flag
+	'C##DB_MIG', 	-- schema name filter
+	'DIM_DATE, DIM_PRODUCT, DIM_STORE, SALES, SALES_POSITION',	-- table name filter
+	4, 				-- degree of parallelism for the import statements.
+	false, 			-- flag for primary key generation.
+	false, 			-- flag for foreign key generation.
+	false			-- flag for creation and loading of checking tables
+)
+--with output
+;

--- a/oracle_to_exasol.sql
+++ b/oracle_to_exasol.sql
@@ -854,7 +854,7 @@ execute script database_migration.oracle_to_exasol(
 	'ORACLE_OCI', 	-- connection name
 	true, 			-- case insensitivity flag
 	'C##DB_MIG', 	-- schema name filter
-	'%%',			-- table name filter
+	'%',			-- table name filter
 	4, 				-- degree of parallelism for the import statements.
 	false, 			-- flag for primary key generation.
 	false, 			-- flag for foreign key generation.

--- a/teradata_to_exasol.sql
+++ b/teradata_to_exasol.sql
@@ -61,71 +61,74 @@ with vv_columns as (
     ''tdwm'', ''SQLJ'', ''TD_SYSFNLIB'', ''SYSSPATIAL'') AND
                                 table_schema like '']]..SCHEMA_FILTER..[['' AND
                                 table_name like '']]..TABLE_FILTER..[[''
-		      ') as tableList order by false),
-vv_primary_keys_raw as (
-select   ]]..exa_upper_begin..[["table_schema"]]..exa_upper_end..[[ as "exa_table_schema", 
-	               ]]..exa_upper_begin..[["table_name"]]..exa_upper_end..[[ as "exa_table_name", 
-	               ]]..exa_upper_begin..[["column_name"]]..exa_upper_end..[[ as "exa_column_name",
-	               "table_schema" as "table_schema",
-	               "table_name" as "table_name",
-	               "column_name" as "column_name",
-	               "column_position" as "column_position"
-from (
-
-import from jdbc at ]]..CONNECTION_NAME..[[  
-        statement   '
-SELECT  DatabaseName as table_schema,
-        TableName as table_name,
-        ColumnName as column_name,
-        ColumnPosition as column_position
-FROM    DBC.IndicesV
-WHERE UniqueFlag = ''Y'' AND IndexType IN (''K'')
-and table_schema not in (''All'', ''Crashdumps'', ''DBC'', ''dbcmngr'', 
-    ''Default'', ''External_AP'', ''EXTUSER'', ''LockLogShredder'', ''PUBLIC'',
-    ''Sys_Calendar'', ''SysAdmin'', ''SYSBAR'', ''SYSJDBC'', ''SYSLIB'',
-    ''SystemFe'', ''SYSUDTLIB'', ''SYSUIF'', ''TD_SERVER_DB'', ''TDStats'',
-    ''TD_SYSGPL'', ''TD_SYSXML'', ''TDMaps'', ''TDPUSER'', ''TDQCD'',
-    ''tdwm'', ''SQLJ'', ''TD_SYSFNLIB'', ''SYSSPATIAL'') AND
-table_schema like '']]..SCHEMA_FILTER..[['' AND
-table_name like '']]..TABLE_FILTER..[['' 
-'
-) as primarykeylist
-),
-vv_foreign_keys_raw as (
-select   ]]..exa_upper_begin..[["ChildDB"]]..exa_upper_end..[[ as "exa_table_schema", 
-	 ]]..exa_upper_begin..[["ChildTable"]]..exa_upper_end..[[ as "exa_table_name", 
-	 ]]..exa_upper_begin..[["ChildKeyColumn"]]..exa_upper_end..[[ as "exa_foreign_key_column",
-	 ]]..exa_upper_begin..[["ParentDB"]]..exa_upper_end..[[ as "exa_referenced_table_schema", 
-	 ]]..exa_upper_begin..[["ParentTable"]]..exa_upper_end..[[ as "exa_referenced_table_name"
-from (
-
-import from jdbc at ]]..CONNECTION_NAME..[[  
-    statement   ' 
-    SELECT  ChildDB,
-		ChildTable,
-        ChildKeyColumn,
-        ParentDB ,
-        ParentTable 
-FROM    DBC.All_RI_ChildrenV
-WHERE   ChildDB NOT IN (''All'', ''Crashdumps'', ''DBC'', ''dbcmngr'', 
-    ''Default'', ''External_AP'', ''EXTUSER'', ''LockLogShredder'', ''PUBLIC'',
-    ''Sys_Calendar'', ''SysAdmin'', ''SYSBAR'', ''SYSJDBC'', ''SYSLIB'',
-    ''SystemFe'', ''SYSUDTLIB'', ''SYSUIF'', ''TD_SERVER_DB'', ''TDStats'',
-    ''TD_SYSGPL'', ''TD_SYSXML'', ''TDMaps'', ''TDPUSER'', ''TDQCD'',
-    ''tdwm'', ''SQLJ'', ''TD_SYSFNLIB'', ''SYSSPATIAL'') and
-ChildDB like '']]..SCHEMA_FILTER..[['' AND
-ChildTable like '']]..TABLE_FILTER..[['' 
-'
+		      ') as tableList order by false
 )
 
-),
-vv_create_schemas as(
+, vv_primary_keys_raw as (
+	select	]]..exa_upper_begin..[["table_schema"]]..exa_upper_end..[[ as "exa_table_schema", 
+			]]..exa_upper_begin..[["table_name"]]..exa_upper_end..[[ as "exa_table_name", 
+			]]..exa_upper_begin..[["column_name"]]..exa_upper_end..[[ as "exa_column_name",
+			"table_schema" as "table_schema",
+	        "table_name" as "table_name",
+	        "column_name" as "column_name",
+	        "column_position" as "column_position"
+	from (
+			import from jdbc at ]]..CONNECTION_NAME..[[  
+			statement '
+			SELECT  DatabaseName as table_schema,
+			        TableName as table_name,
+			        ColumnName as column_name,
+			        ColumnPosition as column_position
+			FROM    DBC.IndicesV
+			WHERE UniqueFlag = ''Y'' AND IndexType IN (''K'')
+			and table_schema not in (''All'', ''Crashdumps'', ''DBC'', ''dbcmngr'', 
+			    ''Default'', ''External_AP'', ''EXTUSER'', ''LockLogShredder'', ''PUBLIC'',
+			    ''Sys_Calendar'', ''SysAdmin'', ''SYSBAR'', ''SYSJDBC'', ''SYSLIB'',
+			    ''SystemFe'', ''SYSUDTLIB'', ''SYSUIF'', ''TD_SERVER_DB'', ''TDStats'',
+			    ''TD_SYSGPL'', ''TD_SYSXML'', ''TDMaps'', ''TDPUSER'', ''TDQCD'',
+			    ''tdwm'', ''SQLJ'', ''TD_SYSFNLIB'', ''SYSSPATIAL'') AND
+			table_schema like '']]..SCHEMA_FILTER..[['' AND
+			table_name like '']]..TABLE_FILTER..[['' 
+			'
+	) as primarykeylist
+)
+
+, vv_foreign_keys_raw as (
+	select   ]]..exa_upper_begin..[["ChildDB"]]..exa_upper_end..[[ as "exa_table_schema", 
+		 ]]..exa_upper_begin..[["ChildTable"]]..exa_upper_end..[[ as "exa_table_name", 
+		 ]]..exa_upper_begin..[["ChildKeyColumn"]]..exa_upper_end..[[ as "exa_foreign_key_column",
+		 ]]..exa_upper_begin..[["ParentDB"]]..exa_upper_end..[[ as "exa_referenced_table_schema", 
+		 ]]..exa_upper_begin..[["ParentTable"]]..exa_upper_end..[[ as "exa_referenced_table_name"
+	from (
+			import from jdbc at ]]..CONNECTION_NAME..[[  
+			statement ' 
+			SELECT  ChildDB,
+					ChildTable,
+			        ChildKeyColumn,
+			        ParentDB ,
+			        ParentTable 
+			FROM    DBC.All_RI_ChildrenV
+			WHERE   ChildDB NOT IN (''All'', ''Crashdumps'', ''DBC'', ''dbcmngr'', 
+			    ''Default'', ''External_AP'', ''EXTUSER'', ''LockLogShredder'', ''PUBLIC'',
+			    ''Sys_Calendar'', ''SysAdmin'', ''SYSBAR'', ''SYSJDBC'', ''SYSLIB'',
+			    ''SystemFe'', ''SYSUDTLIB'', ''SYSUIF'', ''TD_SERVER_DB'', ''TDStats'',
+			    ''TD_SYSGPL'', ''TD_SYSXML'', ''TDMaps'', ''TDPUSER'', ''TDQCD'',
+			    ''tdwm'', ''SQLJ'', ''TD_SYSFNLIB'', ''SYSSPATIAL'') and
+			ChildDB like '']]..SCHEMA_FILTER..[['' AND
+			ChildTable like '']]..TABLE_FILTER..[['' 
+			'
+	)
+
+)
+
+, vv_create_schemas as(
 	SELECT 'create schema if not exists "' || "exa_table_schema" || '";' as sql_text 
 	from vv_columns  
 	group by "exa_table_schema" 
 	order by "exa_table_schema"
 )
-,vv_create_tables as (
+
+, vv_create_tables as (
 	select 'create or replace table "' || "exa_table_schema" || '"."' || "exa_table_name" || '" (' || 
 	group_concat(
 	case 
@@ -138,9 +141,7 @@ vv_create_schemas as(
 	else
 	       '"' ||  "exa_column_name" || '" ' 
 	end
-	   
-	    ||
-	        
+	||  
 	case 
 	when "data_type" = 'PD' then ''  --Period is already splitted into two dates before
 	when "data_type" in ('PS', 'PM', 'PT', 'PZ') then ''  --Period is already splitted into two timestamps before
@@ -234,61 +235,64 @@ vv_create_schemas as(
 	group by       "exa_table_schema", "exa_table_name"
 	order by       "exa_table_schema","exa_table_name"
 )
+
 , vv_primary_keys as (
-
-select 'ALTER TABLE "' || "exa_table_schema" || '"."' || "exa_table_name" || '" ADD CONSTRAINT PRIMARY KEY (' || 
-	group_concat('"'||  "exa_column_name" || '"'  order by "column_position")  || ') ;' as sql_text
-from           vv_primary_keys_raw   
-	group by       "exa_table_schema", "exa_table_name"
-	order by       "exa_table_schema","exa_table_name"
-
-), vv_foreign_keys as (
-
-select 'ALTER TABLE "' || "exa_table_schema" || '"."' || "exa_table_name" ||
- '" ADD FOREIGN KEY (' || '"'||  "exa_foreign_key_column" || '") REFERENCES "' || "exa_referenced_table_schema" || '"."' || "exa_referenced_table_name" || '" DISABLE ;' as sql_text
-from vv_foreign_keys_raw   
-order by "exa_table_schema","exa_table_name"
-
+	select 	'ALTER TABLE "' || "exa_table_schema" || '"."' || "exa_table_name" || '" ADD CONSTRAINT PRIMARY KEY (' || 
+			group_concat('"'||  "exa_column_name" || '"'  order by "column_position")  || ') ;' as sql_text
+	from vv_primary_keys_raw   
+	group by "exa_table_schema", "exa_table_name"
+	order by "exa_table_schema","exa_table_name"
 )
+
+, vv_foreign_keys as (
+	select 'ALTER TABLE "' || "exa_table_schema" || '"."' || "exa_table_name" ||
+	 '" ADD FOREIGN KEY (' || '"'||  "exa_foreign_key_column" || '") REFERENCES "' || "exa_referenced_table_schema" || '"."' || "exa_referenced_table_name" || '" DISABLE ;' as sql_text
+	from vv_foreign_keys_raw   
+	order by "exa_table_schema","exa_table_name"
+)
+
 , vv_imports as (
-	select 'import into "' || "exa_table_schema" || '"."' || "exa_table_name" || '" from jdbc at ]]..CONNECTION_NAME..[[ statement ''select ' || group_concat( 
-	case 
-	when "data_type" = 'DA' then "column_name_delimited"
-	when "data_type" = 'D'  then "column_name_delimited"
-	when "data_type" = 'TS' then "column_name_delimited"
-	when "data_type" = 'CF' then "column_name_delimited"
-	when "data_type" = 'I1' then "column_name_delimited"
-	when "data_type" = 'I2' then "column_name_delimited"
-	when "data_type" = 'I8' then "column_name_delimited"
-	when "data_type" = 'AT' then "column_name_delimited"
-	when "data_type" = 'F'  then "column_name_delimited"
-	when "data_type" = 'CV' then "column_name_delimited"
-	when "data_type" = 'I'  then "column_name_delimited"
-	when "data_type" = 'N'  then "column_name_delimited"
-	when "data_type" in ('A1','AN')  then 'cast(' || "column_name_delimited" || ' as varchar(64000)) '  --array datatypes are casted to a varchar in Teradata
-	when "data_type" in ('BF', 'BO', 'BV') then '''''NOT SUPPORTED''''' --binary data types (BYTE, VARBYTE, BLOB) are not supported
-	when "data_type" = 'JN'  then 'CAST(' || "column_name_delimited" ||  ' AS CLOB ) ' --json (max length in Exasol is 2000000 as it is stored as varchar)  
-	when "data_type" = 'PD'  then  'BEGIN('|| "column_name_delimited" || ') , END(' ||  "column_name_delimited" || ')'  --Period(Date) split into begin and end date
-	when "data_type" in ('PS', 'PM')  then  'CAST(  BEGIN('|| "column_name_delimited" || ') AS TIMESTAMP ) , CAST ( END(' ||  "column_name_delimited" || ') AS TIMESTAMP ) '  --Period(Timestamp) split into begin and end timestamp  
-	when "data_type" in ('PT', 'PZ')  then  'CAST(  BEGIN('|| "column_name_delimited" || ') AS TIME ) , CAST ( END(' ||  "column_name_delimited" || ') AS TIME ) '  --Period(Time) split into begin and end time	
-	when "data_type" = 'TZ' then  'cast(' || "column_name_delimited" || ' AS TIME)'  --time with time zone
-	when "data_type" = 'SZ' then  'cast(' || "column_name_delimited" || ' AS TIMESTAMP)'  --timestamp with time zone
-	when "data_type" = 'YR'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL YEAR  TO MONTH ) AS VARCHAR(50))'  --Interval Year
-	when "data_type" = 'YM'  then 'cast('|| "column_name_delimited" || ' AS VARCHAR(50) )'  --Interval Year to Month
-	when "data_type" = 'MO'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL YEAR  TO MONTH ) AS VARCHAR(50))'  --Interval Month
-	when "data_type" = 'DY'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) ' --Interval Day
-	when "data_type" = 'DH'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Day to hour
-	when "data_type" = 'DM'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Day to minute
-	when "data_type" = 'DS'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval day to second
-	when "data_type" = 'HR'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Hour
-	when "data_type" = 'HM'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Day to minute
-	when "data_type" = 'HS'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval day to second
-	when "data_type" = 'MI'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) ' --Interval Minute
-	when "data_type" = 'MS'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval minute to second
-	when "data_type" = 'SC'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval Second
-	else "column_name_delimited"
-	end
-	order by "ordinal_position") || ' from ' || "table_schema"|| '.' || "table_name"|| ''';' as sql_text
+	select 	'import into "' || "exa_table_schema" || '"."' || "exa_table_name" || '" from jdbc at ]]..CONNECTION_NAME..[[ statement ''select ' || 
+			group_concat( 
+				case 
+				when "data_type" = 'DA' then "column_name_delimited"
+				when "data_type" = 'D'  then "column_name_delimited"
+				when "data_type" = 'TS' then "column_name_delimited"
+				when "data_type" = 'CF' then "column_name_delimited"
+				when "data_type" = 'I1' then "column_name_delimited"
+				when "data_type" = 'I2' then "column_name_delimited"
+				when "data_type" = 'I8' then "column_name_delimited"
+				when "data_type" = 'AT' then "column_name_delimited"
+				when "data_type" = 'F'  then "column_name_delimited"
+				when "data_type" = 'CV' then "column_name_delimited"
+				when "data_type" = 'I'  then "column_name_delimited"
+				when "data_type" = 'N'  then "column_name_delimited"
+				when "data_type" in ('A1','AN')  then 'cast(' || "column_name_delimited" || ' as varchar(64000)) '  --array datatypes are casted to a varchar in Teradata
+				when "data_type" in ('BF', 'BO', 'BV') then '''''NOT SUPPORTED''''' --binary data types (BYTE, VARBYTE, BLOB) are not supported
+				when "data_type" = 'JN'  then 'CAST(' || "column_name_delimited" ||  ' AS CLOB ) ' --json (max length in Exasol is 2000000 as it is stored as varchar)  
+				when "data_type" = 'PD'  then  'BEGIN('|| "column_name_delimited" || ') , END(' ||  "column_name_delimited" || ')'  --Period(Date) split into begin and end date
+				when "data_type" in ('PS', 'PM')  then  'CAST(  BEGIN('|| "column_name_delimited" || ') AS TIMESTAMP ) , CAST ( END(' ||  "column_name_delimited" || ') AS TIMESTAMP ) '  --Period(Timestamp) split into begin and end timestamp  
+				when "data_type" in ('PT', 'PZ')  then  'CAST(  BEGIN('|| "column_name_delimited" || ') AS TIME ) , CAST ( END(' ||  "column_name_delimited" || ') AS TIME ) '  --Period(Time) split into begin and end time	
+				when "data_type" = 'TZ' then  'cast(' || "column_name_delimited" || ' AS TIME)'  --time with time zone
+				when "data_type" = 'SZ' then  'cast(' || "column_name_delimited" || ' AS TIMESTAMP)'  --timestamp with time zone
+				when "data_type" = 'YR'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL YEAR  TO MONTH ) AS VARCHAR(50))'  --Interval Year
+				when "data_type" = 'YM'  then 'cast('|| "column_name_delimited" || ' AS VARCHAR(50) )'  --Interval Year to Month
+				when "data_type" = 'MO'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL YEAR  TO MONTH ) AS VARCHAR(50))'  --Interval Month
+				when "data_type" = 'DY'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) ' --Interval Day
+				when "data_type" = 'DH'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Day to hour
+				when "data_type" = 'DM'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Day to minute
+				when "data_type" = 'DS'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval day to second
+				when "data_type" = 'HR'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Hour
+				when "data_type" = 'HM'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Day to minute
+				when "data_type" = 'HS'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval day to second
+				when "data_type" = 'MI'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) ' --Interval Minute
+				when "data_type" = 'MS'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval minute to second
+				when "data_type" = 'SC'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval Second
+				else "column_name_delimited"
+				end
+				order by "ordinal_position"
+			) || 
+			' from ' || "table_schema"|| '.' || "table_name"|| ''';' as sql_text
 	from vv_columns 
 	group by "exa_table_schema","exa_table_name", "table_schema","table_name"
 	order by "exa_table_schema","exa_table_name", "table_schema","table_name"
@@ -451,7 +455,6 @@ order by "exa_table_schema","exa_table_name"
 	                		end
 	                when "metric_id" = 1 then 'not checked ''' || c."exa_column_name" || ''''
 	        end		"metric_column_name"
-	        
 	from vv_columns c 
 	left join vv_primary_keys_raw p
 	on c."exa_table_schema" = p."exa_table_schema"
@@ -476,13 +479,13 @@ order by "exa_table_schema","exa_table_name"
                         case when "db_system" = 'Exasol' then '"' || "exa_table_schema" || '"."' || "exa_table_name" || '"' else '"' || "table_schema" || '"."' || "table_name" || '"' end ||
                         case when "db_system" = 'Teradata' then ''') ' end 
                         as "check_sql"
-                
                 from vv_checks_expr
                 group by "db_system", "exa_table_schema", "exa_table_name", "table_schema", "table_name", "metric_table"
         )
         group by "exa_table_schema", "metric_table"
         order by "exa_table_schema", "metric_table"
 )
+
 , vv_check_summary as (       
         select  'create or replace table database_migration.migration_check (schema_name varchar(128), table_name varchar(128), column_name varchar(128), exasol_metric varchar(50), teradata_metric varchar(50), check_timestamp timestamp default current_timestamp);' as sql_text
         union all
@@ -508,39 +511,6 @@ order by "exa_table_schema","exa_table_name"
         select 'select * from database_migration.migration_check where exasol_metric != teradata_metric;' as sql_text
         from dual
 )
-
-
-
-
-
-, vv_check_summary as (       
-        select  'create or replace table "' || "metric_schema" || '"."' || "exa_table_schema" || '_MIG_CHK" (schema_name varchar(128), table_name varchar(128), column_name varchar(128), metric_schema varchar(128), metric_table varchar(128),  metric_name varchar(128), exasol_metric varchar(50), teradata_metric varchar(50), check_timestamp timestamp default current_timestamp);' as sql_text
-        from vv_checks_expr
-        group by "metric_schema", "exa_table_schema"
-        union all
-        select  'insert into "' || "metric_schema" || '"."' || "exa_table_schema" || '_MIG_CHK" (schema_name, table_name, column_name, metric_schema, metric_table, metric_name, exasol_metric, teradata_metric) ' 
-                || listagg(sql_text, '') within group(order by case when "db_system" = 'Exasol' then 1 else 2 end) || ' '
-                || 'select e.schema_name, e.table_name, e.column_name, e.metric_schema, e.metric_table, e.metric_name, e.exasol_metric, t.teradata_metric from exasol e join teradata t on e.schema_name = t.schema_name and e.table_name = t.table_name and e.column_name = t.column_name; ' as sql_text
-        from (
-        
-                select  "db_system", "exa_table_schema", "exa_table_name", "metric_schema",
-                        case when "db_system" = 'Exasol' then 'with ' else ', ' end || "db_system" || ' as ( '
-                        || listagg(
-                        	'select ''' || "exa_table_schema" || ''' as schema_name, ''' || "exa_table_name" || ''' as table_name,  ''' || "exa_column_name" || ''' column_name, ''' || "metric_schema" || ''' metric_schema, ''' || "metric_table" || ''' metric_table, ''' || "metric_column_name" || ''' as metric_name, to_char(' || "metric_column_name" || ') as ' || "db_system" || '_metric from "' || "exa_table_schema" || '"."' || "metric_table" || '" where DB_SYSTEM = ''' || "db_system" || '''', ' union all ')
-                        || ' )'  as sql_text
-                from vv_checks_expr
-                group by "db_system", "exa_table_schema", "exa_table_name", "metric_schema", "metric_table"
-                order by case when "db_system" = 'Exasol' then 1 else 2 end
-        
-        )
-        group by "exa_table_schema", "exa_table_name", "metric_schema"
-        union all
-        select  '--select * from "' || "metric_schema" || '"."' || "exa_table_schema" || '_MIG_CHK" where exasol_metric != teradata_metric;' as sql_text
-        from vv_checks_expr
-        group by "metric_schema", "exa_table_schema"
-)
-
-
 select * from vv_create_schemas
 UNION ALL
 select * from vv_create_tables

--- a/teradata_to_exasol.sql
+++ b/teradata_to_exasol.sql
@@ -32,116 +32,114 @@ end
 
 res = query([[
 with vv_columns as (
-	select         ]]..exa_upper_begin..[["table_schema"]]..exa_upper_end..[[ as "exa_table_schema", 
-	               ]]..exa_upper_begin..[["table_name"]]..exa_upper_end..[[ as "exa_table_name", 
-	               ]]..exa_upper_begin..[["column_name"]]..exa_upper_end..[[ as "exa_column_name"
-	               , '"' || "column_name" || '"' as "column_name_delimited"
-	               , tableList.* 
-        from            (import from jdbc at ]]..CONNECTION_NAME..[[ 
-        statement      'select trim(c.DatabaseName) as  table_schema, 
-                                trim(c.TableName) as    table_name, 
-                                ColumnName as           column_name,
-                                ColumnId as             ordinal_position, 
-                                trim(ColumnType) as     data_type, 
-                                cast(case when ColumnType in (''CF'', ''CV'') then substr(ColumnFormat, 3, length(ColumnFormat)-3) else ColumnLength end as integer) as character_maximum_length,
-                                DecimalTotalDigits as   numeric_precision, 
-                                DecimalFractionalDigits as numeric_scale,
-                                DecimalFractionalDigits as datetime_precision, 
-                                Nullable as nullable 
-                        from    DBC.ColumnsV c
-                        join    DBC.TablesV t on 
-                                c.databaseName=t.DatabaseName AND 
-                                c.TableName=t.TableName AND 
-                                TableKind=''T''
-                        where   table_schema not in (''All'', ''Crashdumps'', ''DBC'', ''dbcmngr'', 
-    ''Default'', ''External_AP'', ''EXTUSER'', ''LockLogShredder'', ''PUBLIC'',
-    ''Sys_Calendar'', ''SysAdmin'', ''SYSBAR'', ''SYSJDBC'', ''SYSLIB'',
-    ''SystemFe'', ''SYSUDTLIB'', ''SYSUIF'', ''TD_SERVER_DB'', ''TDStats'',
-    ''TD_SYSGPL'', ''TD_SYSXML'', ''TDMaps'', ''TDPUSER'', ''TDQCD'',
-    ''tdwm'', ''SQLJ'', ''TD_SYSFNLIB'', ''SYSSPATIAL'') AND
-                                table_schema like '']]..SCHEMA_FILTER..[['' AND
-                                table_name like '']]..TABLE_FILTER..[[''
-		      ') as tableList order by false
+	select	]]..exa_upper_begin..[["table_schema"]]..exa_upper_end..[[ as "exa_table_schema", 
+        	]]..exa_upper_begin..[["table_name"]]..exa_upper_end..[[ as "exa_table_name", 
+       		]]..exa_upper_begin..[["column_name"]]..exa_upper_end..[[ as "exa_column_name", 
+			'"' || "column_name" || '"' as "column_name_delimited", 
+			tableList.* 
+	from 	(
+		import from jdbc at ]]..CONNECTION_NAME..[[ 
+    	statement '
+		select 	trim(c.DatabaseName) as  table_schema, 
+        		trim(c.TableName) as    table_name, 
+        		ColumnName as           column_name,
+        		ColumnId as             ordinal_position, 
+        		trim(ColumnType) as     data_type, 
+        		cast(case when ColumnType in (''CF'', ''CV'') then substr(ColumnFormat, 3, length(ColumnFormat)-3) else ColumnLength end as integer) as character_maximum_length,
+        		DecimalTotalDigits as   numeric_precision, 
+       			DecimalFractionalDigits as numeric_scale,
+        		DecimalFractionalDigits as datetime_precision, 
+        		Nullable as nullable 
+        from    DBC.ColumnsV c
+        join    DBC.TablesV t
+		on 		c.databaseName=t.DatabaseName 
+		AND 	c.TableName=t.TableName 
+		AND 	TableKind=''T''
+        where   table_schema not in (''All'', ''Crashdumps'', ''DBC'', ''dbcmngr'', 
+				''Default'', ''External_AP'', ''EXTUSER'', ''LockLogShredder'', ''PUBLIC'',
+				''Sys_Calendar'', ''SysAdmin'', ''SYSBAR'', ''SYSJDBC'', ''SYSLIB'',
+				''SystemFe'', ''SYSUDTLIB'', ''SYSUIF'', ''TD_SERVER_DB'', ''TDStats'',
+				''TD_SYSGPL'', ''TD_SYSXML'', ''TDMaps'', ''TDPUSER'', ''TDQCD'',
+				''tdwm'', ''SQLJ'', ''TD_SYSFNLIB'', ''SYSSPATIAL'') 
+		AND 	table_schema like '']]..SCHEMA_FILTER..[['' 
+		AND		table_name like '']]..TABLE_FILTER..[[''
+		') as tableList
 )
 
 , vv_primary_keys_raw as (
 	select	]]..exa_upper_begin..[["table_schema"]]..exa_upper_end..[[ as "exa_table_schema", 
-			]]..exa_upper_begin..[["table_name"]]..exa_upper_end..[[ as "exa_table_name", 
-			]]..exa_upper_begin..[["column_name"]]..exa_upper_end..[[ as "exa_column_name",
-			"table_schema" as "table_schema",
-	        "table_name" as "table_name",
-	        "column_name" as "column_name",
-	        "column_position" as "column_position"
-	from (
-			import from jdbc at ]]..CONNECTION_NAME..[[  
-			statement '
-			SELECT  DatabaseName as table_schema,
-			        TableName as table_name,
-			        ColumnName as column_name,
-			        ColumnPosition as column_position
-			FROM    DBC.IndicesV
-			WHERE UniqueFlag = ''Y'' AND IndexType IN (''K'')
-			and table_schema not in (''All'', ''Crashdumps'', ''DBC'', ''dbcmngr'', 
-			    ''Default'', ''External_AP'', ''EXTUSER'', ''LockLogShredder'', ''PUBLIC'',
-			    ''Sys_Calendar'', ''SysAdmin'', ''SYSBAR'', ''SYSJDBC'', ''SYSLIB'',
-			    ''SystemFe'', ''SYSUDTLIB'', ''SYSUIF'', ''TD_SERVER_DB'', ''TDStats'',
-			    ''TD_SYSGPL'', ''TD_SYSXML'', ''TDMaps'', ''TDPUSER'', ''TDQCD'',
-			    ''tdwm'', ''SQLJ'', ''TD_SYSFNLIB'', ''SYSSPATIAL'') AND
-			table_schema like '']]..SCHEMA_FILTER..[['' AND
-			table_name like '']]..TABLE_FILTER..[['' 
-			'
+            ]]..exa_upper_begin..[["table_name"]]..exa_upper_end..[[ as "exa_table_name", 
+            ]]..exa_upper_begin..[["column_name"]]..exa_upper_end..[[ as "exa_column_name",
+            "table_schema" as "table_schema",
+            "table_name" as "table_name",
+            "column_name" as "column_name",
+           "column_position" as "column_position"
+	from 	(
+		import from jdbc at ]]..CONNECTION_NAME..[[  
+		statement '
+		SELECT  DatabaseName as table_schema,
+		        TableName as table_name,
+		        ColumnName as column_name,
+		        ColumnPosition as column_position
+		FROM    DBC.IndicesV
+		WHERE 	UniqueFlag = ''Y'' AND IndexType IN (''K'')
+		and 	table_schema not in (''All'', ''Crashdumps'', ''DBC'', ''dbcmngr'', 
+		    	''Default'', ''External_AP'', ''EXTUSER'', ''LockLogShredder'', ''PUBLIC'',
+		    	''Sys_Calendar'', ''SysAdmin'', ''SYSBAR'', ''SYSJDBC'', ''SYSLIB'',
+		    	''SystemFe'', ''SYSUDTLIB'', ''SYSUIF'', ''TD_SERVER_DB'', ''TDStats'',
+		    	''TD_SYSGPL'', ''TD_SYSXML'', ''TDMaps'', ''TDPUSER'', ''TDQCD'',
+		    	''tdwm'', ''SQLJ'', ''TD_SYSFNLIB'', ''SYSSPATIAL'') 
+		and		table_schema like '']]..SCHEMA_FILTER..[['' 
+		and		table_name like '']]..TABLE_FILTER..[['' 
+		'
 	) as primarykeylist
 )
 
-, vv_foreign_keys_raw as (
-	select   ]]..exa_upper_begin..[["ChildDB"]]..exa_upper_end..[[ as "exa_table_schema", 
-		 ]]..exa_upper_begin..[["ChildTable"]]..exa_upper_end..[[ as "exa_table_name", 
-		 ]]..exa_upper_begin..[["ChildKeyColumn"]]..exa_upper_end..[[ as "exa_foreign_key_column",
-		 ]]..exa_upper_begin..[["ParentDB"]]..exa_upper_end..[[ as "exa_referenced_table_schema", 
-		 ]]..exa_upper_begin..[["ParentTable"]]..exa_upper_end..[[ as "exa_referenced_table_name"
-	from (
-			import from jdbc at ]]..CONNECTION_NAME..[[  
-			statement ' 
-			SELECT  ChildDB,
-					ChildTable,
-			        ChildKeyColumn,
-			        ParentDB ,
-			        ParentTable 
-			FROM    DBC.All_RI_ChildrenV
-			WHERE   ChildDB NOT IN (''All'', ''Crashdumps'', ''DBC'', ''dbcmngr'', 
-			    ''Default'', ''External_AP'', ''EXTUSER'', ''LockLogShredder'', ''PUBLIC'',
-			    ''Sys_Calendar'', ''SysAdmin'', ''SYSBAR'', ''SYSJDBC'', ''SYSLIB'',
-			    ''SystemFe'', ''SYSUDTLIB'', ''SYSUIF'', ''TD_SERVER_DB'', ''TDStats'',
-			    ''TD_SYSGPL'', ''TD_SYSXML'', ''TDMaps'', ''TDPUSER'', ''TDQCD'',
-			    ''tdwm'', ''SQLJ'', ''TD_SYSFNLIB'', ''SYSSPATIAL'') and
-			ChildDB like '']]..SCHEMA_FILTER..[['' AND
-			ChildTable like '']]..TABLE_FILTER..[['' 
-			'
+,vv_foreign_keys_raw as (
+	select	]]..exa_upper_begin..[["ChildDB"]]..exa_upper_end..[[ as "exa_table_schema", 
+ 			]]..exa_upper_begin..[["ChildTable"]]..exa_upper_end..[[ as "exa_table_name", 
+ 			]]..exa_upper_begin..[["ChildKeyColumn"]]..exa_upper_end..[[ as "exa_foreign_key_column",
+ 			]]..exa_upper_begin..[["ParentDB"]]..exa_upper_end..[[ as "exa_referenced_table_schema", 
+ 			]]..exa_upper_begin..[["ParentTable"]]..exa_upper_end..[[ as "exa_referenced_table_name"
+	from 	(
+		import from jdbc at ]]..CONNECTION_NAME..[[  
+	    statement ' 
+	    SELECT  ChildDB,
+				ChildTable,
+	        	ChildKeyColumn,
+	        	ParentDB ,
+	        	ParentTable 
+		FROM    DBC.All_RI_ChildrenV
+		WHERE   ChildDB NOT IN (''All'', ''Crashdumps'', ''DBC'', ''dbcmngr'', 
+	    		''Default'', ''External_AP'', ''EXTUSER'', ''LockLogShredder'', ''PUBLIC'',
+	    		''Sys_Calendar'', ''SysAdmin'', ''SYSBAR'', ''SYSJDBC'', ''SYSLIB'',
+	    		''SystemFe'', ''SYSUDTLIB'', ''SYSUIF'', ''TD_SERVER_DB'', ''TDStats'',
+	    		''TD_SYSGPL'', ''TD_SYSXML'', ''TDMaps'', ''TDPUSER'', ''TDQCD'',
+	   			''tdwm'', ''SQLJ'', ''TD_SYSFNLIB'', ''SYSSPATIAL'') 
+		and		ChildDB like '']]..SCHEMA_FILTER..[['' 
+		and		ChildTable like '']]..TABLE_FILTER..[['' 
+		'
 	)
-
+),
+vv_create_schemas as(
+		SELECT	'create schema if not exists "' || "exa_table_schema" || '";' as sql_text 
+		from 	vv_columns  
+		group by "exa_table_schema" 
+		order by "exa_table_schema"
 )
-
-, vv_create_schemas as(
-	SELECT 'create schema if not exists "' || "exa_table_schema" || '";' as sql_text 
-	from vv_columns  
-	group by "exa_table_schema" 
-	order by "exa_table_schema"
-)
-
-, vv_create_tables as (
-	select 'create or replace table "' || "exa_table_schema" || '"."' || "exa_table_name" || '" (' || 
+,vv_create_tables as (
+	select 	'create or replace table "' || "exa_table_schema" || '"."' || "exa_table_name" || '" (' || 
 	group_concat(
 	case 
 	when "data_type" = 'PD' then -- a teradata PERIOD(DATE) is splitted into the beginning and end DATE  
-	       '"' ||  "exa_column_name" || '_BEGINNING " DATE,' ||
-	       '"' ||  "exa_column_name" || '_END" DATE' 
+		'"' ||  "exa_column_name" || '_BEGINNING " DATE,' ||
+		'"' ||  "exa_column_name" || '_END" DATE' 
 	when "data_type" in ('PS', 'PM', 'PT', 'PZ')  then  -- a teradata PERIOD(TIMESTAMP) is splitted into the beginning and end TIMESTAMP  
-	       '"' ||  "exa_column_name" || '_BEGINNING " TIMESTAMP,' ||
-	       '"' ||  "exa_column_name" || '_END" TIMESTAMP'        	       
+		'"' ||  "exa_column_name" || '_BEGINNING " TIMESTAMP,' ||
+		'"' ||  "exa_column_name" || '_END" TIMESTAMP'        	       
 	else
-	       '"' ||  "exa_column_name" || '" ' 
-	end
-	||  
+		'"' ||  "exa_column_name" || '" ' 
+	end ||	        
 	case 
 	when "data_type" = 'PD' then ''  --Period is already splitted into two dates before
 	when "data_type" in ('PS', 'PM', 'PT', 'PZ') then ''  --Period is already splitted into two timestamps before
@@ -237,62 +235,59 @@ with vv_columns as (
 )
 
 , vv_primary_keys as (
-	select 	'ALTER TABLE "' || "exa_table_schema" || '"."' || "exa_table_name" || '" ADD CONSTRAINT PRIMARY KEY (' || 
-			group_concat('"'||  "exa_column_name" || '"'  order by "column_position")  || ') ;' as sql_text
-	from vv_primary_keys_raw   
-	group by "exa_table_schema", "exa_table_name"
-	order by "exa_table_schema","exa_table_name"
-)
+	select 'ALTER TABLE "' || "exa_table_schema" || '"."' || "exa_table_name" || '" ADD CONSTRAINT PRIMARY KEY (' || 
+		group_concat('"'||  "exa_column_name" || '"'  order by "column_position")  || ') ;' as sql_text
+	from           vv_primary_keys_raw   
+		group by       "exa_table_schema", "exa_table_name"
+		order by       "exa_table_schema","exa_table_name"
 
-, vv_foreign_keys as (
-	select 'ALTER TABLE "' || "exa_table_schema" || '"."' || "exa_table_name" ||
-	 '" ADD FOREIGN KEY (' || '"'||  "exa_foreign_key_column" || '") REFERENCES "' || "exa_referenced_table_schema" || '"."' || "exa_referenced_table_name" || '" DISABLE ;' as sql_text
-	from vv_foreign_keys_raw   
-	order by "exa_table_schema","exa_table_name"
-)
+), vv_foreign_keys as (
 
+select 'ALTER TABLE "' || "exa_table_schema" || '"."' || "exa_table_name" ||
+ '" ADD FOREIGN KEY (' || '"'||  "exa_foreign_key_column" || '") REFERENCES "' || "exa_referenced_table_schema" || '"."' || "exa_referenced_table_name" || '" DISABLE ;' as sql_text
+from vv_foreign_keys_raw   
+order by "exa_table_schema","exa_table_name"
+
+)
 , vv_imports as (
-	select 	'import into "' || "exa_table_schema" || '"."' || "exa_table_name" || '" from jdbc at ]]..CONNECTION_NAME..[[ statement ''select ' || 
-			group_concat( 
-				case 
-				when "data_type" = 'DA' then "column_name_delimited"
-				when "data_type" = 'D'  then "column_name_delimited"
-				when "data_type" = 'TS' then "column_name_delimited"
-				when "data_type" = 'CF' then "column_name_delimited"
-				when "data_type" = 'I1' then "column_name_delimited"
-				when "data_type" = 'I2' then "column_name_delimited"
-				when "data_type" = 'I8' then "column_name_delimited"
-				when "data_type" = 'AT' then "column_name_delimited"
-				when "data_type" = 'F'  then "column_name_delimited"
-				when "data_type" = 'CV' then "column_name_delimited"
-				when "data_type" = 'I'  then "column_name_delimited"
-				when "data_type" = 'N'  then "column_name_delimited"
-				when "data_type" in ('A1','AN')  then 'cast(' || "column_name_delimited" || ' as varchar(64000)) '  --array datatypes are casted to a varchar in Teradata
-				when "data_type" in ('BF', 'BO', 'BV') then '''''NOT SUPPORTED''''' --binary data types (BYTE, VARBYTE, BLOB) are not supported
-				when "data_type" = 'JN'  then 'CAST(' || "column_name_delimited" ||  ' AS CLOB ) ' --json (max length in Exasol is 2000000 as it is stored as varchar)  
-				when "data_type" = 'PD'  then  'BEGIN('|| "column_name_delimited" || ') , END(' ||  "column_name_delimited" || ')'  --Period(Date) split into begin and end date
-				when "data_type" in ('PS', 'PM')  then  'CAST(  BEGIN('|| "column_name_delimited" || ') AS TIMESTAMP ) , CAST ( END(' ||  "column_name_delimited" || ') AS TIMESTAMP ) '  --Period(Timestamp) split into begin and end timestamp  
-				when "data_type" in ('PT', 'PZ')  then  'CAST(  BEGIN('|| "column_name_delimited" || ') AS TIME ) , CAST ( END(' ||  "column_name_delimited" || ') AS TIME ) '  --Period(Time) split into begin and end time	
-				when "data_type" = 'TZ' then  'cast(' || "column_name_delimited" || ' AS TIME)'  --time with time zone
-				when "data_type" = 'SZ' then  'cast(' || "column_name_delimited" || ' AS TIMESTAMP)'  --timestamp with time zone
-				when "data_type" = 'YR'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL YEAR  TO MONTH ) AS VARCHAR(50))'  --Interval Year
-				when "data_type" = 'YM'  then 'cast('|| "column_name_delimited" || ' AS VARCHAR(50) )'  --Interval Year to Month
-				when "data_type" = 'MO'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL YEAR  TO MONTH ) AS VARCHAR(50))'  --Interval Month
-				when "data_type" = 'DY'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) ' --Interval Day
-				when "data_type" = 'DH'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Day to hour
-				when "data_type" = 'DM'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Day to minute
-				when "data_type" = 'DS'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval day to second
-				when "data_type" = 'HR'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Hour
-				when "data_type" = 'HM'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Day to minute
-				when "data_type" = 'HS'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval day to second
-				when "data_type" = 'MI'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) ' --Interval Minute
-				when "data_type" = 'MS'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval minute to second
-				when "data_type" = 'SC'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval Second
-				else "column_name_delimited"
-				end
-				order by "ordinal_position"
-			) || 
-			' from ' || "table_schema"|| '.' || "table_name"|| ''';' as sql_text
+	select 'import into "' || "exa_table_schema" || '"."' || "exa_table_name" || '" from jdbc at ]]..CONNECTION_NAME..[[ statement ''select ' || group_concat( 
+	case 
+	when "data_type" = 'DA' then "column_name_delimited"
+	when "data_type" = 'D'  then "column_name_delimited"
+	when "data_type" = 'TS' then "column_name_delimited"
+	when "data_type" = 'CF' then "column_name_delimited"
+	when "data_type" = 'I1' then "column_name_delimited"
+	when "data_type" = 'I2' then "column_name_delimited"
+	when "data_type" = 'I8' then "column_name_delimited"
+	when "data_type" = 'AT' then "column_name_delimited"
+	when "data_type" = 'F'  then "column_name_delimited"
+	when "data_type" = 'CV' then "column_name_delimited"
+	when "data_type" = 'I'  then "column_name_delimited"
+	when "data_type" = 'N'  then "column_name_delimited"
+	when "data_type" in ('A1','AN')  then 'cast(' || "column_name_delimited" || ' as varchar(64000)) '  --array datatypes are casted to a varchar in Teradata
+	when "data_type" in ('BF', 'BO', 'BV') then '''''NOT SUPPORTED''''' --binary data types (BYTE, VARBYTE, BLOB) are not supported
+	when "data_type" = 'JN'  then 'CAST(' || "column_name_delimited" ||  ' AS CLOB ) ' --json (max length in Exasol is 2000000 as it is stored as varchar)  
+	when "data_type" = 'PD'  then  'BEGIN('|| "column_name_delimited" || ') , END(' ||  "column_name_delimited" || ')'  --Period(Date) split into begin and end date
+	when "data_type" in ('PS', 'PM')  then  'CAST(  BEGIN('|| "column_name_delimited" || ') AS TIMESTAMP ) , CAST ( END(' ||  "column_name_delimited" || ') AS TIMESTAMP ) '  --Period(Timestamp) split into begin and end timestamp  
+	when "data_type" in ('PT', 'PZ')  then  'CAST(  BEGIN('|| "column_name_delimited" || ') AS TIME ) , CAST ( END(' ||  "column_name_delimited" || ') AS TIME ) '  --Period(Time) split into begin and end time	
+	when "data_type" = 'TZ' then  'cast(' || "column_name_delimited" || ' AS TIME)'  --time with time zone
+	when "data_type" = 'SZ' then  'cast(' || "column_name_delimited" || ' AS TIMESTAMP)'  --timestamp with time zone
+	when "data_type" = 'YR'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL YEAR  TO MONTH ) AS VARCHAR(50))'  --Interval Year
+	when "data_type" = 'YM'  then 'cast('|| "column_name_delimited" || ' AS VARCHAR(50) )'  --Interval Year to Month
+	when "data_type" = 'MO'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL YEAR  TO MONTH ) AS VARCHAR(50))'  --Interval Month
+	when "data_type" = 'DY'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) ' --Interval Day
+	when "data_type" = 'DH'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Day to hour
+	when "data_type" = 'DM'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Day to minute
+	when "data_type" = 'DS'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval day to second
+	when "data_type" = 'HR'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Hour
+	when "data_type" = 'HM'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) '  --Interval Day to minute
+	when "data_type" = 'HS'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval day to second
+	when "data_type" = 'MI'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND) AS VARCHAR(50)) ' --Interval Minute
+	when "data_type" = 'MS'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval minute to second
+	when "data_type" = 'SC'  then 'cast(cast('|| "column_name_delimited" || ' AS INTERVAL DAY (4)  TO SECOND (' || "numeric_scale" || ')) AS VARCHAR(50)) '  --Interval Second
+	else "column_name_delimited"
+	end
+	order by "ordinal_position") || ' from ' || "table_schema"|| '.' || "table_name"|| ''';' as sql_text
 	from vv_columns 
 	group by "exa_table_schema","exa_table_name", "table_schema","table_name"
 	order by "exa_table_schema","exa_table_name", "table_schema","table_name"
@@ -455,6 +450,7 @@ with vv_columns as (
 	                		end
 	                when "metric_id" = 1 then 'not checked ''' || c."exa_column_name" || ''''
 	        end		"metric_column_name"
+	        
 	from vv_columns c 
 	left join vv_primary_keys_raw p
 	on c."exa_table_schema" = p."exa_table_schema"
@@ -479,6 +475,7 @@ with vv_columns as (
                         case when "db_system" = 'Exasol' then '"' || "exa_table_schema" || '"."' || "exa_table_name" || '"' else '"' || "table_schema" || '"."' || "table_name" || '"' end ||
                         case when "db_system" = 'Teradata' then ''') ' end 
                         as "check_sql"
+                
                 from vv_checks_expr
                 group by "db_system", "exa_table_schema", "exa_table_name", "table_schema", "table_name", "metric_table"
         )
@@ -486,31 +483,36 @@ with vv_columns as (
         order by "exa_table_schema", "metric_table"
 )
 
+
+
+
 , vv_check_summary as (       
-        select  'create or replace table database_migration.migration_check (schema_name varchar(128), table_name varchar(128), column_name varchar(128), exasol_metric varchar(50), teradata_metric varchar(50), check_timestamp timestamp default current_timestamp);' as sql_text
+        select  'create or replace table "' || "metric_schema" || '"."' || "exa_table_schema" || '_MIG_CHK" (schema_name varchar(128), table_name varchar(128), column_name varchar(128), metric_schema varchar(128), metric_table varchar(128),  metric_name varchar(128), exasol_metric varchar(50), teradata_metric varchar(50), check_timestamp timestamp default current_timestamp);' as sql_text
+        from vv_checks_expr
+        group by "metric_schema", "exa_table_schema"
         union all
-        select  'insert into "DATABASE_MIGRATION"."MIGRATION_CHECK" (schema_name, table_name, column_name, exasol_metric, teradata_metric) ' /*|| chr(10)*/
-                || listagg(sql_text, '') within group(order by case when db_name = 'Exasol' then 1 else 2 end) || ' ' /*|| chr(10)*/ 
-                || 'select e.schema_name, e.table_name, e.column_name, e.exasol_metric, t.teradata_metric from exasol e join teradata t on e.schema_name = t.schema_name and e.table_name = t.table_name and e.column_name = t.column_name; ' as sql_text
+        select  'insert into "' || "metric_schema" || '"."' || "exa_table_schema" || '_MIG_CHK" (schema_name, table_name, column_name, metric_schema, metric_table, metric_name, exasol_metric, teradata_metric) ' 
+                || listagg(sql_text, '') within group(order by case when "db_system" = 'Exasol' then 1 else 2 end) || ' '
+                || 'select e.schema_name, e.table_name, e.column_name, e.metric_schema, e.metric_table, e.metric_name, e.exasol_metric, t.teradata_metric from exasol e join teradata t on e.schema_name = t.schema_name and e.table_name = t.table_name and e.column_name = t.column_name; ' as sql_text
         from (
         
-                select  db_name, column_schema, column_table,
-                        case when db_name = 'Exasol' then 'with ' else ', ' end || db_name || ' as ( ' /*|| chr(10)*/
-                        || listagg(case when column_name != 'DB_SYSTEM' then 'select ''' || column_schema || ''' as schema_name, ''' || column_table || ''' as table_name, ''' || column_name || ''' as column_name, to_char("' || column_name || '") as ' || db_name || '_metric from "' || column_schema || '"."' || column_table || '" where DB_SYSTEM = ''' || db_name || '''' end, ' union all ' /* || chr(10)*/)
-                        /*|| chr(10)*/
+                select  "db_system", "exa_table_schema", "exa_table_name", "metric_schema",
+                        case when "db_system" = 'Exasol' then 'with ' else ', ' end || "db_system" || ' as ( '
+                        || listagg(
+                        	'select ''' || "exa_table_schema" || ''' as schema_name, ''' || "exa_table_name" || ''' as table_name,  ''' || "exa_column_name" || ''' column_name, ''' || "metric_schema" || ''' metric_schema, ''' || "metric_table" || ''' metric_table, ''' || "metric_column_name" || ''' as metric_name, to_char(' || "metric_column_name" || ') as ' || "db_system" || '_metric from "' || "exa_table_schema" || '"."' || "metric_table" || '" where DB_SYSTEM = ''' || "db_system" || '''', ' union all ')
                         || ' )'  as sql_text
-                from exa_all_columns, (select 'Exasol' db_name union all select 'Teradata' db_name), (select distinct "exa_table_schema", "exa_table_name" from vv_columns)
-                where column_schema = "exa_table_schema"
-                and column_table = "exa_table_name" || '_MIG_CHK'
-                group by db_name, column_schema, column_table
-                order by case when db_name = 'Exasol' then 1 else 2 end
+                from vv_checks_expr
+                group by "db_system", "exa_table_schema", "exa_table_name", "metric_schema", "metric_table"
+                order by case when "db_system" = 'Exasol' then 1 else 2 end
         
         )
-        group by column_schema, column_table
+        group by "exa_table_schema", "exa_table_name", "metric_schema"
         union all
-        select 'select * from database_migration.migration_check where exasol_metric != teradata_metric;' as sql_text
-        from dual
+        select  '--select * from "' || "metric_schema" || '"."' || "exa_table_schema" || '_MIG_CHK" where exasol_metric != teradata_metric;' as sql_text
+        from vv_checks_expr
+        group by "metric_schema", "exa_table_schema"
 )
+
 
 select * from vv_create_schemas
 UNION ALL
@@ -526,6 +528,8 @@ select * from vv_primary_keys
 UNION ALL
 select * from vv_foreign_keys
 ]],{})
+
+--output(res.statement_text)
 return(res)
 /
 ;
@@ -534,7 +538,7 @@ return(res)
 
 -- Create a connection to the Teradata database
 create or replace connection teradata_db to 'jdbc:teradata://192.168.56.103/CHARSET=UTF16' user 'dbc' identified by 'dbc';
--- Depending on your Teradata installation, CHARSET=UTF16 instead of CHARSET=UTF8 could be the better choice - otherwise you get errors like this one:
+-- Depending on your Teradata installation, CHARSET=UTF16  instead of CHARSET=UTF8 could be the better choice - otherwise you get errors like this one:
 -- [42636] ETL-3003: [Column=5 Row=0] [String data right truncation. String length exceeds limit of 2 characters] (Session: 1611884537138472475)
 -- In that case, configure your connection like this:
 -- create connection teradata_db to 'jdbc:teradata://some.teradata.host.internal/CHARSET=UTF16' user 'db_username' identified by 'exasolRocks!';
@@ -552,5 +556,6 @@ execute script database_migration.TERADATA_TO_EXASOL(
     ,'RETAIL_2020'	-- schema filter --> '%' to load all schemas except 'DBC' / '%pub%' to load all schemas like '%pub%'
     ,'%'			--'DimCustomer' -- table filter --> '%' to load all tables
     ,true			-- boolean flag to create checking tables
-)
+) 
+--with output
 ;

--- a/teradata_to_exasol.sql
+++ b/teradata_to_exasol.sql
@@ -3,11 +3,8 @@ create schema if not exists database_migration;
 /* 
      This script will generate create schema, create table and create import statements 
      to load all needed data from a teradata database. Automatic datatype conversion is 
-     applied whenever needed. Additionally the migration can be checked via generic metrics. 
-     For that a checking table will be created and loaded for each individual table being migrated. 
-     The checking table will be created in the same schema with the same name adding '_MIG_CHK' as a suffix. 
-     A summary table for all the checking tables of a specific schema will be created in the database migration schema with the name of the migrated schema adding '_MIG_CHK' as a suffix.
-     Querying the summary tables will help you to identify deviations easily.
+     applied whenever needed. Additionally the migration can be checked via generic 
+     standardized metrics to identify deviations between the data in Teradata and Exasol. 
      Feel free to adjust it. 
 */
 
@@ -561,6 +558,9 @@ execute script database_migration.TERADATA_TO_EXASOL(
     ,'%'			-- schema filter --> '%' to load all schemas (except system schemas). Examples: 'CORE' (to migrate the 'CORE' schema), 'MART_%' (to migrate all schemas whose name starts with 'MART_')
     ,'%'			-- table filter --> '%' to load all tables in the schemas considered. Examples: 'H_EMPLOYEE' (to migrate all the tables whose name is 'H_EMPLOYEE'), 'H_%' (to migrate all tables whose name starts with 'H_') 
     ,false			-- boolean flag to create checking tables. TRUE -> create/load checking tables / FALSE -> do not create/load checking tables. -> default = FALSE. 
+    				-- When the option is used, a checking table will be created and loaded for each individual table being migrated. 
+    				-- The checking table will be created in the same schema with the same name adding '_MIG_CHK' as a suffix. 
+    				-- A summary table for all the checking tables of a specific schema will be created in the database migration schema with the name of the migrated schema adding '_MIG_CHK' as a suffix.
 ) 
 --with output
 ;

--- a/teradata_to_exasol.sql
+++ b/teradata_to_exasol.sql
@@ -533,7 +533,7 @@ return(res)
 
 -- Create a connection to the Teradata database
 create or replace connection teradata_db to 'jdbc:teradata://192.168.56.103/CHARSET=UTF16' user 'dbc' identified by 'dbc';
--- Depending on your Teradata installation, CHARSET=UTF16 could be the better choice - otherwise you get errors like this one:
+-- Depending on your Teradata installation, CHARSET=UTF16 instead of CHARSET=UTF8 could be the better choice - otherwise you get errors like this one:
 -- [42636] ETL-3003: [Column=5 Row=0] [String data right truncation. String length exceeds limit of 2 characters] (Session: 1611884537138472475)
 -- In that case, configure your connection like this:
 -- create connection teradata_db to 'jdbc:teradata://some.teradata.host.internal/CHARSET=UTF16' user 'db_username' identified by 'exasolRocks!';

--- a/teradata_to_exasol.sql
+++ b/teradata_to_exasol.sql
@@ -405,32 +405,6 @@ order by "exa_table_schema","exa_table_name"
         group by "exa_table_schema", "exa_table_name"
         order by "exa_table_schema", "exa_table_name"
 )
-, vv_check_summary as (       
-        select  'create or replace table database_migration.migration_check (schema_name varchar(128), table_name varchar(128), column_name varchar(128), exasol_metric varchar(50), teradata_metric varchar(50), check_timestamp timestamp default current_timestamp);' as sql_text
-        union all
-        select  'insert into "DATABASE_MIGRATION"."MIGRATION_CHECK" (schema_name, table_name, column_name, exasol_metric, teradata_metric) ' /*|| chr(10)*/
-                || listagg(sql_text, '') within group(order by case when db_name = 'Exasol' then 1 else 2 end) || ' ' /*|| chr(10)*/ 
-                || 'select e.schema_name, e.table_name, e.column_name, e.exasol_metric, t.teradata_metric from exasol e join teradata t on e.schema_name = t.schema_name and e.table_name = t.table_name and e.column_name = t.column_name; ' as sql_text
-        from (
-        
-                select  db_name, column_schema, column_table,
-                        case when db_name = 'Exasol' then 'with ' else ', ' end || db_name || ' as ( ' /*|| chr(10)*/
-                        || listagg(case when column_name != 'DB_SYSTEM' then 'select ''' || column_schema || ''' as schema_name, ''' || column_table || ''' as table_name, ''' || column_name || ''' as column_name, to_char("' || column_name || '") as ' || db_name || '_metric from "' || column_schema || '"."' || column_table || '" where DB_SYSTEM = ''' || db_name || '''' end, ' union all ' /* || chr(10)*/)
-                        /*|| chr(10)*/
-                        || ' )'  as sql_text
-                from exa_all_columns, (select 'Exasol' db_name union all select 'Teradata' db_name), (select distinct "exa_table_schema", "exa_table_name" from vv_columns)
-                where column_schema = "exa_table_schema"
-                and column_table = "exa_table_name" || '_MIG_CHK'
-                group by db_name, column_schema, column_table
-                order by case when db_name = 'Exasol' then 1 else 2 end
-        
-        )
-        group by column_schema, column_table
-        union all
-        select 'select * from database_migration.migration_check where exasol_metric != teradata_metric;' as sql_text
-        from dual
-)
-
 
 select * from vv_create_schemas
 UNION ALL
@@ -439,8 +413,6 @@ UNION ALL
 select * from vv_imports
 UNION ALL
 select * from vv_checks
-UNION ALL
-select * from vv_check_summary
 UNION ALL
 select * from vv_primary_keys
 UNION ALL

--- a/teradata_to_exasol.sql
+++ b/teradata_to_exasol.sql
@@ -511,6 +511,7 @@ with vv_columns as (
         select 'select * from database_migration.migration_check where exasol_metric != teradata_metric;' as sql_text
         from dual
 )
+
 select * from vv_create_schemas
 UNION ALL
 select * from vv_create_tables

--- a/teradata_to_exasol.sql
+++ b/teradata_to_exasol.sql
@@ -555,8 +555,6 @@ select * from vv_primary_keys
 UNION ALL
 select * from vv_foreign_keys
 ]],{})
-
---output(res.statement_text)
 return(res)
 /
 ;
@@ -583,6 +581,5 @@ execute script database_migration.TERADATA_TO_EXASOL(
     ,'RETAIL_2020'	-- schema filter --> '%' to load all schemas except 'DBC' / '%pub%' to load all schemas like '%pub%'
     ,'%'			--'DimCustomer' -- table filter --> '%' to load all tables
     ,true			-- boolean flag to create checking tables
-) 
---with output
+)
 ;

--- a/teradata_to_exasol.sql
+++ b/teradata_to_exasol.sql
@@ -490,7 +490,7 @@ order by "exa_table_schema","exa_table_name"
     union all
     select 2 ord2, 'insert into "' || "metric_schema" || '"."' || "exa_table_schema" || '_MIG_CHK" (schema_name, table_name, column_name, metric_schema, metric_table, metric_name, exasol_metric, teradata_metric) ' 
             || listagg(sql_text, '') within group(order by case when "db_system" = 'Exasol' then 1 else 2 end) || ' '
-            || 'select e.schema_name, e.table_name, e.column_name, e.metric_schema, e.metric_table, e.metric_name, e.exasol_metric, t.teradata_metric from exasol e join teradata t on e.schema_name = t.schema_name and e.table_name = t.table_name and e.column_name = t.column_name; ' as sql_text
+            || 'select e.schema_name, e.table_name, e.column_name, e.metric_schema, e.metric_table, e.metric_name, e.exasol_metric, t.teradata_metric from exasol e join teradata t on e.schema_name = t.schema_name and e.table_name = t.table_name and e.metric_name = t.metric_name; ' as sql_text
     from (
     
             select  "db_system", "exa_table_schema", "exa_table_name", "metric_schema",
@@ -554,7 +554,7 @@ execute script database_migration.TERADATA_TO_EXASOL(
     ,true        	-- case sensitivity handling for identifiers -> false: handle them case sensitiv / true: handle them case insensitiv --> recommended: true
     ,'RETAIL_2020'	-- schema filter --> '%' to load all schemas except 'DBC' / '%pub%' to load all schemas like '%pub%'
     ,'%'			--'DimCustomer' -- table filter --> '%' to load all tables
-    ,false			-- boolean flag to create checking tables
+    ,true			-- boolean flag to create checking tables
 ) 
 --with output
 ;

--- a/teradata_to_exasol.sql
+++ b/teradata_to_exasol.sql
@@ -3,8 +3,11 @@ create schema if not exists database_migration;
 /* 
      This script will generate create schema, create table and create import statements 
      to load all needed data from a teradata database. Automatic datatype conversion is 
-     applied whenever needed. Additionally the migration can be checked via generic 
-     standardized metrics to identify deviations between the data in Teradata and Exasol. 
+     applied whenever needed. Additionally the migration can be checked via generic metrics. 
+     For that a checking table will be created and loaded for each individual table being migrated. 
+     The checking table will be created in the same schema with the same name adding '_MIG_CHK' as a suffix. 
+     A summary table for all the checking tables of a specific schema will be created in the database migration schema with the name of the migrated schema adding '_MIG_CHK' as a suffix.
+     Querying the summary tables will help you to identify deviations easily.
      Feel free to adjust it. 
 */
 
@@ -558,9 +561,6 @@ execute script database_migration.TERADATA_TO_EXASOL(
     ,'%'			-- schema filter --> '%' to load all schemas (except system schemas). Examples: 'CORE' (to migrate the 'CORE' schema), 'MART_%' (to migrate all schemas whose name starts with 'MART_')
     ,'%'			-- table filter --> '%' to load all tables in the schemas considered. Examples: 'H_EMPLOYEE' (to migrate all the tables whose name is 'H_EMPLOYEE'), 'H_%' (to migrate all tables whose name starts with 'H_') 
     ,false			-- boolean flag to create checking tables. TRUE -> create/load checking tables / FALSE -> do not create/load checking tables. -> default = FALSE. 
-    				-- When the option is used, a checking table will be created and loaded for each individual table being migrated. 
-    				-- The checking table will be created in the same schema with the same name adding '_MIG_CHK' as a suffix. 
-    				-- A summary table for all the checking tables of a specific schema will be created in the database migration schema with the name of the migrated schema adding '_MIG_CHK' as a suffix.
 ) 
 --with output
 ;


### PR DESCRIPTION
Update of the oracle_to_exasol.sql database migration script.
The update contains script parameters that control the generation of primary and foreign keys, degree of parallelism for the data migration, checking tables for migration testing and some other improvements.

The option for parallel statements defines the degree of parallelism for the import statements. If a table is partitioned, the number of rows per partition will be determined to distribute the partitions across the parallel statements evenly. If the table does not have partitions, the ora_hash function on the row_id will be used to assign the rows to one of the parallel statements.

The script options for primary / foreign keys control the code being generated. The statements will be generated anyway. When the option is not set (FALSE) the statements will be commented out.

The script also offers the option to create checking tables. These tables are generated for every table in the scope. They will be created in the migrated schema. The name of the checking tables are the same as the orginal ones with the suffix "_MIG_CHK".
A summary table is created in the DATABASE_MIGRATION schema of the script with the name of the schema and the suffix "_MIG_CHK", allowing to query all metrics for all tables of the scope easily to confirm a complete, correct and successful migration.