### PR TITLE
Update mysql_to_exasol.sql

### DIFF
--- a/post_load_optimization/set_primary_keys.sql
+++ b/post_load_optimization/set_primary_keys.sql
@@ -166,6 +166,7 @@ function getForeignKeyInformationFromForeignDb(connection_type, connection_name,
 		JOIN information_schema.columns c ON (c.table_schema = cu.table_schema and c.table_name = cu.table_name and c.column_name = cu.column_name) 
 		WHERE cu.table_schema like '']]..schema_name..[[''
 		AND cu.table_name like '']]..table_name..[[''
+        AND cu.REFERENCED_TABLE_NAME is not null -- to prevent the evalauation of unique constraints
 		GROUP BY cu.Constraint_name, cu.table_schema, cu.table_name, cu.REFERENCED_TABLE_SCHEMA, cu.REFERENCED_TABLE_NAME
 		HAVING max(c.column_key) = ''MUL'';
 		]]


### PR DESCRIPTION
### mysql_to_exasol.sql
The current implementation supports the creation of tables in Exasol without support of NOT NULL constraints and without support of DEFAULT values for certain table columns.
These two parts have been integrated into the existing workflow. That means the corresponding Exasol tables to be created inherit now also NOT NULL constraints from their counterparts in MYSQL and also defined DEFAULT values defined on the MySQL side will be applied during the table creation in Exasol.

### set_primary_keys.sql
The current implementation for MySQL handles unique constraints defined on a table in MySQL also as a foreign key, which leads to wrong foreign key constraints to be applied on the corresponding Exasol table.