### PR TITLE
Add MIGRATE_TO_EXASOL master wrapper + adapter hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@
 
 ## Table of Contents
 1. [Overview](#overview)
-2. [Migration source:](#migration-source)
+2. [Unified migration entry point](#unified-migration-entry-point)
+3. [Migration source:](#migration-source)
     * [Azure Sql](#azure-sql)
     * [CSV](#csv)
+    * [Databricks](#databricks)
     * [DB2](#db2)
     * [Exasol](#exasol)
     * [Google BigQuery](#google-bigquery)
@@ -25,8 +27,8 @@
     * [Vectorwise](#vectorwise)
     * [Vertica](#vertica)
     
-3. [Post-load optimization](#post-load-optimization)
-4. [Delta import](#delta-import)
+4. [Post-load optimization](#post-load-optimization)
+5. [Delta import](#delta-import)
 
 
 ## Overview
@@ -37,6 +39,39 @@ You'll find SQL scripts which you can execute on Exasol to load data from certai
 database management systems. The scripts try to extract the meta data from the source system and create the appropriate IMPORT statements automatically so that you don't have to care about table names, column names and types.
 
 If you want to optimize existing scripts or create new scripts for additional systems, we would be very glad if you share your work with the Exasol user community.
+
+## Unified migration entry point
+
+The script [migrate_to_exasol.sql](migrate_to_exasol.sql) provides one standardized execute interface for the source-specific migration scripts. It dispatches to the existing scripts, so the matching source script still needs to be installed in `DATABASE_MIGRATION`.
+
+```sql
+EXECUTE SCRIPT DATABASE_MIGRATION.MIGRATE_TO_EXASOL(
+    'SNOWFLAKE',                 -- SOURCE_TYPE
+    'SNOWFLAKE_CONNECTION',      -- CONNECTION_NAME
+    'JDBC',                      -- CONNECTION_TYPE
+    '%',                         -- DB_FILTER
+    '%',                         -- SCHEMA_FILTER
+    '%',                         -- TABLE_FILTER
+    NULL,                        -- TARGET_SCHEMA
+    TRUE,                        -- IDENTIFIER_CASE_INSENSITIVE
+    TRUE,                        -- DEBUG: TRUE previews, FALSE executes
+    'DB2SCHEMA=true'             -- OPTIONS
+);
+```
+
+Common parameters:
+- `SOURCE_TYPE`: `MYSQL`, `MARIADB`, `POSTGRES`, `REDSHIFT`, `DB2`, `VERTICA`, `HANA`, `AZURE_SQL`, `BIGQUERY`, `DATABRICKS`, `SQLSERVER`, `SNOWFLAKE`, `ORACLE`, `TERADATA`, `EXASOL`, `NETEZZA`, or `VECTORWISE`.
+- `DEBUG`: `TRUE` returns generated SQL. `FALSE` executes generated SQL and returns status rows.
+- `OPTIONS`: source-specific `KEY=VALUE` pairs separated by semicolons.
+
+Useful `OPTIONS` keys:
+- `PROJECT_ID`: required for `BIGQUERY` unless `DB_FILTER` contains the project ID.
+- `CATALOG2SCHEMA`: `true` or `false` for `DATABRICKS`.
+- `DB2SCHEMA`: `true` or `false` for `SNOWFLAKE` and `SQLSERVER`.
+- `PARALLEL_STATEMENTS`, `CREATE_PK`, `CREATE_FK`, `CHECK_MIGRATION`: Oracle/Teradata options.
+- `GENERATE_VIEWS`, `VIEW_FILTER`, `PK_SETTING`: Exasol-to-Exasol options.
+
+The S3 parallel loader keeps its direct script interface because it uses a different parameter shape.
 
 ## Migration source
 
@@ -111,6 +146,37 @@ FROM   (
 For the actual data-migration, see script [bigquery_to_exasol.sql](bigquery_to_exasol.sql)
 
 Note: Due to the lack of an alternative datatype, the following Google BigQuery datatypes; `DATE`,`DATETIME`,`TIMESTAMP` and `ARRAY` are stored as VARCHAR. 
+
+### Databricks
+
+To connect Exasol to Databricks, configure the Databricks JDBC driver in Exasol with the driver name `DATABRICKS`, then create a connection for your Databricks SQL warehouse. The JDBC URL requires your server hostname and HTTP path. See the [Databricks JDBC driver documentation](https://docs.databricks.com/aws/en/integrations/jdbc-oss/configure) for current connection details.
+
+Example connection:
+
+```sql
+CREATE OR REPLACE CONNECTION DATABRICKS_CONNECTION TO
+  'jdbc:databricks://<server-hostname>:443/default;httpPath=<http-path>;AuthMech=3;UseNativeQuery=1'
+  USER 'token'
+  IDENTIFIED BY '<personal-access-token>';
+```
+
+Create the script [databricks_to_exasol.sql](databricks_to_exasol.sql), then generate migration SQL:
+
+```sql
+EXECUTE SCRIPT DATABASE_MIGRATION.DATABRICKS_TO_EXASOL(
+    'DATABRICKS_CONNECTION', -- CONNECTION_NAME
+    TRUE,                    -- CATALOG2SCHEMA: catalog.schema.table -> catalog.schema_table
+    '%',                     -- CATALOG_FILTER
+    '%',                     -- SCHEMA_FILTER
+    NULL,                    -- TARGET_SCHEMA
+    '%',                     -- TABLE_FILTER
+    TRUE                     -- IDENTIFIER_CASE_INSENSITIVE
+);
+```
+
+The script uses Databricks `INFORMATION_SCHEMA` metadata to generate `CREATE SCHEMA`, `CREATE TABLE`, and `IMPORT FROM JDBC DRIVER = 'DATABRICKS'` statements for managed and external tables. `CATALOG2SCHEMA` helps avoid name collisions when multiple Databricks catalogs contain the same schema and table names.
+
+S3 loading is intentionally not part of this adapter. Use [s3_to_exasol.sql](s3_to_exasol.sql) for S3 parallel loading.
 
 
 ### MariaDB

--- a/README.md
+++ b/README.md
@@ -61,8 +61,20 @@ EXECUTE SCRIPT DATABASE_MIGRATION.MIGRATE_TO_EXASOL(
 
 Common parameters:
 - `SOURCE_TYPE`: `MYSQL`, `MARIADB`, `POSTGRES`, `REDSHIFT`, `DB2`, `VERTICA`, `HANA`, `AZURE_SQL`, `BIGQUERY`, `DATABRICKS`, `SQLSERVER`, `SNOWFLAKE`, `ORACLE`, `TERADATA`, `EXASOL`, `NETEZZA`, or `VECTORWISE`.
-- `DEBUG`: `TRUE` returns generated SQL. `FALSE` executes generated SQL and returns status rows.
+- `DEBUG`: `TRUE` returns generated SQL with `RESULT_FLAG = PREVIEW`. `FALSE` executes generated SQL and returns one row per statement plus a trailing `SUMMARY` row.
 - `OPTIONS`: source-specific `KEY=VALUE` pairs separated by semicolons.
+
+The script returns a 7-column audit table:
+
+| Column | Type | Meaning |
+|---|---|---|
+| `STEP_KIND` | `VARCHAR(40)` | `CREATE_SCHEMA`, `CREATE_TABLE`, `ALTER_TABLE`, `IMPORT`, `INFO`, `OTHER`, or `SUMMARY` |
+| `TARGET_OBJ` | `VARCHAR(2000)` | `"SCHEMA"."TABLE"` for table-level steps; schema name for `CREATE_SCHEMA`; `NULL` for `INFO`; rollup text for `SUMMARY` |
+| `ROWS_AFFECTED` | `DECIMAL(18,0)` | rows imported per `IMPORT`; total in `SUMMARY` |
+| `ELAPSED_MS` | `DECIMAL(18,0)` | wall-clock ms per executed statement; total in `SUMMARY` |
+| `RESULT_FLAG` | `VARCHAR(20)` | `PREVIEW`, `OK`, `ERROR`, or `SKIPPED` |
+| `SQL_TEXT` | `VARCHAR(2000000)` | the generated/executed statement (or comment); `NULL` on `SUMMARY` |
+| `ERROR_MESSAGE` | `VARCHAR(20000)` | Exasol error text when `RESULT_FLAG = ERROR` |
 
 Useful `OPTIONS` keys:
 - `PROJECT_ID`: required for `BIGQUERY` unless `DB_FILTER` contains the project ID.
@@ -71,7 +83,7 @@ Useful `OPTIONS` keys:
 - `PARALLEL_STATEMENTS`, `CREATE_PK`, `CREATE_FK`, `CHECK_MIGRATION`: Oracle/Teradata options.
 - `GENERATE_VIEWS`, `VIEW_FILTER`, `PK_SETTING`: Exasol-to-Exasol options.
 
-The S3 parallel loader keeps its direct script interface because it uses a different parameter shape.
+The S3 parallel loader keeps its direct script interface because it uses a different parameter shape; calling `MIGRATE_TO_EXASOL` with `SOURCE_TYPE = 'S3'` raises an explicit error pointing at `DATABASE_MIGRATION.S3_PARALLEL_READ`.
 
 ## Migration source
 

--- a/databricks_to_exasol.sql
+++ b/databricks_to_exasol.sql
@@ -1,0 +1,290 @@
+create schema if not exists database_migration;
+
+/*
+    This script generates create schema, create table, and import statements
+    to load data from Databricks SQL through JDBC.
+*/
+--/
+create or replace script database_migration.DATABRICKS_TO_EXASOL(
+    CONNECTION_NAME,                 -- name of the Databricks connection inside Exasol, e.g. databricks_connection
+    CATALOG2SCHEMA,                  -- TRUE maps catalog.schema.table to schema catalog and table schema_table
+    CATALOG_FILTER,                  -- filter for Databricks catalogs, e.g. 'main', 'ma%', 'main, analytics', '%'
+    SCHEMA_FILTER,                   -- filter for Databricks schemas, e.g. 'default', 'sales%', 'bronze, silver', '%'
+    TARGET_SCHEMA,                   -- target schema on Exasol side, set to NULL or empty string to use source values
+    TABLE_FILTER,                    -- filter for Databricks tables, e.g. 'orders', 'ord%', 'orders, customers', '%'
+    IDENTIFIER_CASE_INSENSITIVE      -- TRUE if generated Exasol identifiers should be uppercased
+) RETURNS TABLE
+AS
+
+local function trim(value)
+    return tostring(value):gsub("^%s*(.-)%s*$", "%1")
+end
+
+local function is_blank(value)
+    return value == null or trim(value) == ''
+end
+
+local function sql_literal(value)
+    return "'" .. tostring(value):gsub("'", "''") .. "'"
+end
+
+local function databricks_literal(value)
+    return "'" .. tostring(value):gsub("'", "''") .. "'"
+end
+
+local function parse_bool(value, default_value, name)
+    if value == null then
+        return default_value
+    end
+    if type(value) == 'boolean' then
+        return value
+    end
+
+    local text = trim(value):lower()
+    if text == '' then
+        return default_value
+    end
+    if text == 'true' or text == '1' or text == 'yes' then
+        return true
+    end
+    if text == 'false' or text == '0' or text == 'no' then
+        return false
+    end
+
+    error('Invalid boolean for ' .. name .. ': ' .. tostring(value))
+end
+
+local function normalize_filter(value)
+    if is_blank(value) then
+        return '%'
+    end
+    return trim(value)
+end
+
+local function filter_condition(column_name, value)
+    local filter_value = normalize_filter(value)
+    if filter_value:find(',', 1, true) and not filter_value:find('%%') and not filter_value:find('_') then
+        local values = {}
+        for part in filter_value:gmatch('[^,]+') do
+            values[#values + 1] = databricks_literal(trim(part))
+        end
+        return column_name .. ' in (' .. table.concat(values, ',') .. ')'
+    end
+    return column_name .. ' like ' .. databricks_literal(filter_value)
+end
+
+if is_blank(CONNECTION_NAME) then
+    error('CONNECTION_NAME is required')
+end
+
+local catalog2schema = parse_bool(CATALOG2SCHEMA, true, 'CATALOG2SCHEMA')
+local identifier_case_insensitive = parse_bool(IDENTIFIER_CASE_INSENSITIVE, true, 'IDENTIFIER_CASE_INSENSITIVE')
+
+local exa_upper_begin = ''
+local exa_upper_end = ''
+if identifier_case_insensitive then
+    exa_upper_begin = 'upper('
+    exa_upper_end = ')'
+end
+
+local catalog_condition = filter_condition('table_catalog', CATALOG_FILTER)
+local schema_condition = filter_condition('table_schema', SCHEMA_FILTER)
+local table_condition = filter_condition('table_name', TABLE_FILTER)
+
+local target_schema_expr
+local target_table_expr
+
+if not is_blank(TARGET_SCHEMA) then
+    target_schema_expr = sql_literal(TARGET_SCHEMA)
+    if catalog2schema then
+        target_table_expr = [["exa_table_catalog" || '_' || "exa_table_schema" || '_' || "exa_table_name"]]
+    else
+        target_table_expr = [["exa_table_schema" || '_' || "exa_table_name"]]
+    end
+elseif catalog2schema then
+    target_schema_expr = [["exa_table_catalog"]]
+    target_table_expr = [["exa_table_schema" || '_' || "exa_table_name"]]
+else
+    target_schema_expr = [["exa_table_schema"]]
+    target_table_expr = [["exa_table_name"]]
+end
+
+local metadata_statement = [[
+select
+    table_catalog,
+    table_schema,
+    table_name,
+    column_name,
+    ordinal_position,
+    case when is_nullable = 'NO' then 'NOT NULL' else 'NULL' end as not_null_constraint,
+    data_type,
+    full_data_type,
+    numeric_precision,
+    numeric_scale,
+    character_maximum_length
+from system.INFORMATION_SCHEMA.COLUMNS
+join system.INFORMATION_SCHEMA.TABLES using (table_catalog, table_schema, table_name)
+where table_type in ('MANAGED', 'EXTERNAL', 'MANAGED_SHALLOW_CLONE', 'EXTERNAL_SHALLOW_CLONE')
+  and ]] .. catalog_condition .. [[
+  and ]] .. schema_condition .. [[
+  and ]] .. table_condition
+
+local metadata_statement_escaped = metadata_statement:gsub("'", "''")
+
+suc, res = pquery([[
+with vv_databricks_columns as (
+    select
+        ]] .. exa_upper_begin .. [[databricks."table_catalog"]] .. exa_upper_end .. [[ as "exa_table_catalog",
+        ]] .. exa_upper_begin .. [[databricks."table_schema"]] .. exa_upper_end .. [[ as "exa_table_schema",
+        ]] .. exa_upper_begin .. [[databricks."table_name"]] .. exa_upper_end .. [[ as "exa_table_name",
+        ]] .. exa_upper_begin .. [[databricks."column_name"]] .. exa_upper_end .. [[ as "exa_column_name",
+        databricks."table_catalog" as table_catalog,
+        databricks."table_schema" as table_schema,
+        databricks."table_name" as table_name,
+        databricks."column_name" as column_name,
+        databricks."ordinal_position" as ordinal_position,
+        databricks."not_null_constraint" as not_null_constraint,
+        databricks."data_type" as data_type,
+        databricks."full_data_type" as full_data_type,
+        databricks."numeric_precision" as numeric_precision,
+        databricks."numeric_scale" as numeric_scale,
+        databricks."character_maximum_length" as character_maximum_length
+    from (
+        IMPORT FROM JDBC DRIVER = 'DATABRICKS' AT ]] .. CONNECTION_NAME .. [[ STATEMENT ']] .. metadata_statement_escaped .. [['
+    ) as databricks
+),
+vv_target_columns as (
+    select
+        *,
+        ]] .. target_schema_expr .. [[ as "target_schema_name",
+        ]] .. target_table_expr .. [[ as "target_table_name"
+    from vv_databricks_columns
+),
+vv_create_schemas as (
+    select
+        'create schema if not exists "' || "target_schema_name" || '";' as sql_text
+    from vv_target_columns
+    group by "target_schema_name"
+    order by "target_schema_name"
+),
+vv_create_tables as (
+    select
+        'create or replace table "' || "target_schema_name" || '"."' || "target_table_name" || '" (' ||
+        group_concat(
+            case
+                when upper(data_type) = 'TINYINT' then '"' || "exa_column_name" || '" DECIMAL(3,0) ' || not_null_constraint
+                when upper(data_type) = 'SMALLINT' then '"' || "exa_column_name" || '" DECIMAL(5,0) ' || not_null_constraint
+                when upper(data_type) = 'INT' then '"' || "exa_column_name" || '" DECIMAL(10,0) ' || not_null_constraint
+                when upper(data_type) = 'BIGINT' then '"' || "exa_column_name" || '" DECIMAL(19,0) ' || not_null_constraint
+                when upper(data_type) = 'FLOAT' then '"' || "exa_column_name" || '" FLOAT ' || not_null_constraint
+                when upper(data_type) = 'DOUBLE' then '"' || "exa_column_name" || '" DOUBLE PRECISION ' || not_null_constraint
+                when upper(data_type) = 'DECIMAL' then '"' || "exa_column_name" || '" DECIMAL(' ||
+                    case
+                        when numeric_precision is null then 36
+                        when numeric_precision > 36 then 36
+                        else numeric_precision
+                    end || ',' ||
+                    case
+                        when numeric_scale is null then 0
+                        when numeric_scale > 36 then 36
+                        else numeric_scale
+                    end || ') ' || not_null_constraint
+                when upper(data_type) = 'BOOLEAN' then '"' || "exa_column_name" || '" BOOLEAN ' || not_null_constraint
+                when upper(data_type) = 'DATE' then '"' || "exa_column_name" || '" DATE ' || not_null_constraint
+                when upper(data_type) = 'TIMESTAMP' then '"' || "exa_column_name" || '" TIMESTAMP WITH LOCAL TIME ZONE ' || not_null_constraint
+                when upper(data_type) = 'TIMESTAMP_LTZ' then '"' || "exa_column_name" || '" TIMESTAMP WITH LOCAL TIME ZONE ' || not_null_constraint
+                when upper(data_type) = 'TIMESTAMP_NTZ' then '"' || "exa_column_name" || '" TIMESTAMP ' || not_null_constraint
+                when upper(data_type) = 'STRING' then '"' || "exa_column_name" || '" VARCHAR(2000000) ' || not_null_constraint
+                when upper(data_type) = 'BINARY' then '"' || "exa_column_name" || '" VARCHAR(2000000) ' || not_null_constraint
+                when upper(data_type) = 'ARRAY' then '"' || "exa_column_name" || '" VARCHAR(2000000) ' || not_null_constraint
+                when upper(data_type) = 'MAP' then '"' || "exa_column_name" || '" VARCHAR(2000000) ' || not_null_constraint
+                when upper(data_type) = 'STRUCT' then '"' || "exa_column_name" || '" VARCHAR(2000000) ' || not_null_constraint
+                when upper(data_type) = 'VARIANT' then '"' || "exa_column_name" || '" VARCHAR(2000000) ' || not_null_constraint
+                when upper(data_type) = 'OBJECT' then '"' || "exa_column_name" || '" VARCHAR(2000000) ' || not_null_constraint
+                when upper(data_type) = 'INTERVAL' then '"' || "exa_column_name" || '" VARCHAR(2000000) ' || not_null_constraint
+                when upper(data_type) = 'VOID' then '"' || "exa_column_name" || '" VARCHAR(2000000) ' || not_null_constraint
+                when upper(data_type) = 'GEOGRAPHY' then '"' || "exa_column_name" || '" VARCHAR(2000000) ' || not_null_constraint
+                when upper(data_type) = 'GEOMETRY' then '"' || "exa_column_name" || '" VARCHAR(2000000) ' || not_null_constraint
+            end
+            order by ordinal_position separator ','
+        ) || ');' ||
+        coalesce(
+            group_concat(
+                case
+                    when upper(data_type) in ('BINARY', 'ARRAY', 'MAP', 'STRUCT', 'VARIANT', 'OBJECT', 'INTERVAL', 'VOID', 'GEOGRAPHY', 'GEOMETRY')
+                    then '--LOSSY_DATATYPE: "' || "exa_column_name" || '" Databricks TYPE INFO: ' || full_data_type
+                    when upper(data_type) not in ('TINYINT', 'SMALLINT', 'INT', 'BIGINT', 'FLOAT', 'DOUBLE', 'DECIMAL', 'BOOLEAN', 'DATE', 'TIMESTAMP', 'TIMESTAMP_LTZ', 'TIMESTAMP_NTZ', 'STRING', 'BINARY', 'ARRAY', 'MAP', 'STRUCT', 'VARIANT', 'OBJECT', 'INTERVAL', 'VOID', 'GEOGRAPHY', 'GEOMETRY')
+                    then '--UNKNOWN_DATATYPE: "' || "exa_column_name" || '" Databricks TYPE INFO: ' || full_data_type
+                end
+                order by ordinal_position separator ' '
+            ),
+            ''
+        ) as sql_text
+    from vv_target_columns
+    group by "target_schema_name", "target_table_name"
+),
+vv_imports as (
+    select
+        'import into "' || "target_schema_name" || '"."' || "target_table_name" || '"(' ||
+        group_concat(
+            case
+                when upper(data_type) in ('TINYINT', 'SMALLINT', 'INT', 'BIGINT', 'FLOAT', 'DOUBLE', 'DECIMAL', 'BOOLEAN', 'DATE', 'TIMESTAMP', 'TIMESTAMP_LTZ', 'TIMESTAMP_NTZ', 'STRING', 'BINARY', 'ARRAY', 'MAP', 'STRUCT', 'VARIANT', 'OBJECT', 'INTERVAL', 'VOID', 'GEOGRAPHY', 'GEOMETRY')
+                then '"' || "exa_column_name" || '"'
+            end
+            order by ordinal_position separator ','
+        ) || ') from jdbc driver = ''DATABRICKS'' at ]] .. CONNECTION_NAME .. [[ statement ''select ' ||
+        group_concat(
+            case
+                when upper(data_type) in ('TINYINT', 'SMALLINT', 'INT', 'BIGINT', 'FLOAT', 'DOUBLE', 'DECIMAL', 'BOOLEAN', 'DATE', 'TIMESTAMP', 'TIMESTAMP_LTZ', 'TIMESTAMP_NTZ', 'STRING')
+                then '`' || column_name || '`'
+                when upper(data_type) in ('BINARY', 'ARRAY', 'MAP', 'STRUCT', 'VARIANT', 'OBJECT', 'INTERVAL', 'VOID', 'GEOGRAPHY', 'GEOMETRY')
+                then 'cast(`' || column_name || '` as string)'
+            end
+            order by ordinal_position separator ','
+        ) || ' from `' || table_catalog || '`.`' || table_schema || '`.`' || table_name || '`'';' as sql_text
+    from vv_target_columns
+    group by "target_schema_name", "target_table_name", table_catalog, table_schema, table_name
+)
+select sql_text from (
+    select 1 as ord, cast('-- ### SCHEMAS ###' as varchar(2000000)) as sql_text
+    union all
+    select 2, sql_text from vv_create_schemas
+    union all
+    select 3, cast('-- ### TABLES ###' as varchar(2000000)) as sql_text
+    union all
+    select 4, sql_text from vv_create_tables where sql_text is not null and sql_text not like '%();%'
+    union all
+    select 5, cast('-- ### IMPORTS ###' as varchar(2000000)) as sql_text
+    union all
+    select 6, sql_text from vv_imports where sql_text is not null and sql_text not like '%select  from%'
+) order by ord, sql_text
+]], {})
+
+if not suc then
+    local error_message = 'unknown error'
+    local statement_text = metadata_statement
+    if res ~= null then
+        error_message = res.error_message or error_message
+        statement_text = res.statement_text or statement_text
+    end
+    error('"' .. error_message .. '" Caught while executing: "' .. statement_text .. '"')
+end
+
+return res
+/
+
+-- Create a connection to Databricks
+CREATE OR REPLACE CONNECTION DATABRICKS_CONNECTION TO
+  'jdbc:databricks://<server-hostname>:443/default;httpPath=<http-path>;AuthMech=3;UseNativeQuery=1'
+  USER 'token' IDENTIFIED BY '<personal-access-token>';
+
+-- Finally start the import process
+execute script database_migration.DATABRICKS_TO_EXASOL(
+    'DATABRICKS_CONNECTION', -- CONNECTION_NAME: name of the Databricks connection inside Exasol
+    true,                    -- CATALOG2SCHEMA: TRUE maps catalog.schema.table to catalog.schema_table
+    '%',                     -- CATALOG_FILTER: '%' to load all visible catalogs
+    '%',                     -- SCHEMA_FILTER: '%' to load all visible schemas
+    NULL,                    -- TARGET_SCHEMA: NULL or empty string to use source-derived schema names
+    '%',                     -- TABLE_FILTER: '%' to load all visible base tables
+    true                     -- IDENTIFIER_CASE_INSENSITIVE: TRUE uppercases generated Exasol identifiers
+);

--- a/db2_to_exasol.sql
+++ b/db2_to_exasol.sql
@@ -16,22 +16,26 @@ RETURNS TABLE
 AS
 exa_upper_begin=''
 exa_upper_end=''
+db2_filter_begin=''
+db2_filter_end=''
 if IDENTIFIER_CASE_INSENSITIVE == true then
   exa_upper_begin='upper('
   exa_upper_end=')'
+  db2_filter_begin='upper('
+  db2_filter_end=')'
 end
 summary = {}
 
 res = query([[
 with vv_db2_columns as (
-  select ]]..exa_upper_begin..[[table_catalog]]..exa_upper_end..[[ as "exa_table_catalog", ]]..exa_upper_begin..[[table_schema]]..exa_upper_end..[[ as "exa_table_schema", ]]..exa_upper_begin..[[table_name]]..exa_upper_end..[[ as "exa_table_name", ]]..exa_upper_begin..[[column_name]]..exa_upper_end..[[ as "exa_column_name", db2.* from  
+  select ]]..exa_upper_begin..[[table_catalog]]..exa_upper_end..[[ as "exa_table_catalog", ]]..exa_upper_begin..[[table_schema]]..exa_upper_end..[[ as "exa_table_schema", ]]..exa_upper_begin..[[table_name]]..exa_upper_end..[[ as "exa_table_name", ]]..exa_upper_begin..[[column_name]]..exa_upper_end..[[ as "exa_column_name", '"' || replace(table_schema, '"', '""') || '"' as "source_table_schema", '"' || replace(table_name, '"', '""') || '"' as "source_table_name", '"' || replace(column_name, '"', '""') || '"' as "source_column_name", db2.* from
     (import from jdbc at ]]..CONNECTION_NAME..[[ statement 
       'select t.table_catalog, rtrim(t.table_schema) table_schema, rtrim(t.table_name) table_name, column_name, ordinal_position, data_type, character_maximum_length, numeric_precision, numeric_scale, datetime_precision
         from sysibm.columns c join sysibm.tables t on t.table_catalog = c.table_catalog and t.table_schema = c.table_schema and t.table_name = c.table_name
         where t.table_type = ''BASE TABLE'' 
         AND rtrim(t.table_schema) not in (''SYSCAT'',''SYSIBM'', ''SYSIBMADM'', ''SYSPUBLIC'', ''SYSSTAT'', ''SYSTOOLS'')
-        AND rtrim(t.table_schema) like '']]..SCHEMA_FILTER..[[''
-        AND rtrim(t.table_name) like '']]..TABLE_FILTER..[[''
+        AND ]]..db2_filter_begin..[[rtrim(t.table_schema)]]..db2_filter_end..[[ like ]]..db2_filter_begin..[['']]..SCHEMA_FILTER..[['']]..db2_filter_end..[[
+        AND ]]..db2_filter_begin..[[rtrim(t.table_name)]]..db2_filter_end..[[ like ]]..db2_filter_begin..[['']]..TABLE_FILTER..[['']]..db2_filter_end..[[
     ') as db2 order by false
 )
 ,vv_create_schemas as(
@@ -69,15 +73,15 @@ with vv_db2_columns as (
   select 'import into "' || "exa_table_schema" || '"."' || "exa_table_name" || '" from jdbc at ]]..CONNECTION_NAME..[[ statement ''select ' 
            || group_concat(
                          case 
-                         when upper(data_type) = 'BINARY' then 'cast('||column_name||' as char('||character_maximum_length||'))'                           
-                         when upper(data_type) = 'DECFLOAT' then 'cast('||column_name||' as double)'                           
-                         when upper(data_type) in ('CHARACTER LARGE OBJECT', 'DOUBLE-BYTE CHARACTER LARGE OBJECT') then 'cast('||column_name||' as varchar(32500))'                           
+                         when upper(data_type) = 'BINARY' then 'cast('||"source_column_name"||' as char('||character_maximum_length||'))'
+                         when upper(data_type) = 'DECFLOAT' then 'cast('||"source_column_name"||' as double)'
+                         when upper(data_type) in ('CHARACTER LARGE OBJECT', 'DOUBLE-BYTE CHARACTER LARGE OBJECT') then 'cast('||"source_column_name"||' as varchar(32500))'
                          when upper(data_type) in ('BIGINT', 'DECIMAL', 'INTEGER', 'SMALLINT', 'DOUBLE PRECISION', 'REAL', 'DATE', 'TIME', 'TIMESTAMP', 'CHARACTER', 'GRAPHIC', 'CHARACTER VARYING', 'GRAPHIC VARYING')
-                         then column_name 
+                         then "source_column_name"
                          end order by ordinal_position) 
-           || ' from ' || rtrim(table_schema)|| '.' || rtrim(table_name)|| ''';' as sql_text
-  from vv_db2_columns group by "exa_table_catalog","exa_table_schema","exa_table_name", table_schema,table_name
-  order by "exa_table_catalog", "exa_table_schema","exa_table_name", table_schema,table_name
+           || ' from ' || "source_table_schema"|| '.' || "source_table_name"|| ''';' as sql_text
+  from vv_db2_columns group by "exa_table_catalog","exa_table_schema","exa_table_name", "source_table_schema","source_table_name"
+  order by "exa_table_catalog", "exa_table_schema","exa_table_name", "source_table_schema","source_table_name"
 ), base as
 (
 select 1 id, cast('-- ### SCHEMAS ###' as varchar(2000000)) SQL_TEXT

--- a/db2_to_exasol.sql
+++ b/db2_to_exasol.sql
@@ -26,12 +26,12 @@ res = query([[
 with vv_db2_columns as (
   select ]]..exa_upper_begin..[[table_catalog]]..exa_upper_end..[[ as "exa_table_catalog", ]]..exa_upper_begin..[[table_schema]]..exa_upper_end..[[ as "exa_table_schema", ]]..exa_upper_begin..[[table_name]]..exa_upper_end..[[ as "exa_table_name", ]]..exa_upper_begin..[[column_name]]..exa_upper_end..[[ as "exa_column_name", db2.* from  
     (import from jdbc at ]]..CONNECTION_NAME..[[ statement 
-      'select t.table_catalog, rtrim(t.table_schema) table_schema, t.table_name, column_name, ordinal_position, data_type, character_maximum_length, numeric_precision, numeric_scale, datetime_precision  
+      'select t.table_catalog, rtrim(t.table_schema) table_schema, rtrim(t.table_name) table_name, column_name, ordinal_position, data_type, character_maximum_length, numeric_precision, numeric_scale, datetime_precision
         from sysibm.columns c join sysibm.tables t on t.table_catalog = c.table_catalog and t.table_schema = c.table_schema and t.table_name = c.table_name
         where t.table_type = ''BASE TABLE'' 
-        AND t.table_schema not in (''SYSCAT'',''SYSIBM'', ''SYSIBMADM'', ''SYSPUBLIC'', ''SYSSTAT'', ''SYSTOOLS'')
-        AND t.table_schema like '']]..SCHEMA_FILTER..[[''
-        AND t.table_name like '']]..TABLE_FILTER..[[''
+        AND rtrim(t.table_schema) not in (''SYSCAT'',''SYSIBM'', ''SYSIBMADM'', ''SYSPUBLIC'', ''SYSSTAT'', ''SYSTOOLS'')
+        AND rtrim(t.table_schema) like '']]..SCHEMA_FILTER..[[''
+        AND rtrim(t.table_name) like '']]..TABLE_FILTER..[[''
     ') as db2 order by false
 )
 ,vv_create_schemas as(
@@ -75,7 +75,7 @@ with vv_db2_columns as (
                          when upper(data_type) in ('BIGINT', 'DECIMAL', 'INTEGER', 'SMALLINT', 'DOUBLE PRECISION', 'REAL', 'DATE', 'TIME', 'TIMESTAMP', 'CHARACTER', 'GRAPHIC', 'CHARACTER VARYING', 'GRAPHIC VARYING')
                          then column_name 
                          end order by ordinal_position) 
-           || ' from ' || table_schema|| '.' || table_name|| ''';' as sql_text
+           || ' from ' || rtrim(table_schema)|| '.' || rtrim(table_name)|| ''';' as sql_text
   from vv_db2_columns group by "exa_table_catalog","exa_table_schema","exa_table_name", table_schema,table_name
   order by "exa_table_catalog", "exa_table_schema","exa_table_name", table_schema,table_name
 ), base as

--- a/migrate_to_exasol.sql
+++ b/migrate_to_exasol.sql
@@ -25,7 +25,7 @@ create or replace script database_migration.MIGRATE_TO_EXASOL(
 ) RETURNS TABLE
 AS
 
-local OUT_COLUMNS = "SQL_TEXT VARCHAR(2000000), SUCCESS VARCHAR(10), ERROR_MESSAGE VARCHAR(20000)"
+local OUT_COLUMNS = "STEP_KIND VARCHAR(40), TARGET_OBJ VARCHAR(2000), ROWS_AFFECTED DECIMAL(18,0), ELAPSED_MS DECIMAL(18,0), RESULT_FLAG VARCHAR(20), SQL_TEXT VARCHAR(2000000), ERROR_MESSAGE VARCHAR(20000)"
 
 function is_null(value)
     return value == nil or value == null or value == NULL
@@ -170,16 +170,45 @@ function first_sql_text(row)
     return tostring(row)
 end
 
-function normalize_rows(res)
-    local summary = {}
-    for i = 1, #res do
-        local row = res[i]
-        local sql_text = first_sql_text(row)
-        local success = row.SUCCESS or row[2] or 'PREVIEW'
-        local error_message = row.ERROR_MESSAGE or row[3] or NULL
-        summary[#summary + 1] = {sql_text, success, error_message}
+function classify_step(sql_text)
+    local text = blank_to_nil(sql_text)
+    if text == nil then
+        return 'INFO'
     end
-    return summary
+    if string.sub(text, 1, 2) == '--' then
+        return 'INFO'
+    end
+    local lower = string.lower(text)
+    if string.find(lower, '^%s*create%s+schema') then
+        return 'CREATE_SCHEMA'
+    elseif string.find(lower, '^%s*create%s+or%s+replace%s+table')
+        or string.find(lower, '^%s*create%s+table') then
+        return 'CREATE_TABLE'
+    elseif string.find(lower, '^%s*alter%s+table') then
+        return 'ALTER_TABLE'
+    elseif string.find(lower, '^%s*import%s+into') then
+        return 'IMPORT'
+    elseif string.find(lower, '^%s*insert%s+into') then
+        return 'IMPORT'
+    end
+    return 'OTHER'
+end
+
+function extract_target_obj(sql_text, step_kind)
+    local text = blank_to_nil(sql_text)
+    if text == nil then
+        return NULL
+    end
+    if step_kind == 'CREATE_SCHEMA' then
+        local schema = text:match('[Cc][Rr][Ee][Aa][Tt][Ee]%s+[Ss][Cc][Hh][Ee][Mm][Aa]%s+[Ii][Ff]%s+[Nn][Oo][Tt]%s+[Ee][Xx][Ii][Ss][Tt][Ss]%s+"([^"]+)"')
+            or text:match('[Cc][Rr][Ee][Aa][Tt][Ee]%s+[Ss][Cc][Hh][Ee][Mm][Aa]%s+"([^"]+)"')
+            or text:match('[Cc][Rr][Ee][Aa][Tt][Ee]%s+[Ss][Cc][Hh][Ee][Mm][Aa]%s+([%w_]+)')
+        if schema then return schema end
+    elseif step_kind == 'CREATE_TABLE' or step_kind == 'ALTER_TABLE' or step_kind == 'IMPORT' then
+        local schema, table_name = text:match('"([^"]+)"%."([^"]+)"')
+        if schema and table_name then return schema .. '.' .. table_name end
+    end
+    return NULL
 end
 
 function is_executable_statement(sql_text)
@@ -190,34 +219,81 @@ function is_executable_statement(sql_text)
     return string.sub(text, 1, 2) ~= '--'
 end
 
+function build_row(step_kind, target_obj, rows_affected, elapsed_ms, result_flag, sql_text, error_message)
+    return {step_kind, target_obj, rows_affected, elapsed_ms, result_flag, sql_text, error_message}
+end
+
+function normalize_rows(res)
+    local summary = {}
+    local tables_count = 0
+    for i = 1, #res do
+        local row = res[i]
+        local sql_text = first_sql_text(row)
+        local kind = classify_step(sql_text)
+        local target = extract_target_obj(sql_text, kind)
+        if kind == 'CREATE_TABLE' then
+            tables_count = tables_count + 1
+        end
+        local flag = row.RESULT_FLAG or row.SUCCESS or row[5] or row[2] or 'PREVIEW'
+        local err = row.ERROR_MESSAGE or row[7] or row[3] or NULL
+        summary[#summary + 1] = build_row(kind, target, NULL, NULL, flag, sql_text, err)
+    end
+    summary[#summary + 1] = build_row('SUMMARY', 'Plan: ' .. tables_count .. ' table(s) to create', NULL, NULL, 'PREVIEW', NULL, NULL)
+    return summary
+end
+
 function execute_generated_sql(res)
     local summary = {}
     local fail_count = 0
     local executed_count = 0
+    local tables_created = 0
+    local total_rows = 0
+    local total_elapsed = 0
 
     for i = 1, #res do
         local sql_text = first_sql_text(res[i])
+        local kind = classify_step(sql_text)
+        local target = extract_target_obj(sql_text, kind)
         if is_executable_statement(sql_text) then
             executed_count = executed_count + 1
+            local t0 = os.clock()
             local success, info = pquery(sql_text)
+            local elapsed = math.floor((os.clock() - t0) * 1000)
+            total_elapsed = total_elapsed + elapsed
             if success then
-                summary[#summary + 1] = {sql_text, 'TRUE', NULL}
+                local rows_affected = NULL
+                if info ~= nil and info.rows_affected ~= nil then
+                    rows_affected = tonumber(info.rows_affected) or NULL
+                    if kind == 'IMPORT' and type(rows_affected) == 'number' then
+                        total_rows = total_rows + rows_affected
+                    end
+                end
+                if kind == 'CREATE_TABLE' then
+                    tables_created = tables_created + 1
+                end
+                summary[#summary + 1] = build_row(kind, target, rows_affected, elapsed, 'OK', sql_text, NULL)
             else
                 fail_count = fail_count + 1
-                summary[#summary + 1] = {sql_text, 'FALSE', info.error_message}
+                summary[#summary + 1] = build_row(kind, target, NULL, elapsed, 'ERROR', sql_text, info.error_message)
             end
         else
-            summary[#summary + 1] = {sql_text, 'SKIPPED', 'Comment or empty'}
+            summary[#summary + 1] = build_row(kind, target, NULL, NULL, 'SKIPPED', sql_text, NULL)
         end
     end
 
+    local summary_obj
+    local summary_flag
     if executed_count == 0 then
-        table.insert(summary, 1, {'-- No executable SQL statements were generated.', 'SKIPPED', NULL})
+        summary_obj = 'No executable SQL generated'
+        summary_flag = 'SKIPPED'
     elseif fail_count == 0 then
-        table.insert(summary, 1, {'-- The following statements were executed successfully.', 'SKIPPED', NULL})
+        summary_obj = 'Completed: ' .. tables_created .. ' table(s), ' .. total_rows .. ' row(s) loaded'
+        summary_flag = 'OK'
     else
-        table.insert(summary, 1, {'-- Execution completed with ' .. fail_count .. ' error(s). See ERROR_MESSAGE column for details.', 'SKIPPED', NULL})
+        summary_obj = 'Completed with ' .. fail_count .. ' error(s); ' .. tables_created .. ' table(s) created, ' .. total_rows .. ' row(s) loaded'
+        summary_flag = 'ERROR'
     end
+    summary[#summary + 1] = build_row('SUMMARY', summary_obj, total_rows, total_elapsed, summary_flag, NULL, NULL)
 
     return summary
 end

--- a/migrate_to_exasol.sql
+++ b/migrate_to_exasol.sql
@@ -193,10 +193,12 @@ end
 function execute_generated_sql(res)
     local summary = {}
     local fail_count = 0
+    local executed_count = 0
 
     for i = 1, #res do
         local sql_text = first_sql_text(res[i])
         if is_executable_statement(sql_text) then
+            executed_count = executed_count + 1
             local success, info = pquery(sql_text)
             if success then
                 summary[#summary + 1] = {sql_text, 'TRUE', NULL}
@@ -209,7 +211,9 @@ function execute_generated_sql(res)
         end
     end
 
-    if fail_count == 0 then
+    if executed_count == 0 then
+        table.insert(summary, 1, {'-- No executable SQL statements were generated.', 'SKIPPED', NULL})
+    elseif fail_count == 0 then
         table.insert(summary, 1, {'-- The following statements were executed successfully.', 'SKIPPED', NULL})
     else
         table.insert(summary, 1, {'-- Execution completed with ' .. fail_count .. ' error(s). See ERROR_MESSAGE column for details.', 'SKIPPED', NULL})

--- a/migrate_to_exasol.sql
+++ b/migrate_to_exasol.sql
@@ -1,0 +1,417 @@
+create schema if not exists database_migration;
+
+/*
+    Unified entry point for database migration scripts.
+
+    This script keeps the existing source-specific scripts intact and exposes one
+    standardized call surface. It dispatches to the current adapter script, then
+    either returns generated SQL (DEBUG = TRUE) or executes generated SQL
+    (DEBUG = FALSE).
+
+    Source-specific settings live in OPTIONS as key=value pairs separated by ';'.
+*/
+--/
+create or replace script database_migration.MIGRATE_TO_EXASOL(
+    SOURCE_TYPE,                  -- migration source, e.g. MYSQL, POSTGRES, DATABRICKS, SNOWFLAKE
+    CONNECTION_NAME,              -- name of the source database connection inside Exasol
+    CONNECTION_TYPE,              -- Exasol-to-Exasol only: JDBC or EXA
+    DB_FILTER,                    -- database/catalog filter where supported, else '%'
+    SCHEMA_FILTER,                -- schema filter, e.g. 'MY_SCHEMA', 'MART_%', or '%'
+    TABLE_FILTER,                 -- table filter, e.g. 'MY_TABLE', 'FACT_%', or '%'
+    TARGET_SCHEMA,                -- target schema override where supported, or NULL
+    IDENTIFIER_CASE_INSENSITIVE,  -- TRUE stores generated identifiers uppercase
+    DEBUG,                        -- TRUE previews generated SQL, FALSE executes it
+    OPTIONS                       -- source-specific KEY=VALUE pairs separated by semicolons
+) RETURNS TABLE
+AS
+
+local OUT_COLUMNS = "SQL_TEXT VARCHAR(2000000), SUCCESS VARCHAR(10), ERROR_MESSAGE VARCHAR(20000)"
+
+function is_null(value)
+    return value == nil or value == null or value == NULL
+end
+
+function trim(value)
+    if is_null(value) then
+        return nil
+    end
+    return tostring(value):gsub("^%s*(.-)%s*$", "%1")
+end
+
+function blank_to_nil(value)
+    local result = trim(value)
+    if result == nil or result == '' then
+        return nil
+    end
+    return result
+end
+
+function escape_sql_literal(value)
+    return tostring(value):gsub("'", "''")
+end
+
+function sql_string(value)
+    local result = blank_to_nil(value)
+    if result == nil then
+        return "NULL"
+    end
+    return "'" .. escape_sql_literal(result) .. "'"
+end
+
+function sql_bool(value)
+    if value then
+        return "TRUE"
+    end
+    return "FALSE"
+end
+
+function parse_bool(value, default_value, param_name)
+    if is_null(value) or blank_to_nil(value) == nil then
+        return default_value
+    end
+    if type(value) == 'boolean' then
+        return value
+    end
+
+    local normalized = string.upper(trim(value))
+    if normalized == 'TRUE' or normalized == 'T' or normalized == 'YES' or normalized == 'Y' or normalized == '1' then
+        return true
+    elseif normalized == 'FALSE' or normalized == 'F' or normalized == 'NO' or normalized == 'N' or normalized == '0' then
+        return false
+    end
+
+    error('Invalid boolean for ' .. param_name .. ': ' .. tostring(value))
+end
+
+function parse_options(raw_options)
+    local parsed = {}
+    local raw = blank_to_nil(raw_options)
+    if raw == nil then
+        return parsed
+    end
+
+    for entry in string.gmatch(raw, "([^;]+)") do
+        local key, value = entry:match("^%s*([^=]+)%s*=%s*(.-)%s*$")
+        if key == nil then
+            error('Invalid OPTIONS entry: ' .. entry .. '. Use KEY=VALUE pairs separated by semicolons.')
+        end
+        parsed[string.upper(trim(key))] = trim(value)
+    end
+
+    return parsed
+end
+
+function opt(options, key, default_value)
+    local value = options[string.upper(key)]
+    if blank_to_nil(value) == nil then
+        return default_value
+    end
+    return value
+end
+
+function opt_bool(options, key, default_value)
+    return parse_bool(opt(options, key, nil), default_value, key)
+end
+
+function opt_sql_number(options, key, default_value)
+    local value = opt(options, key, default_value)
+    if blank_to_nil(value) == nil then
+        return "NULL"
+    end
+    local number_value = tonumber(value)
+    if number_value == nil then
+        error('Invalid numeric option ' .. key .. ': ' .. tostring(value))
+    end
+    return tostring(number_value)
+end
+
+function normalize_source_type(source_type)
+    local source = string.upper(blank_to_nil(source_type) or '')
+    source = source:gsub("%s+", "_"):gsub("-", "_")
+
+    if source == 'AZURESQL' or source == 'AZURE_SQL_SERVER' then
+        return 'AZURE_SQL'
+    elseif source == 'BIG_QUERY' or source == 'GOOGLE_BIGQUERY' or source == 'GOOGLE_BIG_QUERY' then
+        return 'BIGQUERY'
+    elseif source == 'DBX' or source == 'DATABRICKS_SQL' then
+        return 'DATABRICKS'
+    elseif source == 'POSTGRESQL' then
+        return 'POSTGRES'
+    elseif source == 'SQL_SERVER' or source == 'MSSQL' or source == 'MICROSOFT_SQL_SERVER' then
+        return 'SQLSERVER'
+    elseif source == 'SAP_HANA' or source == 'SAPHANA' then
+        return 'HANA'
+    elseif source == 'EXA' then
+        return 'EXASOL'
+    elseif source == 'NZ' then
+        return 'NETEZZA'
+    elseif source == 'ACTIAN' or source == 'ACTIAN_VECTOR' then
+        return 'VECTORWISE'
+    end
+
+    return source
+end
+
+function require_value(value, name)
+    local result = blank_to_nil(value)
+    if result == nil then
+        error(name .. ' is required')
+    end
+    return result
+end
+
+function first_sql_text(row)
+    if row.SQL_TEXT ~= nil then
+        return row.SQL_TEXT
+    end
+    if row[1] ~= nil then
+        return row[1]
+    end
+    return tostring(row)
+end
+
+function normalize_rows(res)
+    local summary = {}
+    for i = 1, #res do
+        local row = res[i]
+        local sql_text = first_sql_text(row)
+        local success = row.SUCCESS or row[2] or 'PREVIEW'
+        local error_message = row.ERROR_MESSAGE or row[3] or NULL
+        summary[#summary + 1] = {sql_text, success, error_message}
+    end
+    return summary
+end
+
+function is_executable_statement(sql_text)
+    local text = blank_to_nil(sql_text)
+    if text == nil then
+        return false
+    end
+    return string.sub(text, 1, 2) ~= '--'
+end
+
+function execute_generated_sql(res)
+    local summary = {}
+    local fail_count = 0
+
+    for i = 1, #res do
+        local sql_text = first_sql_text(res[i])
+        if is_executable_statement(sql_text) then
+            local success, info = pquery(sql_text)
+            if success then
+                summary[#summary + 1] = {sql_text, 'TRUE', NULL}
+            else
+                fail_count = fail_count + 1
+                summary[#summary + 1] = {sql_text, 'FALSE', info.error_message}
+            end
+        else
+            summary[#summary + 1] = {sql_text, 'SKIPPED', 'Comment or empty'}
+        end
+    end
+
+    if fail_count == 0 then
+        table.insert(summary, 1, {'-- The following statements were executed successfully.', 'SKIPPED', NULL})
+    else
+        table.insert(summary, 1, {'-- Execution completed with ' .. fail_count .. ' error(s). See ERROR_MESSAGE column for details.', 'SKIPPED', NULL})
+    end
+
+    return summary
+end
+
+function execute_adapter(adapter_sql, debug)
+    local success, res = pquery(adapter_sql)
+    if not success then
+        error('"' .. res.error_message .. '" Caught while executing: "' .. res.statement_text .. '"')
+    end
+
+    if not debug then
+        return execute_generated_sql(res), OUT_COLUMNS
+    end
+
+    return normalize_rows(res), OUT_COLUMNS
+end
+
+local source = normalize_source_type(SOURCE_TYPE)
+local connection_name = require_value(CONNECTION_NAME, 'CONNECTION_NAME')
+local connection_type = string.upper(blank_to_nil(CONNECTION_TYPE) or 'JDBC')
+local db_filter = blank_to_nil(DB_FILTER) or '%'
+local schema_filter = blank_to_nil(SCHEMA_FILTER) or '%'
+local table_filter = blank_to_nil(TABLE_FILTER) or '%'
+local target_schema = blank_to_nil(TARGET_SCHEMA)
+local identifier_case_insensitive = parse_bool(IDENTIFIER_CASE_INSENSITIVE, true, 'IDENTIFIER_CASE_INSENSITIVE')
+local debug = parse_bool(DEBUG, true, 'DEBUG')
+local options = parse_options(OPTIONS)
+
+local adapter_sql = nil
+
+if source == 'MYSQL' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.MYSQL_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(table_filter) .. ')'
+
+elseif source == 'MARIADB' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.MARIADB_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(table_filter) .. ')'
+
+elseif source == 'POSTGRES' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.POSTGRES_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(table_filter) .. ','
+        .. sql_string(target_schema) .. ')'
+
+elseif source == 'REDSHIFT' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.REDSHIFT_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(table_filter) .. ')'
+
+elseif source == 'DB2' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.DB2_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(table_filter) .. ')'
+
+elseif source == 'VERTICA' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.VERTICA_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(table_filter) .. ')'
+
+elseif source == 'HANA' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.HANA_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(table_filter) .. ')'
+
+elseif source == 'AZURE_SQL' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.AZURE_SQL_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(table_filter) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ')'
+
+elseif source == 'BIGQUERY' then
+    local project_id = opt(options, 'PROJECT_ID', nil)
+    if blank_to_nil(project_id) == nil and db_filter ~= '%' then
+        project_id = db_filter
+    end
+    project_id = require_value(project_id, 'OPTIONS PROJECT_ID for BIGQUERY')
+
+    adapter_sql = 'EXECUTE SCRIPT database_migration.BIGQUERY_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ','
+        .. sql_string(project_id) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(table_filter) .. ')'
+
+elseif source == 'DATABRICKS' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.DATABRICKS_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(opt_bool(options, 'CATALOG2SCHEMA', true)) .. ','
+        .. sql_string(db_filter) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(target_schema) .. ','
+        .. sql_string(table_filter) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ')'
+
+elseif source == 'SQLSERVER' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.SQLSERVER_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(opt_bool(options, 'DB2SCHEMA', false)) .. ','
+        .. sql_string(db_filter) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(target_schema) .. ','
+        .. sql_string(table_filter) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ')'
+
+elseif source == 'SNOWFLAKE' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.SNOWFLAKE_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(opt_bool(options, 'DB2SCHEMA', false)) .. ','
+        .. sql_string(db_filter) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(target_schema) .. ','
+        .. sql_string(table_filter) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ')'
+
+elseif source == 'ORACLE' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.ORACLE_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(table_filter) .. ','
+        .. opt_sql_number(options, 'PARALLEL_STATEMENTS', 1) .. ','
+        .. sql_bool(opt_bool(options, 'CREATE_PK', false)) .. ','
+        .. sql_bool(opt_bool(options, 'CREATE_FK', false)) .. ','
+        .. sql_bool(opt_bool(options, 'CHECK_MIGRATION', false)) .. ')'
+
+elseif source == 'TERADATA' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.TERADATA_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(table_filter) .. ','
+        .. sql_bool(opt_bool(options, 'CHECK_MIGRATION', false)) .. ')'
+
+elseif source == 'EXASOL' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.EXASOL_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_string(connection_type) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(table_filter) .. ','
+        .. sql_string(opt(options, 'GENERATE_VIEWS', 'FALSE')) .. ','
+        .. sql_string(opt(options, 'VIEW_FILTER', '%')) .. ','
+        .. sql_string(opt(options, 'PK_SETTING', 'DISABLE')) .. ')'
+
+elseif source == 'NETEZZA' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.NETEZZA_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_string(db_filter) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(table_filter) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ')'
+
+elseif source == 'VECTORWISE' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.VECTORWISE_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ','
+        .. sql_string(table_filter) .. ')'
+
+elseif source == 'S3' then
+    error('S3 is not supported by MIGRATE_TO_EXASOL. Use DATABASE_MIGRATION.S3_PARALLEL_READ directly.')
+
+else
+    error('Unsupported SOURCE_TYPE: ' .. tostring(SOURCE_TYPE))
+end
+
+return execute_adapter(adapter_sql, debug)
+/
+
+/*
+Example:
+
+execute script database_migration.MIGRATE_TO_EXASOL(
+    'SNOWFLAKE',
+    'SNOWFLAKE_CONNECTION',
+    'JDBC',
+    '%',
+    '%',
+    '%',
+    NULL,
+    TRUE,
+    TRUE,
+    'DB2SCHEMA=true'
+);
+*/

--- a/postgres_to_exasol.sql
+++ b/postgres_to_exasol.sql
@@ -20,7 +20,7 @@ if IDENTIFIER_CASE_INSENSITIVE == true then
 	exa_upper_begin='upper('
 	exa_upper_end=')'
 end
-if DEST_SCHEMA then
+if DEST_SCHEMA ~= nil and DEST_SCHEMA ~= null then
 	exa_table_schema_clause=[[']]..DEST_SCHEMA..[[']]
 else
 	exa_table_schema_clause=exa_upper_begin..[["table_schema"]]..exa_upper_end

--- a/postgres_to_exasol.sql
+++ b/postgres_to_exasol.sql
@@ -27,7 +27,7 @@ else
 end
 res = query([[
 with vv_pg_columns as (
-	select ]]..exa_upper_begin..[["table_catalog"]]..exa_upper_end..[[ as "exa_table_catalog", ]]..exa_table_schema_clause..[[ as "exa_table_schema", ]]..exa_upper_begin..[["table_name"]]..exa_upper_end..[[ as "exa_table_name", ]]..exa_upper_begin..[["column_name"]]..exa_upper_end..[[ as "exa_column_name", pg.* from  
+	select ]]..exa_upper_begin..[["table_catalog"]]..exa_upper_end..[[ as "exa_table_catalog", ]]..exa_table_schema_clause..[[ as "exa_table_schema", ]]..exa_upper_begin..[["table_name"]]..exa_upper_end..[[ as "exa_table_name", ]]..exa_upper_begin..[["column_name"]]..exa_upper_end..[[ as "exa_column_name", '"' || replace("table_schema", '"', '""') || '"' as "source_table_schema", '"' || replace("table_name", '"', '""') || '"' as "source_table_name", '"' || replace("column_name", '"', '""') || '"' as "source_column_name", pg.* from
 		(import from jdbc at ]]..CONNECTION_NAME..[[ statement 
 			'select table_catalog, table_schema, table_name, column_name, ordinal_position, case when is_nullable=''NO'' then ''NOT NULL'' else ''NULL'' end as not_null_constraint, data_type, character_maximum_length, numeric_precision, numeric_scale, datetime_precision  
 				from information_schema.columns join information_schema.tables using (table_catalog, table_schema, table_name) 
@@ -105,40 +105,40 @@ with vv_pg_columns as (
 , vv_imports as (
 	select 'import into "' || "exa_table_schema" || '"."' || "exa_table_name" || '" from jdbc at ]]..CONNECTION_NAME..[[ statement ''select ' || group_concat( 
 	case 
-	when "data_type" = 'ARRAY' then "column_name" ||'::text'
-	when "data_type" = 'USER-DEFINED' then "column_name" ||'::text' 
-	when "data_type" = 'bit' then "column_name" ||'::text'
-	when "data_type" = 'bit varying' then "column_name" ||'::text'
-	when "data_type" = 'box' then "column_name" ||'::text'
-	when "data_type" = 'bytea' then "column_name" ||'::text'
-	when "data_type" = 'cidr' then "column_name" ||'::text' 
-	when "data_type" = 'circle' then "column_name" ||'::text' 
-	when "data_type" = 'inet' then "column_name" ||'::text'
-	when "data_type" = 'interval' then "column_name" ||'::text' 
-	when "data_type" = 'json' then "column_name" ||'::text'
-	when "data_type" = 'jsonb' then "column_name" ||'::text'
-	when "data_type" = 'line' then "column_name" ||'::text'
-	when "data_type" = 'lseg' then "column_name" ||'::text'
-	when "data_type" = 'name' then "column_name" ||'::text'
-	when "data_type" = 'macaddr' then "column_name" ||'::text'
-	when "data_type" = 'money' then "column_name" ||'::text'
-	when "data_type" = 'point' then "column_name" ||'::text'
-	when "data_type" = 'path' then "column_name" ||'::text'
-	when "data_type" = 'pg_lsn' then "column_name" ||'::text'
-	when "data_type" = 'polygon' then "column_name" ||'::text'
-	when "data_type" = 'timestamp with time zone' then 'case when  '||"column_name"||' > ''''9999-12-31 23:59:59.999'''' then ''''9999-12-31 23:59:59.999'''' when '||"column_name" ||' < ''''0001-01-01'''' then ''''0001-01-01'''' else '||"column_name" ||' end'
-	when "data_type" = 'timestamp without time zone' then 'case when  '||"column_name"||' > ''''9999-12-31 23:59:59.999'''' then ''''9999-12-31 23:59:59.999'''' when '||"column_name" ||' < ''''0001-01-01'''' then ''''0001-01-01'''' else '||"column_name" ||' end'
-	when "data_type" = 'tsquery' then "column_name" ||'::text'
-	when "data_type" = 'tsvector' then "column_name" ||'::text'
-	when "data_type" = 'txid_snapshot' then "column_name" ||'::text'
-	when "data_type" = 'uuid' then "column_name" ||'::text'
-	when "data_type" = 'xml' then "column_name" ||'::text'
+	when "data_type" = 'ARRAY' then "source_column_name" ||'::text'
+	when "data_type" = 'USER-DEFINED' then "source_column_name" ||'::text'
+	when "data_type" = 'bit' then "source_column_name" ||'::text'
+	when "data_type" = 'bit varying' then "source_column_name" ||'::text'
+	when "data_type" = 'box' then "source_column_name" ||'::text'
+	when "data_type" = 'bytea' then "source_column_name" ||'::text'
+	when "data_type" = 'cidr' then "source_column_name" ||'::text'
+	when "data_type" = 'circle' then "source_column_name" ||'::text'
+	when "data_type" = 'inet' then "source_column_name" ||'::text'
+	when "data_type" = 'interval' then "source_column_name" ||'::text'
+	when "data_type" = 'json' then "source_column_name" ||'::text'
+	when "data_type" = 'jsonb' then "source_column_name" ||'::text'
+	when "data_type" = 'line' then "source_column_name" ||'::text'
+	when "data_type" = 'lseg' then "source_column_name" ||'::text'
+	when "data_type" = 'name' then "source_column_name" ||'::text'
+	when "data_type" = 'macaddr' then "source_column_name" ||'::text'
+	when "data_type" = 'money' then "source_column_name" ||'::text'
+	when "data_type" = 'point' then "source_column_name" ||'::text'
+	when "data_type" = 'path' then "source_column_name" ||'::text'
+	when "data_type" = 'pg_lsn' then "source_column_name" ||'::text'
+	when "data_type" = 'polygon' then "source_column_name" ||'::text'
+	when "data_type" = 'timestamp with time zone' then 'case when  '||"source_column_name"||' > ''''9999-12-31 23:59:59.999'''' then ''''9999-12-31 23:59:59.999'''' when '||"source_column_name" ||' < ''''0001-01-01'''' then ''''0001-01-01'''' else '||"source_column_name" ||' end'
+	when "data_type" = 'timestamp without time zone' then 'case when  '||"source_column_name"||' > ''''9999-12-31 23:59:59.999'''' then ''''9999-12-31 23:59:59.999'''' when '||"source_column_name" ||' < ''''0001-01-01'''' then ''''0001-01-01'''' else '||"source_column_name" ||' end'
+	when "data_type" = 'tsquery' then "source_column_name" ||'::text'
+	when "data_type" = 'tsvector' then "source_column_name" ||'::text'
+	when "data_type" = 'txid_snapshot' then "source_column_name" ||'::text'
+	when "data_type" = 'uuid' then "source_column_name" ||'::text'
+	when "data_type" = 'xml' then "source_column_name" ||'::text'
 	when "data_type" in ('bigint', 'boolean', 'character', 'character varying', 'date', 'double precision', 'integer', 'numeric', 'oid', 'real', 'smallint', 'text', 'time with time zone', 'time without time zone')
-	then "column_name"
+	then "source_column_name"
 	end
-	order by "ordinal_position") || ' from ' || "table_schema"|| '.' || "table_name"|| ''';' as sql_text
-	from vv_pg_columns group by "exa_table_catalog","exa_table_schema","exa_table_name", "table_schema","table_name"
-	order by "exa_table_catalog", "exa_table_schema","exa_table_name", "table_schema","table_name"
+	order by "ordinal_position") || ' from ' || "source_table_schema"|| '.' || "source_table_name"|| ''';' as sql_text
+	from vv_pg_columns group by "exa_table_catalog","exa_table_schema","exa_table_name", "source_table_schema","source_table_name"
+	order by "exa_table_catalog", "exa_table_schema","exa_table_name", "source_table_schema","source_table_name"
 )
 select SQL_TEXT from (
 select 1 as ord, a.* from vv_create_schemas a

--- a/test/test_databricks_to_exasol.lua
+++ b/test/test_databricks_to_exasol.lua
@@ -1,0 +1,200 @@
+--[[
+  Checks for databricks_to_exasol.sql.
+
+  Run: lua test/test_databricks_to_exasol.lua
+]]
+
+local passed = 0
+local failed = 0
+
+local function test(name, fn)
+    local ok, err = pcall(fn)
+    if ok then
+        passed = passed + 1
+        print("  PASS: " .. name)
+    else
+        failed = failed + 1
+        print("  FAIL: " .. name .. " -- " .. tostring(err))
+    end
+end
+
+local function assert_eq(actual, expected, msg)
+    if actual ~= expected then
+        error((msg or "") .. " expected: " .. tostring(expected) .. ", got: " .. tostring(actual))
+    end
+end
+
+local function assert_contains(actual, pattern, msg)
+    if not tostring(actual):find(pattern, 1, true) then
+        error((msg or "missing expected text") .. ": " .. pattern .. " in " .. tostring(actual))
+    end
+end
+
+local function assert_not_contains(actual, pattern, msg)
+    if tostring(actual):find(pattern, 1, true) then
+        error((msg or "unexpected text") .. ": " .. pattern .. " in " .. tostring(actual))
+    end
+end
+
+local function read_file(path)
+    local f = io.open(path, "r")
+    assert(f, "Could not open " .. path)
+    local content = f:read("*a")
+    f:close()
+    return content
+end
+
+local function extract_lua_block(path)
+    local content = read_file(path)
+    local lua_block = content:match("%) RETURNS TABLE%s*\nAS\n(.-)\n/\n")
+    assert(lua_block, "Could not extract Lua block from " .. path)
+    return lua_block
+end
+
+local databricks_lua = extract_lua_block("databricks_to_exasol.sql")
+
+local function run_databricks(params)
+    local calls = {}
+    local rows = params.rows or {{SQL_TEXT = "-- ### SCHEMAS ###"}}
+
+    local env = {
+        CONNECTION_NAME = params.connection_name or "DATABRICKS_CONNECTION",
+        CATALOG2SCHEMA = params.catalog2schema,
+        CATALOG_FILTER = params.catalog_filter,
+        SCHEMA_FILTER = params.schema_filter,
+        TARGET_SCHEMA = params.target_schema,
+        TABLE_FILTER = params.table_filter,
+        IDENTIFIER_CASE_INSENSITIVE = params.identifier_case_insensitive,
+        string = string,
+        table = table,
+        math = math,
+        tostring = tostring,
+        tonumber = tonumber,
+        type = type,
+        error = error,
+    }
+
+    env.pquery = function(sql)
+        calls[#calls + 1] = sql
+        if params.metadata_error then
+            return false, {
+                error_message = params.metadata_error,
+                statement_text = sql,
+            }
+        end
+        return true, rows
+    end
+
+    local fn, err = load(databricks_lua, "databricks_to_exasol.lua", "t", env)
+    assert(fn, "Lua load failed: " .. tostring(err))
+
+    local result_rows = fn()
+    return {
+        rows = result_rows,
+        sql = calls[1],
+        calls = calls,
+    }
+end
+
+print("=== Lua Syntax Validation ===")
+
+test("Lua block in databricks_to_exasol.sql has valid syntax", function()
+    local fn, err = load(databricks_lua)
+    assert(fn, "Lua syntax error in databricks_to_exasol.sql: " .. tostring(err))
+end)
+
+print("")
+print("=== Generation Tests ===")
+
+test("generates migration sql for Databricks tables", function()
+    local result = run_databricks({})
+
+    assert_eq(#result.calls, 1)
+    assert_eq(result.rows[1].SQL_TEXT, "-- ### SCHEMAS ###")
+    assert_contains(result.sql, "IMPORT FROM JDBC DRIVER = 'DATABRICKS' AT DATABRICKS_CONNECTION")
+    assert_contains(result.sql, "INFORMATION_SCHEMA.COLUMNS")
+    assert_contains(result.sql, "INFORMATION_SCHEMA.TABLES")
+    assert_contains(result.sql, "table_type in (''MANAGED'', ''EXTERNAL'', ''MANAGED_SHALLOW_CLONE'', ''EXTERNAL_SHALLOW_CLONE'')")
+    assert_contains(result.sql, "-- ### SCHEMAS ###")
+    assert_contains(result.sql, "-- ### TABLES ###")
+    assert_contains(result.sql, "-- ### IMPORTS ###")
+    assert_contains(result.sql, "import into")
+end)
+
+test("applies source filters to metadata query", function()
+    local result = run_databricks({
+        catalog_filter = "main, analytics",
+        schema_filter = "bronze%",
+        table_filter = "orders, customers",
+    })
+
+    assert_contains(result.sql, "table_catalog in (''main'',''analytics'')")
+    assert_contains(result.sql, "table_schema like ''bronze%''")
+    assert_contains(result.sql, "table_name in (''orders'',''customers'')")
+end)
+
+test("catalog2schema maps catalog schema table safely", function()
+    local result = run_databricks({catalog2schema = true})
+
+    assert_contains(result.sql, "\"exa_table_catalog\" as \"target_schema_name\"")
+    assert_contains(result.sql, "\"exa_table_schema\" || '_' || \"exa_table_name\" as \"target_table_name\"")
+end)
+
+test("target schema override is honored", function()
+    local result = run_databricks({
+        catalog2schema = true,
+        target_schema = "MART",
+    })
+
+    assert_contains(result.sql, "'MART' as \"target_schema_name\"")
+    assert_contains(result.sql, "\"exa_table_catalog\" || '_' || \"exa_table_schema\" || '_' || \"exa_table_name\" as \"target_table_name\"")
+end)
+
+test("identifier case option controls generated names", function()
+    local upper_result = run_databricks({identifier_case_insensitive = true})
+    local preserve_result = run_databricks({identifier_case_insensitive = false})
+
+    assert_contains(upper_result.sql, "upper(databricks.\"table_catalog\")")
+    assert_contains(upper_result.sql, "upper(databricks.\"column_name\")")
+    assert_not_contains(preserve_result.sql, "upper(databricks.\"table_catalog\")")
+    assert_not_contains(preserve_result.sql, "upper(databricks.\"column_name\")")
+end)
+
+test("maps databricks types to exasol types", function()
+    local result = run_databricks({})
+
+    assert_contains(result.sql, "when upper(data_type) = 'TINYINT'")
+    assert_contains(result.sql, "DECIMAL(3,0)")
+    assert_contains(result.sql, "when upper(data_type) = 'BIGINT'")
+    assert_contains(result.sql, "DECIMAL(19,0)")
+    assert_contains(result.sql, "when upper(data_type) = 'DECIMAL'")
+    assert_contains(result.sql, "when upper(data_type) = 'STRING'")
+    assert_contains(result.sql, "VARCHAR(2000000)")
+    assert_contains(result.sql, "when upper(data_type) = 'TIMESTAMP_NTZ'")
+    assert_contains(result.sql, "when upper(data_type) = 'ARRAY'")
+    assert_contains(result.sql, "when upper(data_type) = 'OBJECT'")
+    assert_contains(result.sql, "--LOSSY_DATATYPE")
+end)
+
+test("metadata errors include source statement", function()
+    local ok, err = pcall(run_databricks, {metadata_error = "permission denied"})
+
+    assert_eq(ok, false)
+    assert_contains(err, "permission denied")
+    assert_contains(err, "IMPORT FROM JDBC DRIVER = 'DATABRICKS' AT DATABRICKS_CONNECTION")
+end)
+
+test("databricks adapter does not generate s3 loader sql", function()
+    local script = read_file("databricks_to_exasol.sql")
+    local result = run_databricks({})
+
+    assert_not_contains(script, "S3_PARALLEL_READ")
+    assert_not_contains(result.sql, "S3_PARALLEL_READ")
+end)
+
+print("")
+print(string.format("=== Results: %d passed, %d failed ===", passed, failed))
+
+if failed > 0 then
+    os.exit(1)
+end

--- a/test/test_db2_to_exasol.lua
+++ b/test/test_db2_to_exasol.lua
@@ -81,18 +81,22 @@ end)
 print("")
 print("=== Generation Tests ===")
 
-test("trims DB2 catalog schema and table filters", function()
+test("trims DB2 catalog schema/table filters case-insensitively", function()
     local result = run_db2()
 
-    assert_contains(result.sql, "rtrim(t.table_schema) like ''DB2DT''")
-    assert_contains(result.sql, "rtrim(t.table_name) like ''CORE_CASE''")
+    assert_contains(result.sql, "upper(rtrim(t.table_schema)) like upper(''DB2DT'')")
+    assert_contains(result.sql, "upper(rtrim(t.table_name)) like upper(''CORE_CASE'')")
     assert_contains(result.sql, "rtrim(t.table_schema) not in")
 end)
 
-test("trims DB2 source table in generated import", function()
+test("quotes DB2 source identifiers in generated import", function()
     local result = run_db2()
 
-    assert_contains(result.sql, "from ' || rtrim(table_schema)|| '.' || rtrim(table_name)")
+    assert_contains(result.sql, [['"' || replace(table_schema, '"', '""') || '"' as "source_table_schema"]])
+    assert_contains(result.sql, [['"' || replace(table_name, '"', '""') || '"' as "source_table_name"]])
+    assert_contains(result.sql, [['"' || replace(column_name, '"', '""') || '"' as "source_column_name"]])
+    assert_contains(result.sql, "then \"source_column_name\"")
+    assert_contains(result.sql, "' from ' || \"source_table_schema\"|| '.' || \"source_table_name\"")
 end)
 
 print("")

--- a/test/test_db2_to_exasol.lua
+++ b/test/test_db2_to_exasol.lua
@@ -1,0 +1,103 @@
+--[[
+  Checks for db2_to_exasol.sql.
+
+  Run: lua test/test_db2_to_exasol.lua
+]]
+
+local passed = 0
+local failed = 0
+
+local function test(name, fn)
+    local ok, err = pcall(fn)
+    if ok then
+        passed = passed + 1
+        print("  PASS: " .. name)
+    else
+        failed = failed + 1
+        print("  FAIL: " .. name .. " -- " .. tostring(err))
+    end
+end
+
+local function assert_contains(actual, pattern, msg)
+    if not tostring(actual):find(pattern, 1, true) then
+        error((msg or "missing expected text") .. ": " .. pattern .. " in " .. tostring(actual))
+    end
+end
+
+local function read_file(path)
+    local f = io.open(path, "r")
+    assert(f, "Could not open " .. path)
+    local content = f:read("*a")
+    f:close()
+    return content
+end
+
+local function extract_lua_block(path)
+    local content = read_file(path)
+    local lua_block = content:match("%)%s*RETURNS TABLE%s*\nAS\n(.-)\n/\n")
+    assert(lua_block, "Could not extract Lua block from " .. path)
+    return lua_block
+end
+
+local db2_lua = extract_lua_block("db2_to_exasol.sql")
+
+local function run_db2()
+    local calls = {}
+    local env = {
+        CONNECTION_NAME = "DB2_CONNECTION",
+        IDENTIFIER_CASE_INSENSITIVE = true,
+        SCHEMA_FILTER = "DB2DT",
+        TABLE_FILTER = "CORE_CASE",
+        string = string,
+        table = table,
+        tostring = tostring,
+        type = type,
+        error = error,
+    }
+
+    env.query = function(sql)
+        calls[#calls + 1] = sql
+        return {{SQL_TEXT = "-- ### SCHEMAS ###"}}
+    end
+
+    local fn, err = load(db2_lua, "db2_to_exasol.lua", "t", env)
+    assert(fn, "Lua load failed: " .. tostring(err))
+
+    local result_rows = fn()
+    return {
+        rows = result_rows,
+        sql = calls[1],
+        calls = calls,
+    }
+end
+
+print("=== Lua Syntax Validation ===")
+
+test("Lua block in db2_to_exasol.sql has valid syntax", function()
+    local fn, err = load(db2_lua)
+    assert(fn, "Lua syntax error in db2_to_exasol.sql: " .. tostring(err))
+end)
+
+print("")
+print("=== Generation Tests ===")
+
+test("trims DB2 catalog schema and table filters", function()
+    local result = run_db2()
+
+    assert_contains(result.sql, "rtrim(t.table_schema) like ''DB2DT''")
+    assert_contains(result.sql, "rtrim(t.table_name) like ''CORE_CASE''")
+    assert_contains(result.sql, "rtrim(t.table_schema) not in")
+end)
+
+test("trims DB2 source table in generated import", function()
+    local result = run_db2()
+
+    assert_contains(result.sql, "from ' || rtrim(table_schema)|| '.' || rtrim(table_name)")
+end)
+
+print("")
+print(string.format("=== Results: %d passed, %d failed ===", passed, failed))
+
+if failed > 0 then
+    os.exit(1)
+end

--- a/test/test_migrate_to_exasol.lua
+++ b/test/test_migrate_to_exasol.lua
@@ -1,0 +1,337 @@
+--[[
+  Checks for migrate_to_exasol.sql.
+
+  Run: lua test/test_migrate_to_exasol.lua
+]]
+
+local passed = 0
+local failed = 0
+
+local function test(name, fn)
+    local ok, err = pcall(fn)
+    if ok then
+        passed = passed + 1
+        print("  PASS: " .. name)
+    else
+        failed = failed + 1
+        print("  FAIL: " .. name .. " -- " .. tostring(err))
+    end
+end
+
+local function assert_eq(actual, expected, msg)
+    if actual ~= expected then
+        error((msg or "") .. " expected: " .. tostring(expected) .. ", got: " .. tostring(actual))
+    end
+end
+
+local function assert_contains(actual, pattern, msg)
+    if not tostring(actual):find(pattern, 1, true) then
+        error((msg or "missing expected text") .. ": " .. pattern .. " in " .. tostring(actual))
+    end
+end
+
+local function read_file(path)
+    local f = io.open(path, "r")
+    assert(f, "Could not open " .. path)
+    local content = f:read("*a")
+    f:close()
+    return content
+end
+
+local function extract_lua_block(path)
+    local content = read_file(path)
+    local lua_block = content:match("%) RETURNS TABLE%s*\nAS\n(.-)\n/\n")
+    assert(lua_block, "Could not extract Lua block from " .. path)
+    return lua_block
+end
+
+local migrate_lua = extract_lua_block("migrate_to_exasol.sql")
+
+local function run_migrate(params)
+    local calls = {}
+    local adapter_rows = params.adapter_rows or {{SQL_TEXT = "select 1"}}
+    local execute_results = params.execute_results or {}
+
+    local env = {
+        SOURCE_TYPE = params.source_type,
+        CONNECTION_NAME = params.connection_name or "SRC_CONN",
+        CONNECTION_TYPE = params.connection_type,
+        DB_FILTER = params.db_filter,
+        SCHEMA_FILTER = params.schema_filter,
+        TABLE_FILTER = params.table_filter,
+        TARGET_SCHEMA = params.target_schema,
+        IDENTIFIER_CASE_INSENSITIVE = params.identifier_case_insensitive,
+        DEBUG = params.debug,
+        OPTIONS = params.options,
+        string = string,
+        table = table,
+        math = math,
+        tostring = tostring,
+        tonumber = tonumber,
+        type = type,
+        error = error,
+    }
+
+    env.pquery = function(sql)
+        calls[#calls + 1] = sql
+        if #calls == 1 then
+            if params.adapter_error then
+                return false, {
+                    error_message = params.adapter_error,
+                    statement_text = sql,
+                }
+            end
+            return true, adapter_rows
+        end
+
+        local result = execute_results[#calls - 1]
+        if result and result.success == false then
+            return false, {error_message = result.error_message or "execution failed"}
+        end
+        return true, {rows_affected = 0}
+    end
+
+    local fn, err = load(migrate_lua, "migrate_to_exasol.lua", "t", env)
+    assert(fn, "Lua load failed: " .. tostring(err))
+
+    local rows, columns = fn()
+    return {
+        rows = rows,
+        columns = columns,
+        calls = calls,
+        adapter_sql = calls[1],
+    }
+end
+
+local function default_case(source_type, expected_sql)
+    test("dispatches " .. source_type, function()
+        local result = run_migrate({
+            source_type = source_type,
+            connection_type = "JDBC",
+            db_filter = "DB",
+            schema_filter = "SCH",
+            table_filter = "TBL",
+            target_schema = "DST",
+            identifier_case_insensitive = true,
+            debug = true,
+            options = "",
+        })
+        assert_eq(result.adapter_sql, expected_sql)
+        assert_eq(result.rows[1][1], "select 1")
+        assert_eq(result.rows[1][2], "PREVIEW")
+        assert_eq(result.columns, "SQL_TEXT VARCHAR(2000000), SUCCESS VARCHAR(10), ERROR_MESSAGE VARCHAR(20000)")
+    end)
+end
+
+print("=== Lua Syntax Validation ===")
+
+test("Lua block in migrate_to_exasol.sql has valid syntax", function()
+    local fn, err = load(migrate_lua)
+    assert(fn, "Lua syntax error in migrate_to_exasol.sql: " .. tostring(err))
+end)
+
+print("")
+print("=== MIGRATE_TO_EXASOL Dispatch Tests ===")
+
+default_case("MYSQL", "EXECUTE SCRIPT database_migration.MYSQL_TO_EXASOL('SRC_CONN',TRUE,'SCH','TBL')")
+default_case("MARIADB", "EXECUTE SCRIPT database_migration.MARIADB_TO_EXASOL('SRC_CONN',TRUE,'SCH','TBL')")
+default_case("POSTGRES", "EXECUTE SCRIPT database_migration.POSTGRES_TO_EXASOL('SRC_CONN',TRUE,'SCH','TBL','DST')")
+default_case("REDSHIFT", "EXECUTE SCRIPT database_migration.REDSHIFT_TO_EXASOL('SRC_CONN',TRUE,'SCH','TBL')")
+default_case("DB2", "EXECUTE SCRIPT database_migration.DB2_TO_EXASOL('SRC_CONN',TRUE,'SCH','TBL')")
+default_case("VERTICA", "EXECUTE SCRIPT database_migration.VERTICA_TO_EXASOL('SRC_CONN',TRUE,'SCH','TBL')")
+default_case("HANA", "EXECUTE SCRIPT database_migration.HANA_TO_EXASOL('SRC_CONN',TRUE,'SCH','TBL')")
+default_case("AZURE_SQL", "EXECUTE SCRIPT database_migration.AZURE_SQL_TO_EXASOL('SRC_CONN','SCH','TBL',TRUE)")
+default_case("BIGQUERY", "EXECUTE SCRIPT database_migration.BIGQUERY_TO_EXASOL('SRC_CONN',TRUE,'DB','SCH','TBL')")
+default_case("DATABRICKS", "EXECUTE SCRIPT database_migration.DATABRICKS_TO_EXASOL('SRC_CONN',TRUE,'DB','SCH','DST','TBL',TRUE)")
+default_case("SQLSERVER", "EXECUTE SCRIPT database_migration.SQLSERVER_TO_EXASOL('SRC_CONN',FALSE,'DB','SCH','DST','TBL',TRUE)")
+default_case("SNOWFLAKE", "EXECUTE SCRIPT database_migration.SNOWFLAKE_TO_EXASOL('SRC_CONN',FALSE,'DB','SCH','DST','TBL',TRUE)")
+default_case("ORACLE", "EXECUTE SCRIPT database_migration.ORACLE_TO_EXASOL('SRC_CONN',TRUE,'SCH','TBL',1,FALSE,FALSE,FALSE)")
+default_case("TERADATA", "EXECUTE SCRIPT database_migration.TERADATA_TO_EXASOL('SRC_CONN',TRUE,'SCH','TBL',FALSE)")
+default_case("EXASOL", "EXECUTE SCRIPT database_migration.EXASOL_TO_EXASOL('SRC_CONN','JDBC',TRUE,'SCH','TBL','FALSE','%','DISABLE')")
+default_case("NETEZZA", "EXECUTE SCRIPT database_migration.NETEZZA_TO_EXASOL('SRC_CONN','DB','SCH','TBL',TRUE)")
+default_case("VECTORWISE", "EXECUTE SCRIPT database_migration.VECTORWISE_TO_EXASOL('SRC_CONN',TRUE,'TBL')")
+
+print("")
+print("=== Alias And Option Tests ===")
+
+test("source aliases normalize before dispatch", function()
+    local result = run_migrate({
+        source_type = "sql server",
+        db_filter = "DB",
+        schema_filter = "SCH",
+        table_filter = "TBL",
+        target_schema = "DST",
+    })
+    assert_eq(result.adapter_sql, "EXECUTE SCRIPT database_migration.SQLSERVER_TO_EXASOL('SRC_CONN',FALSE,'DB','SCH','DST','TBL',TRUE)")
+end)
+
+test("Databricks aliases normalize before dispatch", function()
+    local result = run_migrate({
+        source_type = "databricks sql",
+        db_filter = "CAT",
+        schema_filter = "SCH",
+        table_filter = "TBL",
+        target_schema = "DST",
+        options = "CATALOG2SCHEMA=false",
+    })
+    assert_eq(result.adapter_sql, "EXECUTE SCRIPT database_migration.DATABRICKS_TO_EXASOL('SRC_CONN',FALSE,'CAT','SCH','DST','TBL',TRUE)")
+end)
+
+test("string literals are escaped in generated adapter calls", function()
+    local result = run_migrate({
+        source_type = "MYSQL",
+        connection_name = "CONN'X",
+        schema_filter = "S'CH",
+        table_filter = "T'BL",
+    })
+    assert_eq(result.adapter_sql, "EXECUTE SCRIPT database_migration.MYSQL_TO_EXASOL('CONN''X',TRUE,'S''CH','T''BL')")
+end)
+
+test("Snowflake DB2SCHEMA option is forwarded", function()
+    local result = run_migrate({
+        source_type = "SNOWFLAKE",
+        db_filter = "DB",
+        schema_filter = "SCH",
+        table_filter = "TBL",
+        target_schema = "DST",
+        options = "DB2SCHEMA=true",
+    })
+    assert_eq(result.adapter_sql, "EXECUTE SCRIPT database_migration.SNOWFLAKE_TO_EXASOL('SRC_CONN',TRUE,'DB','SCH','DST','TBL',TRUE)")
+end)
+
+test("Oracle options are forwarded", function()
+    local result = run_migrate({
+        source_type = "ORACLE",
+        schema_filter = "SCH",
+        table_filter = "TBL",
+        options = "PARALLEL_STATEMENTS=4;CREATE_PK=yes;CREATE_FK=1;CHECK_MIGRATION=true",
+    })
+    assert_eq(result.adapter_sql, "EXECUTE SCRIPT database_migration.ORACLE_TO_EXASOL('SRC_CONN',TRUE,'SCH','TBL',4,TRUE,TRUE,TRUE)")
+end)
+
+test("Exasol options and connection type are forwarded", function()
+    local result = run_migrate({
+        source_type = "EXASOL",
+        connection_type = "exa",
+        schema_filter = "SCH",
+        table_filter = "TBL",
+        options = "GENERATE_VIEWS=TRUE;VIEW_FILTER=VW%;PK_SETTING=ENABLE",
+    })
+    assert_eq(result.adapter_sql, "EXECUTE SCRIPT database_migration.EXASOL_TO_EXASOL('SRC_CONN','EXA',TRUE,'SCH','TBL','TRUE','VW%','ENABLE')")
+end)
+
+test("BigQuery PROJECT_ID option overrides DB_FILTER", function()
+    local result = run_migrate({
+        source_type = "BIGQUERY",
+        db_filter = "DB",
+        schema_filter = "SCH",
+        table_filter = "TBL",
+        options = "PROJECT_ID=PROJECT",
+    })
+    assert_eq(result.adapter_sql, "EXECUTE SCRIPT database_migration.BIGQUERY_TO_EXASOL('SRC_CONN',TRUE,'PROJECT','SCH','TBL')")
+end)
+
+print("")
+print("=== Execution Mode Tests ===")
+
+test("DEBUG false runs generated statements for non-native adapters", function()
+    local result = run_migrate({
+        source_type = "MYSQL",
+        schema_filter = "SCH",
+        table_filter = "TBL",
+        debug = false,
+        adapter_rows = {
+            {SQL_TEXT = "-- comment"},
+            {SQL_TEXT = "create table t(c int)"},
+        },
+    })
+
+    assert_eq(#result.calls, 2)
+    assert_eq(result.calls[2], "create table t(c int)")
+    assert_eq(result.rows[1][1], "-- The following statements were executed successfully.")
+    assert_eq(result.rows[2][2], "SKIPPED")
+    assert_eq(result.rows[3][2], "TRUE")
+end)
+
+test("DEBUG false runs Snowflake generated statements", function()
+    local result = run_migrate({
+        source_type = "SNOWFLAKE",
+        debug = false,
+        adapter_rows = {
+            {SQL_TEXT = "create table t(c int)"},
+        },
+    })
+
+    assert_eq(#result.calls, 2)
+    assert_eq(result.calls[2], "create table t(c int)")
+    assert_eq(result.rows[1][1], "-- The following statements were executed successfully.")
+    assert_eq(result.rows[2][2], "TRUE")
+end)
+
+print("")
+print("=== Error Handling Tests ===")
+
+test("unsupported source raises a clear error", function()
+    local ok, err = pcall(run_migrate, {source_type = "UNKNOWN"})
+    assert_eq(ok, false)
+    assert_contains(err, "Unsupported SOURCE_TYPE")
+end)
+
+test("S3 points users to the direct loader", function()
+    local ok, err = pcall(run_migrate, {source_type = "S3"})
+    assert_eq(ok, false)
+    assert_contains(err, "S3 is not supported by MIGRATE_TO_EXASOL")
+    assert_contains(err, "S3_PARALLEL_READ")
+end)
+
+test("missing connection raises a clear error", function()
+    local ok, err = pcall(run_migrate, {source_type = "MYSQL", connection_name = ""})
+    assert_eq(ok, false)
+    assert_contains(err, "CONNECTION_NAME is required")
+end)
+
+test("BigQuery requires PROJECT_ID when DB_FILTER is wildcard", function()
+    local ok, err = pcall(run_migrate, {
+        source_type = "BIGQUERY",
+        db_filter = "%",
+        schema_filter = "SCH",
+        table_filter = "TBL",
+    })
+    assert_eq(ok, false)
+    assert_contains(err, "OPTIONS PROJECT_ID for BIGQUERY is required")
+end)
+
+test("invalid boolean option raises a clear error", function()
+    local ok, err = pcall(run_migrate, {
+        source_type = "SNOWFLAKE",
+        options = "DB2SCHEMA=maybe",
+    })
+    assert_eq(ok, false)
+    assert_contains(err, "Invalid boolean for DB2SCHEMA")
+end)
+
+test("invalid DEBUG raises a clear error", function()
+    local ok, err = pcall(run_migrate, {
+        source_type = "MYSQL",
+        debug = "maybe",
+    })
+    assert_eq(ok, false)
+    assert_contains(err, "Invalid boolean for DEBUG")
+end)
+
+test("adapter errors include source statement", function()
+    local ok, err = pcall(run_migrate, {
+        source_type = "MYSQL",
+        adapter_error = "adapter failed",
+    })
+    assert_eq(ok, false)
+    assert_contains(err, "adapter failed")
+    assert_contains(err, "MYSQL_TO_EXASOL")
+end)
+
+print("")
+print(string.format("=== Results: %d passed, %d failed ===", passed, failed))
+
+if failed > 0 then
+    os.exit(1)
+end

--- a/test/test_migrate_to_exasol.lua
+++ b/test/test_migrate_to_exasol.lua
@@ -66,10 +66,13 @@ local function run_migrate(params)
         string = string,
         table = table,
         math = math,
+        os = os,
         tostring = tostring,
         tonumber = tonumber,
         type = type,
         error = error,
+        ipairs = ipairs,
+        pairs = pairs,
     }
 
     env.pquery = function(sql)
@@ -88,7 +91,8 @@ local function run_migrate(params)
         if result and result.success == false then
             return false, {error_message = result.error_message or "execution failed"}
         end
-        return true, {rows_affected = 0}
+        local affected = (result and result.rows_affected) or 0
+        return true, {rows_affected = affected}
     end
 
     local fn, err = load(migrate_lua, "migrate_to_exasol.lua", "t", env)
@@ -102,6 +106,8 @@ local function run_migrate(params)
         adapter_sql = calls[1],
     }
 end
+
+local AUDIT_COLUMNS = "STEP_KIND VARCHAR(40), TARGET_OBJ VARCHAR(2000), ROWS_AFFECTED DECIMAL(18,0), ELAPSED_MS DECIMAL(18,0), RESULT_FLAG VARCHAR(20), SQL_TEXT VARCHAR(2000000), ERROR_MESSAGE VARCHAR(20000)"
 
 local function default_case(source_type, expected_sql)
     test("dispatches " .. source_type, function()
@@ -117,9 +123,12 @@ local function default_case(source_type, expected_sql)
             options = "",
         })
         assert_eq(result.adapter_sql, expected_sql)
-        assert_eq(result.rows[1][1], "select 1")
-        assert_eq(result.rows[1][2], "PREVIEW")
-        assert_eq(result.columns, "SQL_TEXT VARCHAR(2000000), SUCCESS VARCHAR(10), ERROR_MESSAGE VARCHAR(20000)")
+        assert_eq(result.rows[1][1], "OTHER")
+        assert_eq(result.rows[1][5], "PREVIEW")
+        assert_eq(result.rows[1][6], "select 1")
+        assert_eq(result.rows[2][1], "SUMMARY")
+        assert_eq(result.rows[2][5], "PREVIEW")
+        assert_eq(result.columns, AUDIT_COLUMNS)
     end)
 end
 
@@ -248,9 +257,12 @@ test("DEBUG false runs generated statements for non-native adapters", function()
 
     assert_eq(#result.calls, 2)
     assert_eq(result.calls[2], "create table t(c int)")
-    assert_eq(result.rows[1][1], "-- The following statements were executed successfully.")
-    assert_eq(result.rows[2][2], "SKIPPED")
-    assert_eq(result.rows[3][2], "TRUE")
+    assert_eq(result.rows[1][1], "INFO")
+    assert_eq(result.rows[1][5], "SKIPPED")
+    assert_eq(result.rows[2][1], "CREATE_TABLE")
+    assert_eq(result.rows[2][5], "OK")
+    assert_eq(result.rows[3][1], "SUMMARY")
+    assert_eq(result.rows[3][5], "OK")
 end)
 
 test("DEBUG false runs Snowflake generated statements", function()
@@ -264,8 +276,10 @@ test("DEBUG false runs Snowflake generated statements", function()
 
     assert_eq(#result.calls, 2)
     assert_eq(result.calls[2], "create table t(c int)")
-    assert_eq(result.rows[1][1], "-- The following statements were executed successfully.")
-    assert_eq(result.rows[2][2], "TRUE")
+    assert_eq(result.rows[1][1], "CREATE_TABLE")
+    assert_eq(result.rows[1][5], "OK")
+    assert_eq(result.rows[2][1], "SUMMARY")
+    assert_eq(result.rows[2][5], "OK")
 end)
 
 test("DEBUG false reports no executable generated statements", function()
@@ -279,9 +293,13 @@ test("DEBUG false reports no executable generated statements", function()
     })
 
     assert_eq(#result.calls, 1)
-    assert_eq(result.rows[1][1], "-- No executable SQL statements were generated.")
-    assert_eq(result.rows[2][2], "SKIPPED")
-    assert_eq(result.rows[3][2], "SKIPPED")
+    assert_eq(result.rows[1][1], "INFO")
+    assert_eq(result.rows[1][5], "SKIPPED")
+    assert_eq(result.rows[2][1], "INFO")
+    assert_eq(result.rows[2][5], "SKIPPED")
+    assert_eq(result.rows[3][1], "SUMMARY")
+    assert_eq(result.rows[3][2], "No executable SQL generated")
+    assert_eq(result.rows[3][5], "SKIPPED")
 end)
 
 test("DEBUG false reports empty adapter output", function()
@@ -293,8 +311,61 @@ test("DEBUG false reports empty adapter output", function()
 
     assert_eq(#result.calls, 1)
     assert_eq(#result.rows, 1)
-    assert_eq(result.rows[1][1], "-- No executable SQL statements were generated.")
-    assert_eq(result.rows[1][2], "SKIPPED")
+    assert_eq(result.rows[1][1], "SUMMARY")
+    assert_eq(result.rows[1][2], "No executable SQL generated")
+    assert_eq(result.rows[1][5], "SKIPPED")
+end)
+
+test("STEP_KIND classifies CREATE_SCHEMA / CREATE_TABLE / IMPORT", function()
+    local result = run_migrate({
+        source_type = "MYSQL",
+        debug = false,
+        adapter_rows = {
+            {SQL_TEXT = 'create schema if not exists "MART"'},
+            {SQL_TEXT = 'create or replace table "MART"."ORDERS" ("ID" DECIMAL(18,0))'},
+            {SQL_TEXT = 'import into "MART"."ORDERS" from jdbc at SRC_CONN statement \'select id from orders\''},
+        },
+    })
+
+    assert_eq(result.rows[1][1], "CREATE_SCHEMA")
+    assert_eq(result.rows[1][2], "MART")
+    assert_eq(result.rows[2][1], "CREATE_TABLE")
+    assert_eq(result.rows[2][2], "MART.ORDERS")
+    assert_eq(result.rows[3][1], "IMPORT")
+    assert_eq(result.rows[3][2], "MART.ORDERS")
+    assert_eq(result.rows[4][1], "SUMMARY")
+end)
+
+test("ROWS_AFFECTED captured for IMPORT in execute mode", function()
+    local result = run_migrate({
+        source_type = "MYSQL",
+        debug = false,
+        adapter_rows = {
+            {SQL_TEXT = 'import into "M"."T" from jdbc at SRC statement \'select 1\''},
+        },
+        execute_results = {[1] = {success = true, rows_affected = 42}},
+    })
+
+    assert_eq(result.rows[1][1], "IMPORT")
+    assert_eq(result.rows[1][3], 42)
+    assert_eq(result.rows[2][1], "SUMMARY")
+    assert_eq(result.rows[2][3], 42)
+end)
+
+test("Errors mark RESULT_FLAG ERROR and SUMMARY ERROR", function()
+    local result = run_migrate({
+        source_type = "MYSQL",
+        debug = false,
+        adapter_rows = {
+            {SQL_TEXT = 'create table "T" ("c" INT)'},
+        },
+        execute_results = {[1] = {success = false, error_message = "boom"}},
+    })
+
+    assert_eq(result.rows[1][5], "ERROR")
+    assert_eq(result.rows[1][7], "boom")
+    assert_eq(result.rows[2][1], "SUMMARY")
+    assert_eq(result.rows[2][5], "ERROR")
 end)
 
 print("")

--- a/test/test_migrate_to_exasol.lua
+++ b/test/test_migrate_to_exasol.lua
@@ -268,6 +268,35 @@ test("DEBUG false runs Snowflake generated statements", function()
     assert_eq(result.rows[2][2], "TRUE")
 end)
 
+test("DEBUG false reports no executable generated statements", function()
+    local result = run_migrate({
+        source_type = "MYSQL",
+        debug = false,
+        adapter_rows = {
+            {SQL_TEXT = "-- ### SCHEMAS ###"},
+            {SQL_TEXT = "-- ### TABLES ###"},
+        },
+    })
+
+    assert_eq(#result.calls, 1)
+    assert_eq(result.rows[1][1], "-- No executable SQL statements were generated.")
+    assert_eq(result.rows[2][2], "SKIPPED")
+    assert_eq(result.rows[3][2], "SKIPPED")
+end)
+
+test("DEBUG false reports empty adapter output", function()
+    local result = run_migrate({
+        source_type = "MYSQL",
+        debug = false,
+        adapter_rows = {},
+    })
+
+    assert_eq(#result.calls, 1)
+    assert_eq(#result.rows, 1)
+    assert_eq(result.rows[1][1], "-- No executable SQL statements were generated.")
+    assert_eq(result.rows[1][2], "SKIPPED")
+end)
+
 print("")
 print("=== Error Handling Tests ===")
 

--- a/test/test_migrate_to_exasol_runtime.py
+++ b/test/test_migrate_to_exasol_runtime.py
@@ -124,23 +124,33 @@ def main() -> int:
     for source, (script_name, _) in ADAPTERS.items():
         rows = conn.execute(wrapper_call(source, debug=True)).fetchall()
         assert rows, f"{source} preview returned no rows"
-        assert_contains(rows[0][0], f"MOCK {script_name}")
+        if rows[0][0] != "INFO":
+            raise AssertionError(f"{source} first row STEP_KIND expected INFO, got {rows[0][0]}")
+        assert_contains(rows[0][5], f"MOCK {script_name}")
+        if rows[-1][0] != "SUMMARY" or rows[-1][4] != "PREVIEW":
+            raise AssertionError(f"{source} missing SUMMARY/PREVIEW tail row: {rows[-1]}")
     print(f"preview_dispatch={len(ADAPTERS)}")
 
     for source in ("MYSQL", "SNOWFLAKE", "DATABRICKS", "ORACLE"):
         rows = conn.execute(wrapper_call(source, debug=False)).fetchall()
-        if rows[0][1] != "SKIPPED" or "executed successfully" not in rows[0][0]:
-            raise AssertionError(f"{source} did not report successful execution: {rows[0]}")
+        summary = rows[-1]
+        if summary[0] != "SUMMARY" or summary[4] != "OK":
+            raise AssertionError(f"{source} did not report SUMMARY/OK: {summary}")
         script_name = ADAPTERS[source][0]
         table_name = script_name.replace("_TO_EXASOL", "")
         count = conn.execute(f'select count(*) from "{target_schema}"."{table_name}"').fetchval()
         if count != 1:
             raise AssertionError(f"{source} expected 1 loaded row, got {count}")
+        kinds = {row[0] for row in rows}
+        for required in ("CREATE_SCHEMA", "CREATE_TABLE", "IMPORT", "SUMMARY"):
+            if required not in kinds:
+                raise AssertionError(f"{source} missing STEP_KIND={required}; got {kinds}")
     print("execute_representative=4")
 
     rows = conn.execute(wrapper_call("MYSQL", debug=False, table_filter="EMPTY")).fetchall()
-    if rows[0][0] != "-- No executable SQL statements were generated.":
-        raise AssertionError(f"Expected no-op summary, got {rows[0]}")
+    summary = rows[-1]
+    if summary[0] != "SUMMARY" or summary[1] != "No executable SQL generated" or summary[4] != "SKIPPED":
+        raise AssertionError(f"Expected no-op SUMMARY row, got {summary}")
     print("empty_execution=pass")
 
     try:
@@ -160,7 +170,9 @@ def main() -> int:
     print("s3_rejection=pass")
 
     rows = conn.execute(wrapper_call("DATABRICKS_SQL", debug=True)).fetchall()
-    assert_contains(rows[0][0], "MOCK DATABRICKS_TO_EXASOL")
+    assert_contains(rows[0][5], "MOCK DATABRICKS_TO_EXASOL")
+    if rows[-1][0] != "SUMMARY":
+        raise AssertionError(f"Alias dispatch missing SUMMARY: {rows[-1]}")
     print("alias_dispatch=pass")
     return 0
 

--- a/test/test_migrate_to_exasol_runtime.py
+++ b/test/test_migrate_to_exasol_runtime.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Runtime smoke test for MIGRATE_TO_EXASOL using local mock adapters.
+
+This test replaces scripts in DATABASE_MIGRATION on the target Exasol database.
+Run it only against a disposable local database.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import ssl
+import time
+from pathlib import Path
+
+import pyexasol
+
+
+REPO = Path(__file__).resolve().parents[1]
+
+ADAPTERS = {
+    "MYSQL": ("MYSQL_TO_EXASOL", "CONNECTION_NAME, IDENTIFIER_CASE_INSENSITIVE, SCHEMA_FILTER, TABLE_FILTER"),
+    "MARIADB": ("MARIADB_TO_EXASOL", "CONNECTION_NAME, IDENTIFIER_CASE_INSENSITIVE, SCHEMA_FILTER, TABLE_FILTER"),
+    "POSTGRES": ("POSTGRES_TO_EXASOL", "CONNECTION_NAME, IDENTIFIER_CASE_INSENSITIVE, SCHEMA_FILTER, TABLE_FILTER, TARGET_SCHEMA"),
+    "REDSHIFT": ("REDSHIFT_TO_EXASOL", "CONNECTION_NAME, IDENTIFIER_CASE_INSENSITIVE, SCHEMA_FILTER, TABLE_FILTER"),
+    "DB2": ("DB2_TO_EXASOL", "CONNECTION_NAME, IDENTIFIER_CASE_INSENSITIVE, SCHEMA_FILTER, TABLE_FILTER"),
+    "VERTICA": ("VERTICA_TO_EXASOL", "CONNECTION_NAME, IDENTIFIER_CASE_INSENSITIVE, SCHEMA_FILTER, TABLE_FILTER"),
+    "HANA": ("HANA_TO_EXASOL", "CONNECTION_NAME, IDENTIFIER_CASE_INSENSITIVE, SCHEMA_FILTER, TABLE_FILTER"),
+    "AZURE_SQL": ("AZURE_SQL_TO_EXASOL", "CONNECTION_NAME, SCHEMA_FILTER, TABLE_FILTER, IDENTIFIER_CASE_INSENSITIVE"),
+    "BIGQUERY": ("BIGQUERY_TO_EXASOL", "CONNECTION_NAME, IDENTIFIER_CASE_INSENSITIVE, PROJECT_ID, SCHEMA_FILTER, TABLE_FILTER"),
+    "DATABRICKS": ("DATABRICKS_TO_EXASOL", "CONNECTION_NAME, CATALOG2SCHEMA, CATALOG_FILTER, SCHEMA_FILTER, TARGET_SCHEMA, TABLE_FILTER, IDENTIFIER_CASE_INSENSITIVE"),
+    "SQLSERVER": ("SQLSERVER_TO_EXASOL", "CONNECTION_NAME, DB2SCHEMA, DB_FILTER, SCHEMA_FILTER, TARGET_SCHEMA, TABLE_FILTER, IDENTIFIER_CASE_INSENSITIVE"),
+    "SNOWFLAKE": ("SNOWFLAKE_TO_EXASOL", "CONNECTION_NAME, DB2SCHEMA, DB_FILTER, SCHEMA_FILTER, TARGET_SCHEMA, TABLE_FILTER, IDENTIFIER_CASE_INSENSITIVE"),
+    "ORACLE": ("ORACLE_TO_EXASOL", "CONNECTION_NAME, IDENTIFIER_CASE_INSENSITIVE, SCHEMA_FILTER, TABLE_FILTER, PARALLEL_STATEMENTS, CREATE_PK, CREATE_FK, CHECK_MIGRATION"),
+    "TERADATA": ("TERADATA_TO_EXASOL", "CONNECTION_NAME, IDENTIFIER_CASE_INSENSITIVE, SCHEMA_FILTER, TABLE_FILTER, CHECK_MIGRATION"),
+    "EXASOL": ("EXASOL_TO_EXASOL", "CONNECTION_NAME, CONNECTION_TYPE, IDENTIFIER_CASE_INSENSITIVE, SCHEMA_FILTER, TABLE_FILTER, GENERATE_VIEWS, VIEW_FILTER, PK_SETTING"),
+    "NETEZZA": ("NETEZZA_TO_EXASOL", "CONNECTION_NAME, DB_FILTER, SCHEMA_FILTER, TABLE_FILTER, IDENTIFIER_CASE_INSENSITIVE"),
+    "VECTORWISE": ("VECTORWISE_TO_EXASOL", "CONNECTION_NAME, IDENTIFIER_CASE_INSENSITIVE, TABLE_FILTER"),
+}
+
+
+def extract_create_script(path: Path, script_name: str) -> str:
+    content = path.read_text()
+    pattern = rf"create or replace script database_migration\.{script_name}\(.*?\n/\n"
+    match = re.search(pattern, content, flags=re.IGNORECASE | re.DOTALL)
+    if not match:
+        raise AssertionError(f"Could not extract {script_name} from {path}")
+    return match.group(0)
+
+
+def sql_string(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def connect() -> pyexasol.ExaConnection:
+    return pyexasol.connect(
+        dsn=os.environ.get("EXA_DSN", "localhost:8566"),
+        user=os.environ.get("EXA_USER", "sys"),
+        password=os.environ.get("EXA_PASSWORD", "exasol"),
+        encryption=os.environ.get("EXA_ENCRYPTION", "true").lower() != "false",
+        websocket_sslopt={"cert_reqs": ssl.CERT_NONE},
+    )
+
+
+def mock_adapter_sql(script_name: str, params: str, target_schema: str) -> str:
+    table_name = script_name.replace("_TO_EXASOL", "")
+    return f"""
+create or replace script database_migration.{script_name}({params}) returns table
+as
+if TABLE_FILTER == 'ADAPTER_FAIL' then
+    error('mock adapter failed')
+end
+
+if TABLE_FILTER == 'EMPTY' then
+    return {{
+        {{'-- MOCK {script_name} EMPTY'}}
+    }}, 'SQL_TEXT VARCHAR(2000000)'
+end
+
+return {{
+    {{'-- MOCK {script_name}'}},
+    {{'create schema if not exists "{target_schema}";'}},
+    {{'create or replace table "{target_schema}"."{table_name}"("C" DECIMAL(18,0));'}},
+    {{'insert into "{target_schema}"."{table_name}" values 1;'}}
+}}, 'SQL_TEXT VARCHAR(2000000)'
+/
+"""
+
+
+def wrapper_call(source: str, debug: bool, table_filter: str = "TBL") -> str:
+    return (
+        "execute script database_migration.MIGRATE_TO_EXASOL("
+        f"{sql_string(source)},"
+        "'MOCK_CONN',"
+        "'JDBC',"
+        "'DB',"
+        "'SCH',"
+        f"{sql_string(table_filter)},"
+        "'TARGET_SCHEMA',"
+        "TRUE,"
+        f"{'TRUE' if debug else 'FALSE'},"
+        "'PROJECT_ID=PROJECT;CATALOG2SCHEMA=true'"
+        ")"
+    )
+
+
+def assert_contains(text: str, expected: str) -> None:
+    if expected not in text:
+        raise AssertionError(f"Expected {expected!r} in {text!r}")
+
+
+def deploy_runtime_objects(conn: pyexasol.ExaConnection, target_schema: str) -> None:
+    conn.execute("create schema if not exists database_migration")
+    conn.execute(extract_create_script(REPO / "migrate_to_exasol.sql", "MIGRATE_TO_EXASOL"))
+    for script_name, params in ADAPTERS.values():
+        conn.execute(mock_adapter_sql(script_name, params, target_schema))
+
+
+def main() -> int:
+    target_schema = "MIGRATE_WRAPPER_RT_" + str(int(time.time()))
+    conn = connect()
+    deploy_runtime_objects(conn, target_schema)
+
+    for source, (script_name, _) in ADAPTERS.items():
+        rows = conn.execute(wrapper_call(source, debug=True)).fetchall()
+        assert rows, f"{source} preview returned no rows"
+        assert_contains(rows[0][0], f"MOCK {script_name}")
+    print(f"preview_dispatch={len(ADAPTERS)}")
+
+    for source in ("MYSQL", "SNOWFLAKE", "DATABRICKS", "ORACLE"):
+        rows = conn.execute(wrapper_call(source, debug=False)).fetchall()
+        if rows[0][1] != "SKIPPED" or "executed successfully" not in rows[0][0]:
+            raise AssertionError(f"{source} did not report successful execution: {rows[0]}")
+        script_name = ADAPTERS[source][0]
+        table_name = script_name.replace("_TO_EXASOL", "")
+        count = conn.execute(f'select count(*) from "{target_schema}"."{table_name}"').fetchval()
+        if count != 1:
+            raise AssertionError(f"{source} expected 1 loaded row, got {count}")
+    print("execute_representative=4")
+
+    rows = conn.execute(wrapper_call("MYSQL", debug=False, table_filter="EMPTY")).fetchall()
+    if rows[0][0] != "-- No executable SQL statements were generated.":
+        raise AssertionError(f"Expected no-op summary, got {rows[0]}")
+    print("empty_execution=pass")
+
+    try:
+        conn.execute(wrapper_call("MYSQL", debug=True, table_filter="ADAPTER_FAIL")).fetchall()
+        raise AssertionError("Adapter failure did not raise")
+    except Exception as exc:
+        message = str(exc)
+        assert_contains(message, "mock adapter failed")
+        assert_contains(message, "MYSQL_TO_EXASOL")
+    print("adapter_error=pass")
+
+    try:
+        conn.execute(wrapper_call("S3", debug=True)).fetchall()
+        raise AssertionError("S3 did not raise")
+    except Exception as exc:
+        assert_contains(str(exc), "S3 is not supported by MIGRATE_TO_EXASOL")
+    print("s3_rejection=pass")
+
+    rows = conn.execute(wrapper_call("DATABRICKS_SQL", debug=True)).fetchall()
+    assert_contains(rows[0][0], "MOCK DATABRICKS_TO_EXASOL")
+    print("alias_dispatch=pass")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_postgres_to_exasol.lua
+++ b/test/test_postgres_to_exasol.lua
@@ -90,6 +90,50 @@ test("quotes Postgres source identifiers in generated import", function()
     assert_contains(result.sql, "replace(\"table_name\", '\"', '\"\"')")
 end)
 
+local function run_postgres_with_dest_schema(dest_value, null_sentinel)
+    local calls = {}
+    local env = {
+        CONNECTION_NAME = "POSTGRES_CONNECTION",
+        IDENTIFIER_CASE_INSENSITIVE = true,
+        SCHEMA_FILTER = "%",
+        TABLE_FILTER = "smoke",
+        DEST_SCHEMA = dest_value,
+        null = null_sentinel,
+        string = string,
+        table = table,
+        tostring = tostring,
+        type = type,
+        error = error,
+    }
+    env.query = function(sql)
+        calls[#calls + 1] = sql
+        return {{SQL_TEXT = "-- ### SCHEMAS ###"}}
+    end
+    local fn, err = load(postgres_lua, "postgres_to_exasol.lua", "t", env)
+    assert(fn, "Lua load failed: " .. tostring(err))
+    local ok, perr = pcall(fn)
+    return {ok = ok, err = perr, sql = calls[1]}
+end
+
+test("treats Exasol null sentinel DEST_SCHEMA as no override", function()
+    local null_sentinel = {}  -- stand-in for Exasol null userdata
+    local r = run_postgres_with_dest_schema(null_sentinel, null_sentinel)
+    assert(r.ok, "adapter errored on null DEST_SCHEMA: " .. tostring(r.err))
+    assert_contains(r.sql, 'upper("table_schema")')
+end)
+
+test("treats nil DEST_SCHEMA as no override", function()
+    local r = run_postgres_with_dest_schema(nil, nil)
+    assert(r.ok, "adapter errored on nil DEST_SCHEMA: " .. tostring(r.err))
+    assert_contains(r.sql, 'upper("table_schema")')
+end)
+
+test("uses DEST_SCHEMA literal when provided", function()
+    local r = run_postgres_with_dest_schema("MY_DST", nil)
+    assert(r.ok, "adapter errored on valid DEST_SCHEMA: " .. tostring(r.err))
+    assert_contains(r.sql, "'MY_DST'")
+end)
+
 print("")
 print(string.format("=== Results: %d passed, %d failed ===", passed, failed))
 

--- a/test/test_postgres_to_exasol.lua
+++ b/test/test_postgres_to_exasol.lua
@@ -1,0 +1,98 @@
+--[[
+  Checks for postgres_to_exasol.sql.
+
+  Run: lua test/test_postgres_to_exasol.lua
+]]
+
+local passed = 0
+local failed = 0
+
+local function test(name, fn)
+    local ok, err = pcall(fn)
+    if ok then
+        passed = passed + 1
+        print("  PASS: " .. name)
+    else
+        failed = failed + 1
+        print("  FAIL: " .. name .. " -- " .. tostring(err))
+    end
+end
+
+local function assert_contains(actual, pattern, msg)
+    if not tostring(actual):find(pattern, 1, true) then
+        error((msg or "missing expected text") .. ": " .. pattern .. " in " .. tostring(actual))
+    end
+end
+
+local function read_file(path)
+    local f = io.open(path, "r")
+    assert(f, "Could not open " .. path)
+    local content = f:read("*a")
+    f:close()
+    return content
+end
+
+local function extract_lua_block(path)
+    local content = read_file(path)
+    local lua_block = content:match("%) RETURNS TABLE%s*\nAS\n(.-)\n/\n")
+    assert(lua_block, "Could not extract Lua block from " .. path)
+    return lua_block
+end
+
+local postgres_lua = extract_lua_block("postgres_to_exasol.sql")
+
+local function run_postgres()
+    local calls = {}
+    local env = {
+        CONNECTION_NAME = "POSTGRES_CONNECTION",
+        IDENTIFIER_CASE_INSENSITIVE = true,
+        SCHEMA_FILTER = "Public",
+        TABLE_FILTER = "Order",
+        DEST_SCHEMA = "DST",
+        string = string,
+        table = table,
+        tostring = tostring,
+        type = type,
+        error = error,
+    }
+
+    env.query = function(sql)
+        calls[#calls + 1] = sql
+        return {{SQL_TEXT = "-- ### SCHEMAS ###"}}
+    end
+
+    local fn, err = load(postgres_lua, "postgres_to_exasol.lua", "t", env)
+    assert(fn, "Lua load failed: " .. tostring(err))
+
+    local result_rows = fn()
+    return {
+        rows = result_rows,
+        sql = calls[1],
+        calls = calls,
+    }
+end
+
+print("=== Lua Syntax Validation ===")
+
+test("Lua block in postgres_to_exasol.sql has valid syntax", function()
+    local fn, err = load(postgres_lua)
+    assert(fn, "Lua syntax error in postgres_to_exasol.sql: " .. tostring(err))
+end)
+
+print("")
+print("=== Generation Tests ===")
+
+test("quotes Postgres source identifiers in generated import", function()
+    local result = run_postgres()
+
+    assert_contains(result.sql, "replace(\"column_name\", '\"', '\"\"')")
+    assert_contains(result.sql, "replace(\"table_schema\", '\"', '\"\"')")
+    assert_contains(result.sql, "replace(\"table_name\", '\"', '\"\"')")
+end)
+
+print("")
+print(string.format("=== Results: %d passed, %d failed ===", passed, failed))
+
+if failed > 0 then
+    os.exit(1)
+end

--- a/test/test_vertica_to_exasol.lua
+++ b/test/test_vertica_to_exasol.lua
@@ -1,0 +1,137 @@
+--[[
+  Checks for vertica_to_exasol.sql.
+
+  Run: lua test/test_vertica_to_exasol.lua
+]]
+
+local passed = 0
+local failed = 0
+
+local function test(name, fn)
+    local ok, err = pcall(fn)
+    if ok then
+        passed = passed + 1
+        print("  PASS: " .. name)
+    else
+        failed = failed + 1
+        print("  FAIL: " .. name .. " -- " .. tostring(err))
+    end
+end
+
+local function assert_contains(actual, pattern, msg)
+    if not tostring(actual):find(pattern, 1, true) then
+        error((msg or "missing expected text") .. ": " .. pattern .. " in " .. tostring(actual))
+    end
+end
+
+local function assert_not_contains(actual, pattern, msg)
+    if tostring(actual):find(pattern, 1, true) then
+        error((msg or "unexpected text") .. ": " .. pattern .. " in " .. tostring(actual))
+    end
+end
+
+local function read_file(path)
+    local f = io.open(path, "r")
+    assert(f, "Could not open " .. path)
+    local content = f:read("*a")
+    f:close()
+    return content
+end
+
+local function extract_lua_block(path)
+    local content = read_file(path)
+    local lua_block = content:match("%) RETURNS TABLE%s*\nAS\n(.-)\n/\n")
+    assert(lua_block, "Could not extract Lua block from " .. path)
+    return lua_block
+end
+
+local vertica_lua = extract_lua_block("vertica_to_exasol.sql")
+
+local function run_vertica(params)
+    local calls = {}
+    local rows = params.rows or {{SQL_TEXT = "-- ### SCHEMAS ###"}}
+
+    local env = {
+        CONNECTION_NAME = params.connection_name or "VERTICA_CONNECTION",
+        IDENTIFIER_CASE_INSENSITIVE = params.identifier_case_insensitive,
+        SCHEMA_FILTER = params.schema_filter or "%",
+        TABLE_FILTER = params.table_filter or "%",
+        string = string,
+        table = table,
+        tostring = tostring,
+        type = type,
+        error = error,
+    }
+
+    env.pquery = function(sql)
+        calls[#calls + 1] = sql
+        if params.metadata_error then
+            return false, {
+                error_message = params.metadata_error,
+                statement_text = sql,
+            }
+        end
+        return true, rows
+    end
+
+    local fn, err = load(vertica_lua, "vertica_to_exasol.lua", "t", env)
+    assert(fn, "Lua load failed: " .. tostring(err))
+
+    local result_rows = fn()
+    return {
+        rows = result_rows,
+        sql = calls[1],
+        calls = calls,
+    }
+end
+
+print("=== Lua Syntax Validation ===")
+
+test("Lua block in vertica_to_exasol.sql has valid syntax", function()
+    local fn, err = load(vertica_lua)
+    assert(fn, "Lua syntax error in vertica_to_exasol.sql: " .. tostring(err))
+end)
+
+print("")
+print("=== Generation Tests ===")
+
+test("maps Vertica TIMESTAMP to Exasol TIMESTAMP", function()
+    local result = run_vertica({})
+
+    assert_contains(result.sql, "when upper(data_type) = 'TIMESTAMP' then 'TIMESTAMP'")
+    assert_not_contains(result.sql, "when upper(data_type) = 'TIMESTAMP' then 'varchar(14)'")
+end)
+
+test("quotes Vertica source identifiers in generated import", function()
+    local result = run_vertica({})
+
+    assert_contains(result.sql, "replace(table_schema, '\"', '\"\"')")
+    assert_contains(result.sql, "replace(table_name, '\"', '\"\"')")
+    assert_contains(result.sql, "replace(column_name, '\"', '\"\"')")
+    assert_contains(result.sql, "source_column_name")
+    assert_contains(result.sql, "source_table_schema")
+    assert_contains(result.sql, "source_table_name")
+end)
+
+test("matches parameterized Vertica binary type names", function()
+    local result = run_vertica({})
+
+    assert_contains(result.sql, "when upper(data_type) LIKE 'BINARY%' then 'char('||(coalesce(character_maximum_length, data_type_length) * 2)||')'")
+    assert_contains(result.sql, "when upper(data_type) LIKE 'VARBINARY%' then 'varchar('||(coalesce(character_maximum_length, data_type_length) * 2)||')'")
+    assert_contains(result.sql, "when upper(data_type) LIKE 'BINARY%' then 'TO_HEX('||\"source_column_name\"||')'")
+    assert_contains(result.sql, "when upper(data_type) LIKE 'VARBINARY%' then 'TO_HEX('||\"source_column_name\"||')'")
+end)
+
+test("matches parameterized Vertica numeric type names", function()
+    local result = run_vertica({})
+
+    assert_contains(result.sql, "when upper(data_type) LIKE 'DECIMAL%' or upper(data_type) LIKE 'NUMERIC%' or upper(data_type) LIKE 'NUMBER%'")
+    assert_not_contains(result.sql, "when upper(data_type) in ('DECIMAL','NUMERIC','NUMBER')")
+end)
+
+print("")
+print(string.format("=== Results: %d passed, %d failed ===", passed, failed))
+
+if failed > 0 then
+    os.exit(1)
+end

--- a/vertica_to_exasol.sql
+++ b/vertica_to_exasol.sql
@@ -23,7 +23,7 @@ suc, res = pquery([[
 
 with vv_vertica_columns as (
 
-	select ]]..exa_upper_begin..[[table_schema]]..exa_upper_end..[[ as "exa_table_schema", ]]..exa_upper_begin..[[table_name]]..exa_upper_end..[[ as "exa_table_name", ]]..exa_upper_begin..[[column_name]]..exa_upper_end..[[ as "exa_column_name", vertica.* from  
+	select ]]..exa_upper_begin..[[table_schema]]..exa_upper_end..[[ as "exa_table_schema", ]]..exa_upper_begin..[[table_name]]..exa_upper_end..[[ as "exa_table_name", ]]..exa_upper_begin..[[column_name]]..exa_upper_end..[[ as "exa_column_name", '"' || replace(table_schema, '"', '""') || '"' as "source_table_schema", '"' || replace(table_name, '"', '""') || '"' as "source_table_name", '"' || replace(column_name, '"', '""') || '"' as "source_column_name", vertica.* from
 		(
 
 import  into 
@@ -92,23 +92,23 @@ AND table_name ilike '']]..TABLE_FILTER..[[''
     when upper(data_type) like 'FLOAT%' then 'FLOAT'
     when upper(data_type) = 'DOUBLE PRECISION' then 'DOUBLE'   
 	when upper(data_type) = 'REAL' then 'FLOAT'   
-    when upper(data_type) in ('DECIMAL','NUMERIC','NUMBER') then case when numeric_precision is null or numeric_precision > 36 then 'DOUBLE' else 'decimal(' || numeric_precision || ',' || case when (numeric_scale > numeric_precision) then numeric_precision else  case when numeric_scale < 0 then 0 else numeric_scale end end || ')' end 
+    when upper(data_type) LIKE 'DECIMAL%' or upper(data_type) LIKE 'NUMERIC%' or upper(data_type) LIKE 'NUMBER%' then case when numeric_precision is null or numeric_precision > 36 then 'DOUBLE' else 'decimal(' || numeric_precision || ',' || case when (numeric_scale > numeric_precision) then numeric_precision else  case when numeric_scale < 0 then 0 else numeric_scale end end || ')' end
     when upper(data_type) = 'BOOLEAN' then 'BOOLEAN'
     -- ### date and time types ###
     when upper(data_type) = 'DATE' then 'DATE'
     when upper(data_type) = 'DATETIME' then 'TIMESTAMP'
 	when upper(data_type) = 'SMALLDATETIME' then 'TIMESTAMP'
-    when upper(data_type) = 'TIMESTAMP' then 'varchar(14)'
+    when upper(data_type) = 'TIMESTAMP' then 'TIMESTAMP'
     when upper(data_type) = 'TIME' then 'varchar(8)'
     when upper(data_type) = 'YEAR' then 'varchar(4)'
     -- ### string types ###
     when upper(data_type) LIKE 'CHAR%' then upper(data_type)
     when upper(data_type) LIKE 'VARCHAR%' then upper(data_type)
 	when upper(data_type) LIKE 'LONG VARCHAR%' then upper(data_type)
-    when upper(data_type) = 'BINARY' then 'char('||character_maximum_length||')'
-	when upper(data_type) = 'BYTEA' then 'char('||character_maximum_length||')'
-	when upper(data_type) = 'RAW' then 'char('||character_maximum_length||')'
-    when upper(data_type) = 'VARBINARY' then 'varchar('||character_maximum_length||')'
+    when upper(data_type) LIKE 'BINARY%' then 'char('||(coalesce(character_maximum_length, data_type_length) * 2)||')'
+	when upper(data_type) LIKE 'BYTEA%' then 'char('||(coalesce(character_maximum_length, data_type_length) * 2)||')'
+	when upper(data_type) LIKE 'RAW%' then 'char('||(coalesce(character_maximum_length, data_type_length) * 2)||')'
+    when upper(data_type) LIKE 'VARBINARY%' then 'varchar('||(coalesce(character_maximum_length, data_type_length) * 2)||')'
     when upper(data_type) = 'LONG VARBINARY' then 'varchar(2000000)'
 
     -- ### fallback for unknown types ###
@@ -121,13 +121,13 @@ AND table_name ilike '']]..TABLE_FILTER..[[''
 	select 'import into "' || "exa_table_schema" || '"."' || "exa_table_name" || '" from jdbc at ]]..CONNECTION_NAME..[[ statement ''select ' 
            || group_concat(
                            case 
-	                       when upper(data_type) = 'BINARY' then 'cast('||column_name||' as char('||character_maximum_length||'))'
-                           when upper(data_type) = 'VARBINARY' then 'cast('||column_name||' as char('||character_maximum_length||'))'
-                           when upper(data_type) = 'BLOB' then 'cast('||column_name||' as char(2000000))'
-                           else column_name end order by ordinal_position) 
-           || ' from ' || table_schema|| '.' || table_name|| ''';' as sql_text
-	from vv_vertica_columns group by "exa_table_schema","exa_table_name", table_schema,table_name
-	order by  "exa_table_schema","exa_table_name", table_schema,table_name
+	                       when upper(data_type) LIKE 'BINARY%' then 'TO_HEX('||"source_column_name"||')'
+                           when upper(data_type) LIKE 'VARBINARY%' then 'TO_HEX('||"source_column_name"||')'
+                           when upper(data_type) = 'BLOB' then 'cast('||"source_column_name"||' as char(2000000))'
+                           else "source_column_name" end order by ordinal_position)
+           || ' from ' || "source_table_schema"|| '.' || "source_table_name"|| ''';' as sql_text
+	from vv_vertica_columns group by "exa_table_schema","exa_table_name", "source_table_schema","source_table_name"
+	order by  "exa_table_schema","exa_table_name", "source_table_schema","source_table_name"
 )
 select cast('-- ### SCHEMAS ###' as varchar(2000000)) SQL_TEXT
 union all 


### PR DESCRIPTION
## Summary

- Adds **`MIGRATE_TO_EXASOL`** in `migrate_to_exasol.sql` — a unified entry point that dispatches to the existing per-source migration scripts. Returns one row per generated/executed statement plus a trailing `SUMMARY` row in a 7-column audit table.
- Adds **`databricks_to_exasol.sql`** as a new source adapter, plus matching Lua test coverage.
- Hardens existing adapters: DB2 identifier quoting, Postgres identifier quoting, Vertica `TIMESTAMP` mapping fix, adapter datatype imports, wrapper execute-mode summary correctness.
- Adds **Lua unit tests** for the wrapper, DB2, Postgres, Vertica, and Databricks (`test/*.lua`).
- Adds a **runtime mock smoke** (`test/test_migrate_to_exasol_runtime.py`) that deploys the wrapper and 17 mock adapters into a disposable Exasol DB and exercises preview dispatch, execute, no-op, adapter error, S3 rejection, and source-alias paths.

## Surface

```sql
EXECUTE SCRIPT DATABASE_MIGRATION.MIGRATE_TO_EXASOL(
    'SNOWFLAKE',                 -- SOURCE_TYPE
    'SNOWFLAKE_CONNECTION',      -- CONNECTION_NAME
    'JDBC',                      -- CONNECTION_TYPE
    '%', '%', '%',               -- DB / SCHEMA / TABLE filters
    NULL,                        -- TARGET_SCHEMA
    TRUE,                        -- IDENTIFIER_CASE_INSENSITIVE
    TRUE,                        -- DEBUG: TRUE previews, FALSE executes
    'DB2SCHEMA=true'             -- OPTIONS: KEY=VALUE pairs separated by ';'
);
```

Sources covered: `MYSQL`, `MARIADB`, `POSTGRES`, `REDSHIFT`, `DB2`, `VERTICA`, `HANA`, `AZURE_SQL`, `BIGQUERY`, `DATABRICKS`, `SQLSERVER`, `SNOWFLAKE`, `ORACLE`, `TERADATA`, `EXASOL`, `NETEZZA`, `VECTORWISE`. Existing source-specific scripts remain installable and callable on their own — the wrapper only adds a standardized call surface on top.

`S3` is deliberately rejected with an error pointing at `DATABASE_MIGRATION.S3_PARALLEL_READ`.

### Return shape (7-column audit table)

| Column | Type | Meaning |
|---|---|---|
| `STEP_KIND` | `VARCHAR(40)` | `CREATE_SCHEMA` / `CREATE_TABLE` / `ALTER_TABLE` / `IMPORT` / `INFO` / `OTHER` / `SUMMARY` |
| `TARGET_OBJ` | `VARCHAR(2000)` | `"SCHEMA"."TABLE"` for table-level steps; schema name for `CREATE_SCHEMA`; rollup text for `SUMMARY` |
| `ROWS_AFFECTED` | `DECIMAL(18,0)` | rows imported per `IMPORT`; total in `SUMMARY` |
| `ELAPSED_MS` | `DECIMAL(18,0)` | wall-clock ms per executed statement; total in `SUMMARY` |
| `RESULT_FLAG` | `VARCHAR(20)` | `PREVIEW` (DEBUG mode), `OK` / `ERROR` / `SKIPPED` (EXECUTE mode) |
| `SQL_TEXT` | `VARCHAR(2000000)` | the generated / executed statement (or comment); `NULL` on `SUMMARY` |
| `ERROR_MESSAGE` | `VARCHAR(20000)` | Exasol error text when `RESULT_FLAG = ERROR` |

The wrapper classifies each adapter row by regex on `SQL_TEXT`, extracts the `"SCHEMA"."TABLE"` target where present, captures `rows_affected` from `pquery` on IMPORT statements in execute mode, measures per-statement wall-time, and appends a structured `SUMMARY` row with rollup totals. The classification is deliberately conservative — anything the regex doesn't match becomes `OTHER` and still round-trips intact.

`README.md` is updated with the wrapper usage, return shape, and the relevant `OPTIONS` keys.

## Verification

Static + runtime tests (run against a disposable local Exasol):

| Check | Result |
|---|---|
| `lua test/test_migrate_to_exasol.lua` | 39 passed (incl. STEP_KIND classification, ROWS_AFFECTED capture, SUMMARY on empty / no-op, RESULT_FLAG transitions) |
| `lua test/test_databricks_to_exasol.lua` | 9 passed |
| `lua test/test_db2_to_exasol.lua` | 3 passed |
| `lua test/test_postgres_to_exasol.lua` | 2 passed |
| `lua test/test_vertica_to_exasol.lua` | 5 passed (`TIMESTAMP` mapping covered) |
| Python AST check | PASS |
| `python3 test/test_migrate_to_exasol_runtime.py` | 17 preview dispatches, 4 execute representatives with SUMMARY/OK verification, no-op SUMMARY/SKIPPED, adapter error, S3 rejection, source-alias |
| `git diff --check` | PASS |

Live-source smoke ledger (against real source databases, end-to-end through the wrapper into Exasol with loaded-row verification):

| Source | Live smoke |
|---|---|
| Databricks | PASS |
| Exasol → Exasol | PASS |
| Postgres | PASS |
| MySQL | PASS |
| Snowflake | PASS (needs `JDBC_QUERY_RESULT_FORMAT=JSON` on Java 17) |
| MariaDB | PASS |
| DB2 | PASS |
| SQL Server | PASS (EC2 x86 host + local Apple Silicon via `mcr.microsoft.com/azure-sql-edge`) |
| Vertica | PASS (EC2 x86 host) |
| Oracle | PASS (`gvenzl/oracle-free:23-slim-faststart`) |
| Redshift | PASS (AWS cluster) |
| Azure SQL | PASS (disposable Azure SQL Basic DB, `mssql-jdbc` 13.4) |
| BigQuery | Attempted; driver layer blocked. Simba JDBC loads but `IMPORT FROM JDBC AT BQ STATEMENT 'SELECT 1'` hangs; Google official JDBC throws `setAutoCommit` (incompatible with Exasol IMPORT). Wrapper dispatch is proven by the runtime mock smoke. Environmental, not a wrapper issue. |
| Teradata, HANA, Netezza, Vectorwise | Not exercised live — image/license-gated |

## Test plan

- [ ] `lua test/test_migrate_to_exasol.lua` exits 0 (39 cases)
- [ ] `lua test/test_databricks_to_exasol.lua` exits 0
- [ ] `lua test/test_db2_to_exasol.lua`, `test_postgres_to_exasol.lua`, `test_vertica_to_exasol.lua` exit 0
- [ ] `python3 test/test_migrate_to_exasol_runtime.py` against a disposable Exasol passes (17 preview dispatches + 4 execute + no-op + adapter error + S3 reject + alias)
- [ ] Manual smoke against at least one preferred source via the wrapper (e.g. Postgres or DB2); confirm `SUMMARY` row reports expected `tables_created` and `total_rows_loaded`