### PR TITLE
Update exasol_to_exasol.sql

### DIFF
--- a/exasol_to_exasol.sql
+++ b/exasol_to_exasol.sql
@@ -134,7 +134,7 @@ union all
 select 12, f.* from vv_imports f
 union all
 select 13, cast('-- ### VIEWS - Add FORCE as needed to avoid ordering dependencies ###' as varchar(2000000)) SQL_TEXT
-from dual where ]]..GENERATE_VIEWS..[[ -- the whitespace at the end is important and must no be removed
+from dual where ]]..GENERATE_VIEWS..[[ -- the whitespace at the end is important and must not be removed
 union all
 select 14, g.* from vv_create_views g
 ) order by ord

--- a/exasol_to_exasol.sql
+++ b/exasol_to_exasol.sql
@@ -134,7 +134,7 @@ union all
 select 12, f.* from vv_imports f
 union all
 select 13, cast('-- ### VIEWS - Add FORCE as needed to avoid ordering dependencies ###' as varchar(2000000)) SQL_TEXT
-from dual where ]]..GENERATE_VIEWS..[[ 
+from dual where ]]..GENERATE_VIEWS..[[ -- the whitespace at the end is important and must no be removed
 union all
 select 14, g.* from vv_create_views g
 ) order by ord


### PR DESCRIPTION
Line 137 caused problems when importing the script to Datagrip because it removed the whitespace at the end which is important for a successful execution.