### PR TITLE
Per-source parallel IMPORT splitter + threshold gate on MIGRATE_TO_EXASOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@
 
 ## Table of Contents
 1. [Overview](#overview)
-2. [Migration source:](#migration-source)
+2. [Unified migration entry point](#unified-migration-entry-point)
+3. [Migration source:](#migration-source)
     * [Azure Sql](#azure-sql)
     * [CSV](#csv)
+    * [Databricks](#databricks)
     * [DB2](#db2)
     * [Exasol](#exasol)
     * [Google BigQuery](#google-bigquery)
@@ -25,8 +27,8 @@
     * [Vectorwise](#vectorwise)
     * [Vertica](#vertica)
     
-3. [Post-load optimization](#post-load-optimization)
-4. [Delta import](#delta-import)
+4. [Post-load optimization](#post-load-optimization)
+5. [Delta import](#delta-import)
 
 
 ## Overview
@@ -37,6 +39,39 @@ You'll find SQL scripts which you can execute on Exasol to load data from certai
 database management systems. The scripts try to extract the meta data from the source system and create the appropriate IMPORT statements automatically so that you don't have to care about table names, column names and types.
 
 If you want to optimize existing scripts or create new scripts for additional systems, we would be very glad if you share your work with the Exasol user community.
+
+## Unified migration entry point
+
+The script [migrate_to_exasol.sql](migrate_to_exasol.sql) provides one standardized execute interface for the source-specific migration scripts. It dispatches to the existing scripts, so the matching source script still needs to be installed in `DATABASE_MIGRATION`.
+
+```sql
+EXECUTE SCRIPT DATABASE_MIGRATION.MIGRATE_TO_EXASOL(
+    'SNOWFLAKE',                 -- SOURCE_TYPE
+    'SNOWFLAKE_CONNECTION',      -- CONNECTION_NAME
+    'JDBC',                      -- CONNECTION_TYPE
+    '%',                         -- DB_FILTER
+    '%',                         -- SCHEMA_FILTER
+    '%',                         -- TABLE_FILTER
+    NULL,                        -- TARGET_SCHEMA
+    TRUE,                        -- IDENTIFIER_CASE_INSENSITIVE
+    TRUE,                        -- DEBUG: TRUE previews, FALSE executes
+    'DB2SCHEMA=true'             -- OPTIONS
+);
+```
+
+Common parameters:
+- `SOURCE_TYPE`: `MYSQL`, `MARIADB`, `POSTGRES`, `REDSHIFT`, `DB2`, `VERTICA`, `HANA`, `AZURE_SQL`, `BIGQUERY`, `DATABRICKS`, `SQLSERVER`, `SNOWFLAKE`, `ORACLE`, `TERADATA`, `EXASOL`, `NETEZZA`, or `VECTORWISE`.
+- `DEBUG`: `TRUE` returns generated SQL. `FALSE` executes generated SQL and returns status rows.
+- `OPTIONS`: source-specific `KEY=VALUE` pairs separated by semicolons.
+
+Useful `OPTIONS` keys:
+- `PROJECT_ID`: required for `BIGQUERY` unless `DB_FILTER` contains the project ID.
+- `CATALOG2SCHEMA`: `true` or `false` for `DATABRICKS`.
+- `DB2SCHEMA`: `true` or `false` for `SNOWFLAKE` and `SQLSERVER`.
+- `PARALLEL_STATEMENTS`, `CREATE_PK`, `CREATE_FK`, `CHECK_MIGRATION`: Oracle/Teradata options.
+- `GENERATE_VIEWS`, `VIEW_FILTER`, `PK_SETTING`: Exasol-to-Exasol options.
+
+The S3 parallel loader keeps its direct script interface because it uses a different parameter shape.
 
 ## Migration source
 
@@ -111,6 +146,37 @@ FROM   (
 For the actual data-migration, see script [bigquery_to_exasol.sql](bigquery_to_exasol.sql)
 
 Note: Due to the lack of an alternative datatype, the following Google BigQuery datatypes; `DATE`,`DATETIME`,`TIMESTAMP` and `ARRAY` are stored as VARCHAR. 
+
+### Databricks
+
+To connect Exasol to Databricks, configure the Databricks JDBC driver in Exasol with the driver name `DATABRICKS`, then create a connection for your Databricks SQL warehouse. The JDBC URL requires your server hostname and HTTP path. See the [Databricks JDBC driver documentation](https://docs.databricks.com/aws/en/integrations/jdbc-oss/configure) for current connection details.
+
+Example connection:
+
+```sql
+CREATE OR REPLACE CONNECTION DATABRICKS_CONNECTION TO
+  'jdbc:databricks://<server-hostname>:443/default;httpPath=<http-path>;AuthMech=3;UseNativeQuery=1'
+  USER 'token'
+  IDENTIFIED BY '<personal-access-token>';
+```
+
+Create the script [databricks_to_exasol.sql](databricks_to_exasol.sql), then generate migration SQL:
+
+```sql
+EXECUTE SCRIPT DATABASE_MIGRATION.DATABRICKS_TO_EXASOL(
+    'DATABRICKS_CONNECTION', -- CONNECTION_NAME
+    TRUE,                    -- CATALOG2SCHEMA: catalog.schema.table -> catalog.schema_table
+    '%',                     -- CATALOG_FILTER
+    '%',                     -- SCHEMA_FILTER
+    NULL,                    -- TARGET_SCHEMA
+    '%',                     -- TABLE_FILTER
+    TRUE                     -- IDENTIFIER_CASE_INSENSITIVE
+);
+```
+
+The script uses Databricks `INFORMATION_SCHEMA` metadata to generate `CREATE SCHEMA`, `CREATE TABLE`, and `IMPORT FROM JDBC DRIVER = 'DATABRICKS'` statements for managed and external tables. `CATALOG2SCHEMA` helps avoid name collisions when multiple Databricks catalogs contain the same schema and table names.
+
+S3 loading is intentionally not part of this adapter. Use [s3_to_exasol.sql](s3_to_exasol.sql) for S3 parallel loading.
 
 
 ### MariaDB

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ If you want to optimize existing scripts or create new scripts for additional sy
 
 The script [migrate_to_exasol.sql](migrate_to_exasol.sql) provides one standardized execute interface for the source-specific migration scripts. It dispatches to the existing scripts, so the matching source script still needs to be installed in `DATABASE_MIGRATION`.
 
+`MIGRATE_TO_EXASOL` is a thin orchestrator on top of the per-source adapter scripts: it invokes the adapter exactly as the SE team and existing customers call it directly today, then applies cross-cutting post-processing passes (per-IMPORT row-count threshold, parallel-statement splitter, audit columns) over the rows the adapter returned. Adapter scripts themselves are never modified by the orchestrator — they remain authoritative for source-specific schema discovery, type mapping, identifier quoting, and IMPORT shape. Direct `EXECUTE SCRIPT DATABASE_MIGRATION.<SRC>_TO_EXASOL(...)` callers continue to work byte-for-byte.
+
 ```sql
 EXECUTE SCRIPT DATABASE_MIGRATION.MIGRATE_TO_EXASOL(
     'SNOWFLAKE',                 -- SOURCE_TYPE
@@ -64,7 +66,7 @@ Common parameters:
 - `DEBUG`: `TRUE` returns generated SQL with `RESULT_FLAG = PREVIEW`. `FALSE` executes generated SQL and returns one row per statement plus a trailing `SUMMARY` row.
 - `OPTIONS`: source-specific `KEY=VALUE` pairs separated by semicolons.
 
-The script returns a 7-column audit table:
+The script returns an 11-column audit table:
 
 | Column | Type | Meaning |
 |---|---|---|
@@ -75,13 +77,21 @@ The script returns a 7-column audit table:
 | `RESULT_FLAG` | `VARCHAR(20)` | `PREVIEW`, `OK`, `ERROR`, or `SKIPPED` |
 | `SQL_TEXT` | `VARCHAR(2000000)` | the generated/executed statement (or comment); `NULL` on `SUMMARY` |
 | `ERROR_MESSAGE` | `VARCHAR(20000)` | Exasol error text when `RESULT_FLAG = ERROR` |
+| `SPLIT_STRATEGY` | `VARCHAR(32)` | how the orchestrator decided each `IMPORT` would be parallelized: `PK_RANGE`, `DATE_BUCKET`, `HASH_NUM`, `ROWID`, `SINGLE`, `MULTI_PASSTHROUGH`; `NULL` for non-`IMPORT` rows |
+| `SPLIT_KEY` | `VARCHAR(256)` | column or pseudo-column used as the parallel selector (`ORDER_ID`, `ctid`, `%%physloc%%`); `NULL` for `SINGLE`, `MULTI_PASSTHROUGH`, and non-`IMPORT` rows |
+| `PARALLEL_REQUESTED` | `VARCHAR(16)` | raw `PARALLEL_STATEMENTS` value (`AUTO`, `8`, …); `NULL` for non-`IMPORT` rows |
+| `PARALLEL_EFFECTIVE` | `DECIMAL(4,0)` | number of `statement '...'` clauses actually emitted after the threshold gate and splitter resolved; `NULL` for non-`IMPORT` rows |
 
 Useful `OPTIONS` keys:
 - `PROJECT_ID`: required for `BIGQUERY` unless `DB_FILTER` contains the project ID.
 - `CATALOG2SCHEMA`: `true` or `false` for `DATABRICKS`.
 - `DB2SCHEMA`: `true` or `false` for `SNOWFLAKE` and `SQLSERVER`.
-- `PARALLEL_STATEMENTS`, `CREATE_PK`, `CREATE_FK`, `CHECK_MIGRATION`: Oracle/Teradata options.
+- `CREATE_PK`, `CREATE_FK`, `CHECK_MIGRATION`: Oracle/Teradata options.
 - `GENERATE_VIEWS`, `VIEW_FILTER`, `PK_SETTING`: Exasol-to-Exasol options.
+- `PARALLEL_STATEMENTS`: `AUTO` (default) or a positive integer. `AUTO` resolves to `min(PARALLEL_AUTO_CEILING, max(1, ceil(src_rows / 5_000_000)))` per table; explicit integers bypass the ceiling. Affects every adapter that emits single-statement `IMPORT`s.
+- `PARALLEL_ROW_THRESHOLD`: positive integer (default `1000000`). The orchestrator collapses multi-statement IMPORTs whose source row count is below this threshold and only fires the splitter on single-statement IMPORTs whose source row count is at-or-above it. `0` disables the gate.
+- `PARALLEL_SPLIT`: `AUTO` (default), `OFF`, `PK`, `DATE[:col[:grain]]`, `HASH:col`, `ROWID`, or `PARTITION`. Forces one step of the parallel-split hierarchy (or disables it via `OFF`); `AUTO` walks the hierarchy stopping at the first usable strategy.
+- `PARALLEL_AUTO_CEILING`: positive integer (default `12`). Per-table cap for `PARALLEL_STATEMENTS=AUTO`. Raise for sources with deep connection pools; explicit `PARALLEL_STATEMENTS=N` ignores it.
 
 The S3 parallel loader keeps its direct script interface because it uses a different parameter shape; calling `MIGRATE_TO_EXASOL` with `SOURCE_TYPE = 'S3'` raises an explicit error pointing at `DATABASE_MIGRATION.S3_PARALLEL_READ`.
 

--- a/README.md
+++ b/README.md
@@ -61,8 +61,20 @@ EXECUTE SCRIPT DATABASE_MIGRATION.MIGRATE_TO_EXASOL(
 
 Common parameters:
 - `SOURCE_TYPE`: `MYSQL`, `MARIADB`, `POSTGRES`, `REDSHIFT`, `DB2`, `VERTICA`, `HANA`, `AZURE_SQL`, `BIGQUERY`, `DATABRICKS`, `SQLSERVER`, `SNOWFLAKE`, `ORACLE`, `TERADATA`, `EXASOL`, `NETEZZA`, or `VECTORWISE`.
-- `DEBUG`: `TRUE` returns generated SQL. `FALSE` executes generated SQL and returns status rows.
+- `DEBUG`: `TRUE` returns generated SQL with `RESULT_FLAG = PREVIEW`. `FALSE` executes generated SQL and returns one row per statement plus a trailing `SUMMARY` row.
 - `OPTIONS`: source-specific `KEY=VALUE` pairs separated by semicolons.
+
+The script returns a 7-column audit table:
+
+| Column | Type | Meaning |
+|---|---|---|
+| `STEP_KIND` | `VARCHAR(40)` | `CREATE_SCHEMA`, `CREATE_TABLE`, `ALTER_TABLE`, `IMPORT`, `INFO`, `OTHER`, or `SUMMARY` |
+| `TARGET_OBJ` | `VARCHAR(2000)` | `"SCHEMA"."TABLE"` for table-level steps; schema name for `CREATE_SCHEMA`; `NULL` for `INFO`; rollup text for `SUMMARY` |
+| `ROWS_AFFECTED` | `DECIMAL(18,0)` | rows imported per `IMPORT`; total in `SUMMARY` |
+| `ELAPSED_MS` | `DECIMAL(18,0)` | wall-clock ms per executed statement; total in `SUMMARY` |
+| `RESULT_FLAG` | `VARCHAR(20)` | `PREVIEW`, `OK`, `ERROR`, or `SKIPPED` |
+| `SQL_TEXT` | `VARCHAR(2000000)` | the generated/executed statement (or comment); `NULL` on `SUMMARY` |
+| `ERROR_MESSAGE` | `VARCHAR(20000)` | Exasol error text when `RESULT_FLAG = ERROR` |
 
 Useful `OPTIONS` keys:
 - `PROJECT_ID`: required for `BIGQUERY` unless `DB_FILTER` contains the project ID.
@@ -71,7 +83,7 @@ Useful `OPTIONS` keys:
 - `PARALLEL_STATEMENTS`, `CREATE_PK`, `CREATE_FK`, `CHECK_MIGRATION`: Oracle/Teradata options.
 - `GENERATE_VIEWS`, `VIEW_FILTER`, `PK_SETTING`: Exasol-to-Exasol options.
 
-The S3 parallel loader keeps its direct script interface because it uses a different parameter shape.
+The S3 parallel loader keeps its direct script interface because it uses a different parameter shape; calling `MIGRATE_TO_EXASOL` with `SOURCE_TYPE = 'S3'` raises an explicit error pointing at `DATABASE_MIGRATION.S3_PARALLEL_READ`.
 
 ## Migration source
 

--- a/databricks_to_exasol.sql
+++ b/databricks_to_exasol.sql
@@ -1,0 +1,290 @@
+create schema if not exists database_migration;
+
+/*
+    This script generates create schema, create table, and import statements
+    to load data from Databricks SQL through JDBC.
+*/
+--/
+create or replace script database_migration.DATABRICKS_TO_EXASOL(
+    CONNECTION_NAME,                 -- name of the Databricks connection inside Exasol, e.g. databricks_connection
+    CATALOG2SCHEMA,                  -- TRUE maps catalog.schema.table to schema catalog and table schema_table
+    CATALOG_FILTER,                  -- filter for Databricks catalogs, e.g. 'main', 'ma%', 'main, analytics', '%'
+    SCHEMA_FILTER,                   -- filter for Databricks schemas, e.g. 'default', 'sales%', 'bronze, silver', '%'
+    TARGET_SCHEMA,                   -- target schema on Exasol side, set to NULL or empty string to use source values
+    TABLE_FILTER,                    -- filter for Databricks tables, e.g. 'orders', 'ord%', 'orders, customers', '%'
+    IDENTIFIER_CASE_INSENSITIVE      -- TRUE if generated Exasol identifiers should be uppercased
+) RETURNS TABLE
+AS
+
+local function trim(value)
+    return tostring(value):gsub("^%s*(.-)%s*$", "%1")
+end
+
+local function is_blank(value)
+    return value == null or trim(value) == ''
+end
+
+local function sql_literal(value)
+    return "'" .. tostring(value):gsub("'", "''") .. "'"
+end
+
+local function databricks_literal(value)
+    return "'" .. tostring(value):gsub("'", "''") .. "'"
+end
+
+local function parse_bool(value, default_value, name)
+    if value == null then
+        return default_value
+    end
+    if type(value) == 'boolean' then
+        return value
+    end
+
+    local text = trim(value):lower()
+    if text == '' then
+        return default_value
+    end
+    if text == 'true' or text == '1' or text == 'yes' then
+        return true
+    end
+    if text == 'false' or text == '0' or text == 'no' then
+        return false
+    end
+
+    error('Invalid boolean for ' .. name .. ': ' .. tostring(value))
+end
+
+local function normalize_filter(value)
+    if is_blank(value) then
+        return '%'
+    end
+    return trim(value)
+end
+
+local function filter_condition(column_name, value)
+    local filter_value = normalize_filter(value)
+    if filter_value:find(',', 1, true) and not filter_value:find('%%') and not filter_value:find('_') then
+        local values = {}
+        for part in filter_value:gmatch('[^,]+') do
+            values[#values + 1] = databricks_literal(trim(part))
+        end
+        return column_name .. ' in (' .. table.concat(values, ',') .. ')'
+    end
+    return column_name .. ' like ' .. databricks_literal(filter_value)
+end
+
+if is_blank(CONNECTION_NAME) then
+    error('CONNECTION_NAME is required')
+end
+
+local catalog2schema = parse_bool(CATALOG2SCHEMA, true, 'CATALOG2SCHEMA')
+local identifier_case_insensitive = parse_bool(IDENTIFIER_CASE_INSENSITIVE, true, 'IDENTIFIER_CASE_INSENSITIVE')
+
+local exa_upper_begin = ''
+local exa_upper_end = ''
+if identifier_case_insensitive then
+    exa_upper_begin = 'upper('
+    exa_upper_end = ')'
+end
+
+local catalog_condition = filter_condition('table_catalog', CATALOG_FILTER)
+local schema_condition = filter_condition('table_schema', SCHEMA_FILTER)
+local table_condition = filter_condition('table_name', TABLE_FILTER)
+
+local target_schema_expr
+local target_table_expr
+
+if not is_blank(TARGET_SCHEMA) then
+    target_schema_expr = sql_literal(TARGET_SCHEMA)
+    if catalog2schema then
+        target_table_expr = [["exa_table_catalog" || '_' || "exa_table_schema" || '_' || "exa_table_name"]]
+    else
+        target_table_expr = [["exa_table_schema" || '_' || "exa_table_name"]]
+    end
+elseif catalog2schema then
+    target_schema_expr = [["exa_table_catalog"]]
+    target_table_expr = [["exa_table_schema" || '_' || "exa_table_name"]]
+else
+    target_schema_expr = [["exa_table_schema"]]
+    target_table_expr = [["exa_table_name"]]
+end
+
+local metadata_statement = [[
+select
+    table_catalog,
+    table_schema,
+    table_name,
+    column_name,
+    ordinal_position,
+    case when is_nullable = 'NO' then 'NOT NULL' else 'NULL' end as not_null_constraint,
+    data_type,
+    full_data_type,
+    numeric_precision,
+    numeric_scale,
+    character_maximum_length
+from system.INFORMATION_SCHEMA.COLUMNS
+join system.INFORMATION_SCHEMA.TABLES using (table_catalog, table_schema, table_name)
+where table_type in ('MANAGED', 'EXTERNAL', 'MANAGED_SHALLOW_CLONE', 'EXTERNAL_SHALLOW_CLONE')
+  and ]] .. catalog_condition .. [[
+  and ]] .. schema_condition .. [[
+  and ]] .. table_condition
+
+local metadata_statement_escaped = metadata_statement:gsub("'", "''")
+
+suc, res = pquery([[
+with vv_databricks_columns as (
+    select
+        ]] .. exa_upper_begin .. [[databricks."table_catalog"]] .. exa_upper_end .. [[ as "exa_table_catalog",
+        ]] .. exa_upper_begin .. [[databricks."table_schema"]] .. exa_upper_end .. [[ as "exa_table_schema",
+        ]] .. exa_upper_begin .. [[databricks."table_name"]] .. exa_upper_end .. [[ as "exa_table_name",
+        ]] .. exa_upper_begin .. [[databricks."column_name"]] .. exa_upper_end .. [[ as "exa_column_name",
+        databricks."table_catalog" as table_catalog,
+        databricks."table_schema" as table_schema,
+        databricks."table_name" as table_name,
+        databricks."column_name" as column_name,
+        databricks."ordinal_position" as ordinal_position,
+        databricks."not_null_constraint" as not_null_constraint,
+        databricks."data_type" as data_type,
+        databricks."full_data_type" as full_data_type,
+        databricks."numeric_precision" as numeric_precision,
+        databricks."numeric_scale" as numeric_scale,
+        databricks."character_maximum_length" as character_maximum_length
+    from (
+        IMPORT FROM JDBC DRIVER = 'DATABRICKS' AT ]] .. CONNECTION_NAME .. [[ STATEMENT ']] .. metadata_statement_escaped .. [['
+    ) as databricks
+),
+vv_target_columns as (
+    select
+        *,
+        ]] .. target_schema_expr .. [[ as "target_schema_name",
+        ]] .. target_table_expr .. [[ as "target_table_name"
+    from vv_databricks_columns
+),
+vv_create_schemas as (
+    select
+        'create schema if not exists "' || "target_schema_name" || '";' as sql_text
+    from vv_target_columns
+    group by "target_schema_name"
+    order by "target_schema_name"
+),
+vv_create_tables as (
+    select
+        'create or replace table "' || "target_schema_name" || '"."' || "target_table_name" || '" (' ||
+        group_concat(
+            case
+                when upper(data_type) = 'TINYINT' then '"' || "exa_column_name" || '" DECIMAL(3,0) ' || not_null_constraint
+                when upper(data_type) = 'SMALLINT' then '"' || "exa_column_name" || '" DECIMAL(5,0) ' || not_null_constraint
+                when upper(data_type) = 'INT' then '"' || "exa_column_name" || '" DECIMAL(10,0) ' || not_null_constraint
+                when upper(data_type) = 'BIGINT' then '"' || "exa_column_name" || '" DECIMAL(19,0) ' || not_null_constraint
+                when upper(data_type) = 'FLOAT' then '"' || "exa_column_name" || '" FLOAT ' || not_null_constraint
+                when upper(data_type) = 'DOUBLE' then '"' || "exa_column_name" || '" DOUBLE PRECISION ' || not_null_constraint
+                when upper(data_type) = 'DECIMAL' then '"' || "exa_column_name" || '" DECIMAL(' ||
+                    case
+                        when numeric_precision is null then 36
+                        when numeric_precision > 36 then 36
+                        else numeric_precision
+                    end || ',' ||
+                    case
+                        when numeric_scale is null then 0
+                        when numeric_scale > 36 then 36
+                        else numeric_scale
+                    end || ') ' || not_null_constraint
+                when upper(data_type) = 'BOOLEAN' then '"' || "exa_column_name" || '" BOOLEAN ' || not_null_constraint
+                when upper(data_type) = 'DATE' then '"' || "exa_column_name" || '" DATE ' || not_null_constraint
+                when upper(data_type) = 'TIMESTAMP' then '"' || "exa_column_name" || '" TIMESTAMP WITH LOCAL TIME ZONE ' || not_null_constraint
+                when upper(data_type) = 'TIMESTAMP_LTZ' then '"' || "exa_column_name" || '" TIMESTAMP WITH LOCAL TIME ZONE ' || not_null_constraint
+                when upper(data_type) = 'TIMESTAMP_NTZ' then '"' || "exa_column_name" || '" TIMESTAMP ' || not_null_constraint
+                when upper(data_type) = 'STRING' then '"' || "exa_column_name" || '" VARCHAR(2000000) ' || not_null_constraint
+                when upper(data_type) = 'BINARY' then '"' || "exa_column_name" || '" VARCHAR(2000000) ' || not_null_constraint
+                when upper(data_type) = 'ARRAY' then '"' || "exa_column_name" || '" VARCHAR(2000000) ' || not_null_constraint
+                when upper(data_type) = 'MAP' then '"' || "exa_column_name" || '" VARCHAR(2000000) ' || not_null_constraint
+                when upper(data_type) = 'STRUCT' then '"' || "exa_column_name" || '" VARCHAR(2000000) ' || not_null_constraint
+                when upper(data_type) = 'VARIANT' then '"' || "exa_column_name" || '" VARCHAR(2000000) ' || not_null_constraint
+                when upper(data_type) = 'OBJECT' then '"' || "exa_column_name" || '" VARCHAR(2000000) ' || not_null_constraint
+                when upper(data_type) = 'INTERVAL' then '"' || "exa_column_name" || '" VARCHAR(2000000) ' || not_null_constraint
+                when upper(data_type) = 'VOID' then '"' || "exa_column_name" || '" VARCHAR(2000000) ' || not_null_constraint
+                when upper(data_type) = 'GEOGRAPHY' then '"' || "exa_column_name" || '" VARCHAR(2000000) ' || not_null_constraint
+                when upper(data_type) = 'GEOMETRY' then '"' || "exa_column_name" || '" VARCHAR(2000000) ' || not_null_constraint
+            end
+            order by ordinal_position separator ','
+        ) || ');' ||
+        coalesce(
+            group_concat(
+                case
+                    when upper(data_type) in ('BINARY', 'ARRAY', 'MAP', 'STRUCT', 'VARIANT', 'OBJECT', 'INTERVAL', 'VOID', 'GEOGRAPHY', 'GEOMETRY')
+                    then '--LOSSY_DATATYPE: "' || "exa_column_name" || '" Databricks TYPE INFO: ' || full_data_type
+                    when upper(data_type) not in ('TINYINT', 'SMALLINT', 'INT', 'BIGINT', 'FLOAT', 'DOUBLE', 'DECIMAL', 'BOOLEAN', 'DATE', 'TIMESTAMP', 'TIMESTAMP_LTZ', 'TIMESTAMP_NTZ', 'STRING', 'BINARY', 'ARRAY', 'MAP', 'STRUCT', 'VARIANT', 'OBJECT', 'INTERVAL', 'VOID', 'GEOGRAPHY', 'GEOMETRY')
+                    then '--UNKNOWN_DATATYPE: "' || "exa_column_name" || '" Databricks TYPE INFO: ' || full_data_type
+                end
+                order by ordinal_position separator ' '
+            ),
+            ''
+        ) as sql_text
+    from vv_target_columns
+    group by "target_schema_name", "target_table_name"
+),
+vv_imports as (
+    select
+        'import into "' || "target_schema_name" || '"."' || "target_table_name" || '"(' ||
+        group_concat(
+            case
+                when upper(data_type) in ('TINYINT', 'SMALLINT', 'INT', 'BIGINT', 'FLOAT', 'DOUBLE', 'DECIMAL', 'BOOLEAN', 'DATE', 'TIMESTAMP', 'TIMESTAMP_LTZ', 'TIMESTAMP_NTZ', 'STRING', 'BINARY', 'ARRAY', 'MAP', 'STRUCT', 'VARIANT', 'OBJECT', 'INTERVAL', 'VOID', 'GEOGRAPHY', 'GEOMETRY')
+                then '"' || "exa_column_name" || '"'
+            end
+            order by ordinal_position separator ','
+        ) || ') from jdbc driver = ''DATABRICKS'' at ]] .. CONNECTION_NAME .. [[ statement ''select ' ||
+        group_concat(
+            case
+                when upper(data_type) in ('TINYINT', 'SMALLINT', 'INT', 'BIGINT', 'FLOAT', 'DOUBLE', 'DECIMAL', 'BOOLEAN', 'DATE', 'TIMESTAMP', 'TIMESTAMP_LTZ', 'TIMESTAMP_NTZ', 'STRING')
+                then '`' || column_name || '`'
+                when upper(data_type) in ('BINARY', 'ARRAY', 'MAP', 'STRUCT', 'VARIANT', 'OBJECT', 'INTERVAL', 'VOID', 'GEOGRAPHY', 'GEOMETRY')
+                then 'cast(`' || column_name || '` as string)'
+            end
+            order by ordinal_position separator ','
+        ) || ' from `' || table_catalog || '`.`' || table_schema || '`.`' || table_name || '`'';' as sql_text
+    from vv_target_columns
+    group by "target_schema_name", "target_table_name", table_catalog, table_schema, table_name
+)
+select sql_text from (
+    select 1 as ord, cast('-- ### SCHEMAS ###' as varchar(2000000)) as sql_text
+    union all
+    select 2, sql_text from vv_create_schemas
+    union all
+    select 3, cast('-- ### TABLES ###' as varchar(2000000)) as sql_text
+    union all
+    select 4, sql_text from vv_create_tables where sql_text is not null and sql_text not like '%();%'
+    union all
+    select 5, cast('-- ### IMPORTS ###' as varchar(2000000)) as sql_text
+    union all
+    select 6, sql_text from vv_imports where sql_text is not null and sql_text not like '%select  from%'
+) order by ord, sql_text
+]], {})
+
+if not suc then
+    local error_message = 'unknown error'
+    local statement_text = metadata_statement
+    if res ~= null then
+        error_message = res.error_message or error_message
+        statement_text = res.statement_text or statement_text
+    end
+    error('"' .. error_message .. '" Caught while executing: "' .. statement_text .. '"')
+end
+
+return res
+/
+
+-- Create a connection to Databricks
+CREATE OR REPLACE CONNECTION DATABRICKS_CONNECTION TO
+  'jdbc:databricks://<server-hostname>:443/default;httpPath=<http-path>;AuthMech=3;UseNativeQuery=1'
+  USER 'token' IDENTIFIED BY '<personal-access-token>';
+
+-- Finally start the import process
+execute script database_migration.DATABRICKS_TO_EXASOL(
+    'DATABRICKS_CONNECTION', -- CONNECTION_NAME: name of the Databricks connection inside Exasol
+    true,                    -- CATALOG2SCHEMA: TRUE maps catalog.schema.table to catalog.schema_table
+    '%',                     -- CATALOG_FILTER: '%' to load all visible catalogs
+    '%',                     -- SCHEMA_FILTER: '%' to load all visible schemas
+    NULL,                    -- TARGET_SCHEMA: NULL or empty string to use source-derived schema names
+    '%',                     -- TABLE_FILTER: '%' to load all visible base tables
+    true                     -- IDENTIFIER_CASE_INSENSITIVE: TRUE uppercases generated Exasol identifiers
+);

--- a/db2_to_exasol.sql
+++ b/db2_to_exasol.sql
@@ -16,22 +16,26 @@ RETURNS TABLE
 AS
 exa_upper_begin=''
 exa_upper_end=''
+db2_filter_begin=''
+db2_filter_end=''
 if IDENTIFIER_CASE_INSENSITIVE == true then
   exa_upper_begin='upper('
   exa_upper_end=')'
+  db2_filter_begin='upper('
+  db2_filter_end=')'
 end
 summary = {}
 
 res = query([[
 with vv_db2_columns as (
-  select ]]..exa_upper_begin..[[table_catalog]]..exa_upper_end..[[ as "exa_table_catalog", ]]..exa_upper_begin..[[table_schema]]..exa_upper_end..[[ as "exa_table_schema", ]]..exa_upper_begin..[[table_name]]..exa_upper_end..[[ as "exa_table_name", ]]..exa_upper_begin..[[column_name]]..exa_upper_end..[[ as "exa_column_name", db2.* from  
+  select ]]..exa_upper_begin..[[table_catalog]]..exa_upper_end..[[ as "exa_table_catalog", ]]..exa_upper_begin..[[table_schema]]..exa_upper_end..[[ as "exa_table_schema", ]]..exa_upper_begin..[[table_name]]..exa_upper_end..[[ as "exa_table_name", ]]..exa_upper_begin..[[column_name]]..exa_upper_end..[[ as "exa_column_name", '"' || replace(table_schema, '"', '""') || '"' as "source_table_schema", '"' || replace(table_name, '"', '""') || '"' as "source_table_name", '"' || replace(column_name, '"', '""') || '"' as "source_column_name", db2.* from
     (import from jdbc at ]]..CONNECTION_NAME..[[ statement 
       'select t.table_catalog, rtrim(t.table_schema) table_schema, rtrim(t.table_name) table_name, column_name, ordinal_position, data_type, character_maximum_length, numeric_precision, numeric_scale, datetime_precision
         from sysibm.columns c join sysibm.tables t on t.table_catalog = c.table_catalog and t.table_schema = c.table_schema and t.table_name = c.table_name
         where t.table_type = ''BASE TABLE'' 
         AND rtrim(t.table_schema) not in (''SYSCAT'',''SYSIBM'', ''SYSIBMADM'', ''SYSPUBLIC'', ''SYSSTAT'', ''SYSTOOLS'')
-        AND rtrim(t.table_schema) like '']]..SCHEMA_FILTER..[[''
-        AND rtrim(t.table_name) like '']]..TABLE_FILTER..[[''
+        AND ]]..db2_filter_begin..[[rtrim(t.table_schema)]]..db2_filter_end..[[ like ]]..db2_filter_begin..[['']]..SCHEMA_FILTER..[['']]..db2_filter_end..[[
+        AND ]]..db2_filter_begin..[[rtrim(t.table_name)]]..db2_filter_end..[[ like ]]..db2_filter_begin..[['']]..TABLE_FILTER..[['']]..db2_filter_end..[[
     ') as db2 order by false
 )
 ,vv_create_schemas as(
@@ -69,15 +73,15 @@ with vv_db2_columns as (
   select 'import into "' || "exa_table_schema" || '"."' || "exa_table_name" || '" from jdbc at ]]..CONNECTION_NAME..[[ statement ''select ' 
            || group_concat(
                          case 
-                         when upper(data_type) = 'BINARY' then 'cast('||column_name||' as char('||character_maximum_length||'))'                           
-                         when upper(data_type) = 'DECFLOAT' then 'cast('||column_name||' as double)'                           
-                         when upper(data_type) in ('CHARACTER LARGE OBJECT', 'DOUBLE-BYTE CHARACTER LARGE OBJECT') then 'cast('||column_name||' as varchar(32500))'                           
+                         when upper(data_type) = 'BINARY' then 'cast('||"source_column_name"||' as char('||character_maximum_length||'))'
+                         when upper(data_type) = 'DECFLOAT' then 'cast('||"source_column_name"||' as double)'
+                         when upper(data_type) in ('CHARACTER LARGE OBJECT', 'DOUBLE-BYTE CHARACTER LARGE OBJECT') then 'cast('||"source_column_name"||' as varchar(32500))'
                          when upper(data_type) in ('BIGINT', 'DECIMAL', 'INTEGER', 'SMALLINT', 'DOUBLE PRECISION', 'REAL', 'DATE', 'TIME', 'TIMESTAMP', 'CHARACTER', 'GRAPHIC', 'CHARACTER VARYING', 'GRAPHIC VARYING')
-                         then column_name 
+                         then "source_column_name"
                          end order by ordinal_position) 
-           || ' from ' || rtrim(table_schema)|| '.' || rtrim(table_name)|| ''';' as sql_text
-  from vv_db2_columns group by "exa_table_catalog","exa_table_schema","exa_table_name", table_schema,table_name
-  order by "exa_table_catalog", "exa_table_schema","exa_table_name", table_schema,table_name
+           || ' from ' || "source_table_schema"|| '.' || "source_table_name"|| ''';' as sql_text
+  from vv_db2_columns group by "exa_table_catalog","exa_table_schema","exa_table_name", "source_table_schema","source_table_name"
+  order by "exa_table_catalog", "exa_table_schema","exa_table_name", "source_table_schema","source_table_name"
 ), base as
 (
 select 1 id, cast('-- ### SCHEMAS ###' as varchar(2000000)) SQL_TEXT

--- a/db2_to_exasol.sql
+++ b/db2_to_exasol.sql
@@ -26,12 +26,12 @@ res = query([[
 with vv_db2_columns as (
   select ]]..exa_upper_begin..[[table_catalog]]..exa_upper_end..[[ as "exa_table_catalog", ]]..exa_upper_begin..[[table_schema]]..exa_upper_end..[[ as "exa_table_schema", ]]..exa_upper_begin..[[table_name]]..exa_upper_end..[[ as "exa_table_name", ]]..exa_upper_begin..[[column_name]]..exa_upper_end..[[ as "exa_column_name", db2.* from  
     (import from jdbc at ]]..CONNECTION_NAME..[[ statement 
-      'select t.table_catalog, rtrim(t.table_schema) table_schema, t.table_name, column_name, ordinal_position, data_type, character_maximum_length, numeric_precision, numeric_scale, datetime_precision  
+      'select t.table_catalog, rtrim(t.table_schema) table_schema, rtrim(t.table_name) table_name, column_name, ordinal_position, data_type, character_maximum_length, numeric_precision, numeric_scale, datetime_precision
         from sysibm.columns c join sysibm.tables t on t.table_catalog = c.table_catalog and t.table_schema = c.table_schema and t.table_name = c.table_name
         where t.table_type = ''BASE TABLE'' 
-        AND t.table_schema not in (''SYSCAT'',''SYSIBM'', ''SYSIBMADM'', ''SYSPUBLIC'', ''SYSSTAT'', ''SYSTOOLS'')
-        AND t.table_schema like '']]..SCHEMA_FILTER..[[''
-        AND t.table_name like '']]..TABLE_FILTER..[[''
+        AND rtrim(t.table_schema) not in (''SYSCAT'',''SYSIBM'', ''SYSIBMADM'', ''SYSPUBLIC'', ''SYSSTAT'', ''SYSTOOLS'')
+        AND rtrim(t.table_schema) like '']]..SCHEMA_FILTER..[[''
+        AND rtrim(t.table_name) like '']]..TABLE_FILTER..[[''
     ') as db2 order by false
 )
 ,vv_create_schemas as(
@@ -75,7 +75,7 @@ with vv_db2_columns as (
                          when upper(data_type) in ('BIGINT', 'DECIMAL', 'INTEGER', 'SMALLINT', 'DOUBLE PRECISION', 'REAL', 'DATE', 'TIME', 'TIMESTAMP', 'CHARACTER', 'GRAPHIC', 'CHARACTER VARYING', 'GRAPHIC VARYING')
                          then column_name 
                          end order by ordinal_position) 
-           || ' from ' || table_schema|| '.' || table_name|| ''';' as sql_text
+           || ' from ' || rtrim(table_schema)|| '.' || rtrim(table_name)|| ''';' as sql_text
   from vv_db2_columns group by "exa_table_catalog","exa_table_schema","exa_table_name", table_schema,table_name
   order by "exa_table_catalog", "exa_table_schema","exa_table_name", table_schema,table_name
 ), base as

--- a/migrate_to_exasol.sql
+++ b/migrate_to_exasol.sql
@@ -301,8 +301,11 @@ end
 -- Per-source metadata SQL. Each template returns 8 columns in this order:
 --   src_schema, src_table, src_rows,
 --   src_pk_col, src_pk_type, src_date_col, src_num_col, src_partitioned
--- Phase 1 emits only src_rows; remaining columns are NULL placeholders.
--- Phase 2+ enriches per-source SQL with PK / date / numeric / partition detection.
+-- Tier 0 sources (POSTGRES, MYSQL, SQLSERVER, SNOWFLAKE) populate all eight columns.
+-- Other sources currently emit only src_rows; splitter falls through to ROWID
+-- or SINGLE depending on dialect capabilities.
+-- BIGQUERY remains skip_with_info: BQ INFORMATION_SCHEMA is dataset-scoped, and
+-- the cross-dataset round-trip needs per-dataset query orchestration not yet built.
 SOURCE_METADATA_BY_SOURCE = {
     ORACLE = {
         mode = 'sql',
@@ -311,27 +314,51 @@ SOURCE_METADATA_BY_SOURCE = {
     },
     POSTGRES = {
         mode = 'sql',
-        template = "select n.nspname, c.relname, c.reltuples::bigint, NULL, NULL, NULL, NULL, NULL from pg_class c join pg_namespace n on n.oid = c.relnamespace where c.relkind in ('r','p') and (<PREDICATE>)",
+        template = "select n.nspname, c.relname, c.reltuples::bigint,"
+            .. " (select a.attname::text from pg_constraint con join pg_attribute a on a.attrelid = con.conrelid and a.attnum = con.conkey[1] where con.conrelid = c.oid and con.contype = 'p' and array_length(con.conkey, 1) = 1 and a.atttypid in (20, 21, 23, 700, 701, 1700) limit 1),"
+            .. " (select format_type(a.atttypid, a.atttypmod) from pg_constraint con join pg_attribute a on a.attrelid = con.conrelid and a.attnum = con.conkey[1] where con.conrelid = c.oid and con.contype = 'p' and array_length(con.conkey, 1) = 1 and a.atttypid in (20, 21, 23, 700, 701, 1700) limit 1),"
+            .. " (select a.attname::text from pg_attribute a where a.attrelid = c.oid and a.attnum > 0 and not a.attisdropped and a.atttypid in (1082, 1114, 1184) order by (case when a.attname ~* '(date|dt|time|day|created|loaded|event|posted)$' then 0 else 1 end), a.attnum limit 1),"
+            .. " (select a.attname::text from pg_attribute a where a.attrelid = c.oid and a.attnum > 0 and not a.attisdropped and a.attnotnull and a.atttypid in (20, 21, 23, 700, 701, 1700) order by a.attnum limit 1),"
+            .. " (c.relkind = 'p')"
+            .. " from pg_class c join pg_namespace n on n.oid = c.relnamespace where c.relkind in ('r','p') and (<PREDICATE>)",
         pair = "(n.nspname = '%s' and c.relname = '%s')",
     },
     MYSQL = {
         mode = 'sql',
-        template = "select table_schema, table_name, table_rows, NULL, NULL, NULL, NULL, NULL from information_schema.tables where (<PREDICATE>)",
-        pair = "(table_schema = '%s' and table_name = '%s')",
+        template = "select t.table_schema, t.table_name, t.table_rows,"
+            .. " (select kcu.column_name from information_schema.key_column_usage kcu join information_schema.table_constraints tc on tc.constraint_name = kcu.constraint_name and tc.table_schema = kcu.table_schema and tc.table_name = kcu.table_name join information_schema.columns col on col.table_schema = kcu.table_schema and col.table_name = kcu.table_name and col.column_name = kcu.column_name where tc.constraint_type = 'PRIMARY KEY' and kcu.table_schema = t.table_schema and kcu.table_name = t.table_name and col.data_type in ('tinyint','smallint','mediumint','int','bigint','decimal','numeric','float','double') and kcu.constraint_name in (select constraint_name from information_schema.key_column_usage where table_schema = t.table_schema and table_name = t.table_name group by constraint_name having count(*) = 1) limit 1),"
+            .. " (select col.data_type from information_schema.columns col where col.table_schema = t.table_schema and col.table_name = t.table_name and col.column_name = (select kcu.column_name from information_schema.key_column_usage kcu join information_schema.table_constraints tc on tc.constraint_name = kcu.constraint_name and tc.table_schema = kcu.table_schema and tc.table_name = kcu.table_name where tc.constraint_type = 'PRIMARY KEY' and kcu.table_schema = t.table_schema and kcu.table_name = t.table_name limit 1) limit 1),"
+            .. " (select column_name from information_schema.columns where table_schema = t.table_schema and table_name = t.table_name and data_type in ('date','datetime','timestamp') order by (case when lower(column_name) regexp '(date|dt|time|day|created|loaded|event|posted)$' then 0 else 1 end), ordinal_position limit 1),"
+            .. " (select column_name from information_schema.columns where table_schema = t.table_schema and table_name = t.table_name and is_nullable = 'NO' and data_type in ('tinyint','smallint','mediumint','int','bigint','decimal','numeric','float','double') order by ordinal_position limit 1),"
+            .. " (select count(*) > 0 from information_schema.partitions where table_schema = t.table_schema and table_name = t.table_name and partition_name is not null)"
+            .. " from information_schema.tables t where (<PREDICATE>)",
+        pair = "(t.table_schema = '%s' and t.table_name = '%s')",
     },
     SQLSERVER = {
         mode = 'sql',
-        template = "select s.name as schema_name, t.name as table_name, sum(ps.row_count) as row_count, NULL, NULL, NULL, NULL, NULL from sys.tables t join sys.schemas s on s.schema_id = t.schema_id join sys.dm_db_partition_stats ps on ps.object_id = t.object_id and ps.index_id in (0,1) where (<PREDICATE>) group by s.name, t.name",
+        template = "select s.name as src_schema, t.name as src_table, sum(ps.row_count) as src_rows,"
+            .. " (select top 1 c2.name from sys.indexes i join sys.index_columns ic on ic.object_id = i.object_id and ic.index_id = i.index_id join sys.columns c2 on c2.object_id = ic.object_id and c2.column_id = ic.column_id join sys.types ty on ty.user_type_id = c2.user_type_id where i.object_id = t.object_id and i.is_primary_key = 1 and ty.name in ('tinyint','smallint','int','bigint','decimal','numeric','float','real','money','smallmoney') and (select count(*) from sys.index_columns ic2 where ic2.object_id = i.object_id and ic2.index_id = i.index_id) = 1) as src_pk_col,"
+            .. " (select top 1 ty.name from sys.indexes i join sys.index_columns ic on ic.object_id = i.object_id and ic.index_id = i.index_id join sys.columns c2 on c2.object_id = ic.object_id and c2.column_id = ic.column_id join sys.types ty on ty.user_type_id = c2.user_type_id where i.object_id = t.object_id and i.is_primary_key = 1 and ty.name in ('tinyint','smallint','int','bigint','decimal','numeric','float','real','money','smallmoney') and (select count(*) from sys.index_columns ic2 where ic2.object_id = i.object_id and ic2.index_id = i.index_id) = 1) as src_pk_type,"
+            .. " (select top 1 c2.name from sys.columns c2 join sys.types ty on ty.user_type_id = c2.user_type_id where c2.object_id = t.object_id and ty.name in ('date','datetime','datetime2','smalldatetime','datetimeoffset','time') order by (case when lower(c2.name) like '%date' or lower(c2.name) like '%dt' or lower(c2.name) like '%time' or lower(c2.name) like '%day' or lower(c2.name) like '%created' or lower(c2.name) like '%loaded' or lower(c2.name) like '%event' or lower(c2.name) like '%posted' then 0 else 1 end), c2.column_id) as src_date_col,"
+            .. " (select top 1 c2.name from sys.columns c2 join sys.types ty on ty.user_type_id = c2.user_type_id where c2.object_id = t.object_id and c2.is_nullable = 0 and ty.name in ('tinyint','smallint','int','bigint','decimal','numeric','float','real','money','smallmoney') order by c2.column_id) as src_num_col,"
+            .. " (case when exists(select 1 from sys.partitions p where p.object_id = t.object_id and p.partition_number > 1) then 1 else 0 end) as src_partitioned"
+            .. " from sys.tables t join sys.schemas s on s.schema_id = t.schema_id join sys.dm_db_partition_stats ps on ps.object_id = t.object_id and ps.index_id in (0, 1) where (<PREDICATE>) group by s.name, t.name, t.object_id",
         pair = "(s.name = '%s' and t.name = '%s')",
     },
     SNOWFLAKE = {
         mode = 'sql',
-        template = "select table_schema, table_name, row_count, NULL, NULL, NULL, NULL, NULL from information_schema.tables where (<PREDICATE>)",
-        pair = "(table_schema = '%s' and table_name = '%s')",
+        template = "select t.table_schema, t.table_name, t.row_count,"
+            .. " (select kcu.column_name from information_schema.table_constraints tc join information_schema.key_column_usage kcu on kcu.constraint_name = tc.constraint_name and kcu.table_schema = tc.table_schema and kcu.table_name = tc.table_name join information_schema.columns col on col.table_schema = kcu.table_schema and col.table_name = kcu.table_name and col.column_name = kcu.column_name where tc.constraint_type = 'PRIMARY KEY' and tc.table_schema = t.table_schema and tc.table_name = t.table_name and col.data_type in ('NUMBER','DECIMAL','FLOAT','REAL','DOUBLE','INTEGER','BIGINT','SMALLINT','TINYINT','BYTEINT') and (select count(*) from information_schema.key_column_usage k2 where k2.constraint_name = tc.constraint_name and k2.table_schema = tc.table_schema and k2.table_name = tc.table_name) = 1 limit 1) as src_pk_col,"
+            .. " (select col.data_type from information_schema.columns col where col.table_schema = t.table_schema and col.table_name = t.table_name and col.column_name = (select kcu.column_name from information_schema.table_constraints tc join information_schema.key_column_usage kcu on kcu.constraint_name = tc.constraint_name and kcu.table_schema = tc.table_schema and kcu.table_name = tc.table_name where tc.constraint_type = 'PRIMARY KEY' and tc.table_schema = t.table_schema and tc.table_name = t.table_name limit 1) limit 1) as src_pk_type,"
+            .. " (select column_name from information_schema.columns where table_schema = t.table_schema and table_name = t.table_name and data_type in ('DATE','TIMESTAMP','TIMESTAMP_LTZ','TIMESTAMP_NTZ','TIMESTAMP_TZ','DATETIME','TIME') order by (case when lower(column_name) regexp '(date|dt|time|day|created|loaded|event|posted)$' then 0 else 1 end), ordinal_position limit 1) as src_date_col,"
+            .. " (select column_name from information_schema.columns where table_schema = t.table_schema and table_name = t.table_name and is_nullable = 'NO' and data_type in ('NUMBER','DECIMAL','FLOAT','REAL','DOUBLE','INTEGER','BIGINT','SMALLINT','TINYINT','BYTEINT') order by ordinal_position limit 1) as src_num_col,"
+            .. " FALSE as src_partitioned"
+            .. " from information_schema.tables t where (<PREDICATE>)",
+        pair = "(t.table_schema = '%s' and t.table_name = '%s')",
     },
     BIGQUERY = {
         mode = 'skip_with_info',
-        reason = 'per-dataset INFORMATION_SCHEMA lookup not yet implemented',
+        reason = 'BigQuery INFORMATION_SCHEMA is dataset-scoped; per-dataset metadata round-trip not yet implemented',
     },
     REDSHIFT = {
         mode = 'sql',
@@ -371,6 +398,93 @@ SOURCE_METADATA_BY_SOURCE = {
 }
 SOURCE_METADATA_BY_SOURCE.MARIADB = SOURCE_METADATA_BY_SOURCE.MYSQL
 SOURCE_METADATA_BY_SOURCE.AZURE_SQL = SOURCE_METADATA_BY_SOURCE.SQLSERVER
+
+-- Per-source SQL-dialect building blocks consumed by transform_for_split.
+-- Each entry exposes pushdown-friendly fragments for date bucketing, hash
+-- bucketing, and (where supported) ROWID-range bucketing. Sources missing an
+-- entry fall through to SINGLE in the split hierarchy.
+DIALECT_BY_SOURCE = {
+    POSTGRES = {
+        month_fn = function(col) return 'EXTRACT(MONTH FROM "' .. col .. '")' end,
+        day_fn = function(col) return 'EXTRACT(DAY FROM "' .. col .. '")' end,
+        year_month_fn = function(col) return '(EXTRACT(YEAR FROM "' .. col .. '") * 12 + EXTRACT(MONTH FROM "' .. col .. '"))' end,
+        hash_where = function(col, n, k) return 'MOD(ABS(HASHTEXT("' .. col .. '"::text)), ' .. n .. ') = ' .. k end,
+        rowid_supported = true,
+        rowid_expr = 'ctid',
+        rowid_where = function(n, k) return 'MOD(ABS(HASHTEXT(ctid::text)), ' .. n .. ') = ' .. k end,
+    },
+    SQLSERVER = {
+        month_fn = function(col) return 'MONTH("' .. col .. '")' end,
+        day_fn = function(col) return 'DAY("' .. col .. '")' end,
+        year_month_fn = function(col) return '(YEAR("' .. col .. '") * 12 + MONTH("' .. col .. '"))' end,
+        hash_where = function(col, n, k) return '(ABS(CHECKSUM("' .. col .. '")) % ' .. n .. ') = ' .. k end,
+        rowid_supported = true,
+        rowid_expr = '%%physloc%%',
+        rowid_where = function(n, k) return '(ABS(CHECKSUM(%%physloc%%)) % ' .. n .. ') = ' .. k end,
+    },
+    MYSQL = {
+        month_fn = function(col) return 'MONTH("' .. col .. '")' end,
+        day_fn = function(col) return 'DAY("' .. col .. '")' end,
+        year_month_fn = function(col) return '(YEAR("' .. col .. '") * 12 + MONTH("' .. col .. '"))' end,
+        hash_where = function(col, n, k) return '(CONV(SUBSTRING(MD5(CAST("' .. col .. '" AS CHAR)), 1, 8), 16, 10) MOD ' .. n .. ') = ' .. k end,
+        rowid_supported = false,
+    },
+    SNOWFLAKE = {
+        month_fn = function(col) return 'MONTH("' .. col .. '")' end,
+        day_fn = function(col) return 'DAY("' .. col .. '")' end,
+        year_month_fn = function(col) return '(YEAR("' .. col .. '") * 12 + MONTH("' .. col .. '"))' end,
+        hash_where = function(col, n, k) return '(ABS(HASH("' .. col .. '")) % ' .. n .. ') = ' .. k end,
+        rowid_supported = false,
+    },
+    ORACLE = {
+        month_fn = function(col) return 'EXTRACT(MONTH FROM "' .. col .. '")' end,
+        day_fn = function(col) return 'EXTRACT(DAY FROM "' .. col .. '")' end,
+        year_month_fn = function(col) return '(EXTRACT(YEAR FROM "' .. col .. '") * 12 + EXTRACT(MONTH FROM "' .. col .. '"))' end,
+        hash_where = function(col, n, k) return 'MOD(ORA_HASH("' .. col .. '"), ' .. n .. ') = ' .. k end,
+        rowid_supported = true,
+        rowid_expr = 'ROWID',
+        rowid_where = function(n, k) return 'MOD(ORA_HASH(ROWID), ' .. n .. ') = ' .. k end,
+    },
+    DB2 = {
+        month_fn = function(col) return 'MONTH("' .. col .. '")' end,
+        day_fn = function(col) return 'DAY("' .. col .. '")' end,
+        year_month_fn = function(col) return '(YEAR("' .. col .. '") * 12 + MONTH("' .. col .. '"))' end,
+        hash_where = function(col, n, k) return 'MOD(HASH4("' .. col .. '"), ' .. n .. ') = ' .. k end,
+        rowid_supported = true,
+        rowid_expr = 'RID_BIT(t)',
+        rowid_where = function(n, k) return 'MOD(HASH4(RID_BIT(t)), ' .. n .. ') = ' .. k end,
+    },
+    VERTICA = {
+        month_fn = function(col) return 'MONTH("' .. col .. '")' end,
+        day_fn = function(col) return 'DAY("' .. col .. '")' end,
+        year_month_fn = function(col) return '(YEAR("' .. col .. '") * 12 + MONTH("' .. col .. '"))' end,
+        hash_where = function(col, n, k) return 'MOD(HASH("' .. col .. '"), ' .. n .. ') = ' .. k end,
+        rowid_supported = false,
+    },
+    HANA = {
+        month_fn = function(col) return 'MONTH("' .. col .. '")' end,
+        day_fn = function(col) return 'DAYOFMONTH("' .. col .. '")' end,
+        year_month_fn = function(col) return '(YEAR("' .. col .. '") * 12 + MONTH("' .. col .. '"))' end,
+        hash_where = function(col, n, k) return 'MOD(HASH_SHA256("' .. col .. '"), ' .. n .. ') = ' .. k end,
+        rowid_supported = false,
+    },
+    REDSHIFT = {
+        month_fn = function(col) return 'EXTRACT(MONTH FROM "' .. col .. '")' end,
+        day_fn = function(col) return 'EXTRACT(DAY FROM "' .. col .. '")' end,
+        year_month_fn = function(col) return '(EXTRACT(YEAR FROM "' .. col .. '") * 12 + EXTRACT(MONTH FROM "' .. col .. '"))' end,
+        hash_where = function(col, n, k) return '(STRTOL(SUBSTRING(MD5("' .. col .. '"::varchar), 1, 8), 16) % ' .. n .. ') = ' .. k end,
+        rowid_supported = false,
+    },
+    DATABRICKS = {
+        month_fn = function(col) return 'MONTH(`' .. col .. '`)' end,
+        day_fn = function(col) return 'DAY(`' .. col .. '`)' end,
+        year_month_fn = function(col) return '(YEAR(`' .. col .. '`) * 12 + MONTH(`' .. col .. '`))' end,
+        hash_where = function(col, n, k) return 'PMOD(HASH(`' .. col .. '`), ' .. n .. ') = ' .. k end,
+        rowid_supported = false,
+    },
+}
+DIALECT_BY_SOURCE.MARIADB = DIALECT_BY_SOURCE.MYSQL
+DIALECT_BY_SOURCE.AZURE_SQL = DIALECT_BY_SOURCE.SQLSERVER
 
 function count_statement_clauses(sql)
     if sql == nil then return 0 end
@@ -423,25 +537,41 @@ function parse_threshold(options)
 end
 
 -- Collects unique source (schema, table) pairs the metadata round-trip needs.
--- Phase 1: gate is the only consumer, so only multi-statement IMPORTs require a lookup.
--- Phase 2 will broaden this when the splitter goes live.
+-- Multi-statement IMPORTs are needed by the gate (Speq 1) for threshold-collapse.
+-- Single-statement IMPORTs are needed by the splitter (Speq 2) for expansion.
+-- A single round-trip serves both consumers; the cache is keyed on source ident.
+-- Skipped entirely when threshold = 0 AND splitter is OFF AND PARALLEL_STATEMENTS = 1.
 function collect_metadata_pairs(res, options)
     local pair_list = {}
     local pairs_seen = {}
     if res == nil then return pair_list end
 
     local threshold = parse_threshold(options)
-    if threshold <= 0 then return pair_list end
+    local split_directive_ok, split_directive = pcall(parse_split_directive, options)
+    local split_off = split_directive_ok and split_directive.mode == 'OFF'
+    local resolved_n = resolve_split_n(options, nil)
+    local splitter_disabled = split_off or resolved_n < 2
+
+    if threshold <= 0 and splitter_disabled then return pair_list end
 
     for i = 1, #res do
         local sql_text = first_sql_text(res[i])
-        if classify_step(sql_text) == 'IMPORT' and count_statement_clauses(sql_text) > 1 then
-            local src_schema, src_table = extract_source_ref_from_import(sql_text)
-            if src_schema ~= nil and src_table ~= nil then
-                local key = src_schema .. '\t' .. src_table
-                if not pairs_seen[key] then
-                    pairs_seen[key] = true
-                    pair_list[#pair_list + 1] = { schema = src_schema, table_name = src_table }
+        if classify_step(sql_text) == 'IMPORT' then
+            local clauses = count_statement_clauses(sql_text)
+            local relevant = false
+            if clauses > 1 and threshold > 0 then
+                relevant = true
+            elseif clauses == 1 and not splitter_disabled and threshold > 0 then
+                relevant = true
+            end
+            if relevant then
+                local src_schema, src_table = extract_source_ref_from_import(sql_text)
+                if src_schema ~= nil and src_table ~= nil then
+                    local key = src_schema .. '\t' .. src_table
+                    if not pairs_seen[key] then
+                        pairs_seen[key] = true
+                        pair_list[#pair_list + 1] = { schema = src_schema, table_name = src_table }
+                    end
                 end
             end
         end
@@ -563,6 +693,340 @@ function transform_for_gate(res, options, cache)
     return out
 end
 
+function parse_split_directive(options)
+    local raw = blank_to_nil(opt(options, 'PARALLEL_SPLIT', 'AUTO')) or 'AUTO'
+    local up = string.upper(raw)
+    if up == 'AUTO' then return { mode = 'AUTO' } end
+    if up == 'OFF' then return { mode = 'OFF' } end
+    if up == 'PK' then return { mode = 'PK' } end
+    if up == 'PARTITION' then return { mode = 'PARTITION' } end
+    if up == 'ROWID' then return { mode = 'ROWID' } end
+    if up == 'DATE' then return { mode = 'DATE' } end
+
+    local prefix, rest = raw:match('^([^:]+):(.+)$')
+    if prefix and string.upper(prefix) == 'DATE' then
+        local col, grain = rest:match('^([^:]+):(.+)$')
+        if col then return { mode = 'DATE', col = col, grain = string.upper(grain) } end
+        return { mode = 'DATE', col = rest }
+    end
+    if prefix and string.upper(prefix) == 'HASH' then
+        return { mode = 'HASH', col = rest }
+    end
+    error('Invalid PARALLEL_SPLIT value: ' .. tostring(raw))
+end
+
+-- Phase 2 N-resolver: explicit positive integer in PARALLEL_STATEMENTS yields N.
+-- AUTO is a Phase-3 feature; it currently short-circuits to 1 (= no split). The
+-- splitter is still wired so that Phase 3 only needs to swap this function out
+-- for the row-count heuristic specified in parallel-auto-ceiling.
+function resolve_split_n(options, src_rows)
+    local raw = blank_to_nil(opt(options, 'PARALLEL_STATEMENTS', 'AUTO')) or 'AUTO'
+    if string.upper(raw) == 'AUTO' then return 1 end
+    local n = tonumber(raw)
+    if n == nil then return 1 end
+    n = math.floor(n)
+    if n < 1 then return 1 end
+    return n
+end
+
+function is_numeric_pk_type(type_str)
+    if type_str == nil then return false end
+    local up = string.upper(tostring(type_str))
+    if up == '' then return false end
+    if up:find('INT', 1, true) then return true end
+    if up:find('NUMERIC', 1, true) then return true end
+    if up:find('NUMBER', 1, true) then return true end
+    if up:find('DECIMAL', 1, true) then return true end
+    if up:find('FLOAT', 1, true) then return true end
+    if up:find('DOUBLE', 1, true) then return true end
+    if up:find('REAL', 1, true) then return true end
+    if up == 'SERIAL' or up == 'BIGSERIAL' or up == 'SMALLSERIAL' then return true end
+    return false
+end
+
+function pick_split_strategy(meta, options, dialect, source_type)
+    local directive = parse_split_directive(options)
+    if directive.mode == 'OFF' then return nil, nil end
+
+    if directive.mode == 'AUTO' then
+        if meta == nil then return nil, 'metadata cache empty' end
+        if meta.src_pk_col and is_numeric_pk_type(meta.src_pk_type) then
+            return { strategy = 'PK_RANGE', key = meta.src_pk_col }
+        end
+        if meta.src_date_col then
+            return { strategy = 'DATE_BUCKET', key = meta.src_date_col }
+        end
+        if meta.src_num_col then
+            return { strategy = 'HASH_NUM', key = meta.src_num_col }
+        end
+        if dialect and dialect.rowid_supported then
+            return { strategy = 'ROWID', key = dialect.rowid_expr }
+        end
+        return nil, 'no usable split column for ' .. tostring(source_type)
+    end
+
+    if directive.mode == 'PK' then
+        if meta and meta.src_pk_col and is_numeric_pk_type(meta.src_pk_type) then
+            return { strategy = 'PK_RANGE', key = meta.src_pk_col }
+        end
+        return nil, 'PARALLEL_SPLIT=PK requested but no numeric PK in metadata'
+    end
+
+    if directive.mode == 'DATE' then
+        local col = directive.col or (meta and meta.src_date_col)
+        if col == nil then return nil, 'PARALLEL_SPLIT=DATE but no date column known' end
+        return { strategy = 'DATE_BUCKET', key = col, grain = directive.grain }
+    end
+
+    if directive.mode == 'HASH' then
+        if directive.col == nil then return nil, 'PARALLEL_SPLIT=HASH requires a column name' end
+        return { strategy = 'HASH_NUM', key = directive.col }
+    end
+
+    if directive.mode == 'ROWID' then
+        if dialect and dialect.rowid_supported then
+            return { strategy = 'ROWID', key = dialect.rowid_expr }
+        end
+        return nil, 'PARALLEL_SPLIT=ROWID unsupported for ' .. tostring(source_type)
+    end
+
+    if directive.mode == 'PARTITION' then
+        return nil, 'PARALLEL_SPLIT=PARTITION not supported in v1'
+    end
+
+    return nil, 'unsupported PARALLEL_SPLIT mode ' .. tostring(directive.mode)
+end
+
+function build_date_bucket(col, grain, dialect, n, k)
+    if dialect == nil or dialect.month_fn == nil then return nil end
+
+    local resolved_grain = grain
+    if resolved_grain == nil then
+        if n == 2 then resolved_grain = 'HALF'
+        elseif n == 3 then resolved_grain = 'TRIMESTER'
+        elseif n == 4 then resolved_grain = 'QUARTER'
+        elseif n == 6 then resolved_grain = 'BIMONTH'
+        elseif n == 12 then resolved_grain = 'MONTH'
+        elseif n <= 31 then resolved_grain = 'DAY'
+        else resolved_grain = 'YEAR_MONTH' end
+    end
+
+    local clause
+    if resolved_grain == 'MONTH' then
+        if n == 12 then
+            clause = dialect.month_fn(col) .. ' = ' .. (k + 1)
+        else
+            local months = {}
+            local m = k + 1
+            while m <= 12 do months[#months + 1] = tostring(m); m = m + n end
+            clause = dialect.month_fn(col) .. ' IN (' .. table.concat(months, ', ') .. ')'
+        end
+    elseif resolved_grain == 'QUARTER' then
+        local m0 = k * 3 + 1
+        clause = dialect.month_fn(col) .. ' IN (' .. m0 .. ', ' .. (m0 + 1) .. ', ' .. (m0 + 2) .. ')'
+    elseif resolved_grain == 'HALF' then
+        if k == 0 then clause = dialect.month_fn(col) .. ' IN (1, 2, 3, 4, 5, 6)'
+        else clause = dialect.month_fn(col) .. ' IN (7, 8, 9, 10, 11, 12)' end
+    elseif resolved_grain == 'TRIMESTER' then
+        local m0 = k * 4 + 1
+        clause = dialect.month_fn(col) .. ' IN (' .. m0 .. ', ' .. (m0 + 1) .. ', ' .. (m0 + 2) .. ', ' .. (m0 + 3) .. ')'
+    elseif resolved_grain == 'BIMONTH' then
+        local m0 = k * 2 + 1
+        clause = dialect.month_fn(col) .. ' IN (' .. m0 .. ', ' .. (m0 + 1) .. ')'
+    elseif resolved_grain == 'DAY' then
+        if dialect.day_fn == nil then return nil end
+        if k == n - 1 and n < 31 then
+            local days = {}
+            for d = n + 1, 31 do days[#days + 1] = tostring(d) end
+            if #days == 0 then
+                clause = dialect.day_fn(col) .. ' = ' .. (k + 1)
+            else
+                clause = dialect.day_fn(col) .. ' IN (' .. (k + 1) .. ', ' .. table.concat(days, ', ') .. ')'
+            end
+        else
+            clause = dialect.day_fn(col) .. ' = ' .. (k + 1)
+        end
+    elseif resolved_grain == 'YEAR_MONTH' then
+        if dialect.year_month_fn == nil then return nil end
+        clause = 'MOD(' .. dialect.year_month_fn(col) .. ', ' .. n .. ') = ' .. k
+    else
+        return nil
+    end
+
+    if k == 0 then
+        clause = '(' .. clause .. ' OR "' .. col .. '" IS NULL)'
+    end
+    return clause
+end
+
+function build_where_for_split(decision, dialect, n, k)
+    if decision == nil then return nil end
+    if decision.strategy == 'PK_RANGE' or decision.strategy == 'UNIQUE_NUM' then
+        return 'MOD("' .. decision.key .. '", ' .. n .. ') = ' .. k
+    end
+    if decision.strategy == 'DATE_BUCKET' then
+        return build_date_bucket(decision.key, decision.grain, dialect, n, k)
+    end
+    if decision.strategy == 'HASH_NUM' then
+        if dialect == nil or dialect.hash_where == nil then return nil end
+        return dialect.hash_where(decision.key, n, k)
+    end
+    if decision.strategy == 'ROWID' then
+        if dialect == nil or dialect.rowid_where == nil then return nil end
+        return dialect.rowid_where(n, k)
+    end
+    return nil
+end
+
+function append_where_to_inner_select(inner, where_clause)
+    local lower = inner:lower()
+    local where_pos = nil
+    local cut_pos = #inner + 1
+
+    local i = 1
+    local in_string = false
+    while i <= #inner do
+        local c = inner:sub(i, i)
+        if in_string then
+            if c == "'" then
+                if inner:sub(i + 1, i + 1) == "'" then i = i + 2
+                else in_string = false; i = i + 1 end
+            else i = i + 1 end
+        elseif c == "'" then
+            in_string = true; i = i + 1
+        else
+            local before_ok = (i == 1) or inner:sub(i - 1, i - 1):match('[%s%)]') ~= nil
+            if before_ok then
+                local six = lower:sub(i, i + 5)
+                if (six == 'where ' or six == 'where\t' or six == 'where\n') and where_pos == nil then
+                    where_pos = i
+                end
+                if six == 'group ' or six == 'order ' or six == 'having' then
+                    if i < cut_pos then cut_pos = i end
+                end
+                if lower:sub(i, i + 4) == 'limit' then
+                    local trail = inner:sub(i + 5, i + 5)
+                    if trail == '' or trail:match('[%s]') then
+                        if i < cut_pos then cut_pos = i end
+                    end
+                end
+            end
+            i = i + 1
+        end
+    end
+
+    local head = inner:sub(1, cut_pos - 1)
+    local tail = inner:sub(cut_pos)
+    local trimmed = head:gsub('%s+$', '')
+
+    if where_pos and where_pos < cut_pos then
+        if tail == '' then return trimmed .. ' AND (' .. where_clause .. ')' end
+        return trimmed .. ' AND (' .. where_clause .. ') ' .. tail
+    end
+    if tail == '' then return trimmed .. ' WHERE ' .. where_clause end
+    return trimmed .. ' WHERE ' .. where_clause .. ' ' .. tail
+end
+
+function rewrite_import_to_multi_stmt(sql, where_per_k, n)
+    local stmt_start = string.find(sql:lower(), "statement%s+'")
+    if not stmt_start then return nil end
+    local quote_open = sql:find("'", stmt_start)
+    if not quote_open then return nil end
+
+    local i = quote_open + 1
+    local inner_end = nil
+    while i <= #sql do
+        local c = sql:sub(i, i)
+        if c == "'" then
+            if sql:sub(i + 1, i + 1) == "'" then i = i + 2
+            else inner_end = i - 1; break end
+        else i = i + 1 end
+    end
+    if inner_end == nil then return nil end
+
+    local prefix = sql:sub(1, stmt_start - 1):gsub('%s+$', '')
+    local inner_escaped = sql:sub(quote_open + 1, inner_end)
+    local inner = inner_escaped:gsub("''", "'")
+
+    local out = prefix
+    for k = 0, n - 1 do
+        local where = where_per_k[k + 1]
+        if where == nil then return nil end
+        local modified = append_where_to_inner_select(inner, where)
+        local re_escaped = modified:gsub("'", "''")
+        out = out .. " STATEMENT '" .. re_escaped .. "'"
+    end
+    return out
+end
+
+-- Speq 2 splitter: expands single-statement IMPORTs at-or-above
+-- PARALLEL_ROW_THRESHOLD into N parallel STATEMENT clauses with pushdown-friendly
+-- WHERE selectors picked via the split-strategy hierarchy. Multi-statement
+-- IMPORTs are left untouched (the adapter already chose its split). Any failure
+-- inside the splitter logs an INFO row and leaves the IMPORT unchanged - the
+-- splitter is an optimization and MUST NOT break a migration.
+function transform_for_split(res, options, cache, source_type)
+    if res == nil or #res == 0 then return res end
+
+    local directive_ok, directive = pcall(parse_split_directive, options)
+    if not directive_ok then return res end
+    if directive.mode == 'OFF' then return res end
+    if cache == nil or not cache.available then return res end
+
+    local threshold = parse_threshold(options)
+    if threshold <= 0 then return res end
+
+    local dialect = DIALECT_BY_SOURCE[source_type]
+
+    local out = {}
+    for j = 1, #res do out[j] = res[j] end
+
+    local info_rows = {}
+
+    for i = 1, #res do
+        local sql_text = first_sql_text(res[i])
+        if classify_step(sql_text) == 'IMPORT' and count_statement_clauses(sql_text) == 1 then
+            local src_schema, src_table = extract_source_ref_from_import(sql_text)
+            if src_schema ~= nil and src_table ~= nil then
+                local meta = cache.rows[src_schema .. '\t' .. src_table]
+                local rowcount = meta and tonumber(meta.src_rows) or 0
+                if rowcount >= threshold then
+                    local n = resolve_split_n(options, rowcount)
+                    if n >= 2 then
+                        local decision, reason = pick_split_strategy(meta, options, dialect, source_type)
+                        if decision ~= nil then
+                            local where_per_k = {}
+                            local build_ok = true
+                            for k = 0, n - 1 do
+                                local w = build_where_for_split(decision, dialect, n, k)
+                                if w == nil then build_ok = false; break end
+                                where_per_k[#where_per_k + 1] = w
+                            end
+                            if build_ok then
+                                local rewritten = rewrite_import_to_multi_stmt(sql_text, where_per_k, n)
+                                if rewritten ~= nil then
+                                    out[i] = replace_row_sql(out[i], rewritten)
+                                else
+                                    info_rows[#info_rows + 1] = '-- PARALLEL_SPLIT: rewrite failed for ' .. src_schema .. '.' .. src_table .. ' -- IMPORT left unchanged'
+                                end
+                            else
+                                info_rows[#info_rows + 1] = '-- PARALLEL_SPLIT: WHERE-builder failed for ' .. src_schema .. '.' .. src_table .. ' -- IMPORT left unchanged'
+                            end
+                        elseif reason ~= nil then
+                            info_rows[#info_rows + 1] = '-- PARALLEL_SPLIT: ' .. src_schema .. '.' .. src_table .. ' -> SINGLE (' .. reason .. ')'
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    for _, t in ipairs(info_rows) do
+        out[#out + 1] = { SQL_TEXT = t }
+    end
+    return out
+end
+
 function execute_adapter(adapter_sql, debug, ctx)
     local success, res = pquery(adapter_sql)
     if not success then
@@ -572,6 +1036,7 @@ function execute_adapter(adapter_sql, debug, ctx)
     if ctx ~= nil then
         local cache = transform_for_metadata(res, ctx.source_type, ctx.connection_name, ctx.options)
         res = transform_for_gate(res, ctx.options, cache)
+        res = transform_for_split(res, ctx.options, cache, ctx.source_type)
     end
 
     if not debug then

--- a/migrate_to_exasol.sql
+++ b/migrate_to_exasol.sql
@@ -648,19 +648,26 @@ function transform_for_metadata(res, source_type, connection_name, options)
         }
     end
 
+    -- Exasol's IMPORT-FROM-JDBC layer returns SQL NULLs as a userdata sentinel,
+    -- not Lua nil. Coerce here so downstream truthiness checks work as written.
+    local function nullify(v)
+        if is_null(v) then return nil end
+        return v
+    end
+
     local rows = {}
     for i = 1, #lookup_res do
         local r = lookup_res[i]
-        local s = r.SRC_SCHEMA or r[1]
-        local t = r.SRC_TABLE or r[2]
+        local s = nullify(r.SRC_SCHEMA or r[1])
+        local t = nullify(r.SRC_TABLE or r[2])
         if s ~= nil and t ~= nil then
             rows[tostring(s) .. '\t' .. tostring(t)] = {
-                src_rows = r.SRC_ROWS or r[3],
-                src_pk_col = r.SRC_PK_COL or r[4],
-                src_pk_type = r.SRC_PK_TYPE or r[5],
-                src_date_col = r.SRC_DATE_COL or r[6],
-                src_num_col = r.SRC_NUM_COL or r[7],
-                src_partitioned = r.SRC_PARTITIONED or r[8],
+                src_rows = nullify(r.SRC_ROWS or r[3]),
+                src_pk_col = nullify(r.SRC_PK_COL or r[4]),
+                src_pk_type = nullify(r.SRC_PK_TYPE or r[5]),
+                src_date_col = nullify(r.SRC_DATE_COL or r[6]),
+                src_num_col = nullify(r.SRC_NUM_COL or r[7]),
+                src_partitioned = nullify(r.SRC_PARTITIONED or r[8]),
             }
         end
     end

--- a/migrate_to_exasol.sql
+++ b/migrate_to_exasol.sql
@@ -516,8 +516,22 @@ end
 
 function extract_source_ref_from_import(sql)
     if sql == nil then return nil, nil end
+    -- Postgres / Oracle / MySQL / Snowflake adapters quote source identifiers
+    -- with double quotes. Match those first.
     local schema, table_name = sql:match('[Ff][Rr][Oo][Mm]%s+"([^"]+)"%."([^"]+)"')
-    return schema, table_name
+    if schema and table_name then return schema, table_name end
+    -- SQL Server / Azure SQL adapter uses [bracket] quoting and may emit a
+    -- three-part name `[db].[schema].[table]`. Reduce to (schema, table).
+    local db, sch, tab = sql:match('[Ff][Rr][Oo][Mm]%s+%[([^%]]+)%]%.%[([^%]]+)%]%.%[([^%]]+)%]')
+    if db and sch and tab then return sch, tab end
+    schema, table_name = sql:match('[Ff][Rr][Oo][Mm]%s+%[([^%]]+)%]%.%[([^%]]+)%]')
+    if schema and table_name then return schema, table_name end
+    -- Databricks adapter uses backticks (`db`.`schema`.`table` or `schema`.`table`).
+    local db_b, sch_b, tab_b = sql:match('[Ff][Rr][Oo][Mm]%s+`([^`]+)`%.`([^`]+)`%.`([^`]+)`')
+    if db_b and sch_b and tab_b then return sch_b, tab_b end
+    schema, table_name = sql:match('[Ff][Rr][Oo][Mm]%s+`([^`]+)`%.`([^`]+)`')
+    if schema and table_name then return schema, table_name end
+    return nil, nil
 end
 
 function rewrite_to_first_statement(sql)

--- a/migrate_to_exasol.sql
+++ b/migrate_to_exasol.sql
@@ -25,7 +25,7 @@ create or replace script database_migration.MIGRATE_TO_EXASOL(
 ) RETURNS TABLE
 AS
 
-local OUT_COLUMNS = "STEP_KIND VARCHAR(40), TARGET_OBJ VARCHAR(2000), ROWS_AFFECTED DECIMAL(18,0), ELAPSED_MS DECIMAL(18,0), RESULT_FLAG VARCHAR(20), SQL_TEXT VARCHAR(2000000), ERROR_MESSAGE VARCHAR(20000)"
+local OUT_COLUMNS = "STEP_KIND VARCHAR(40), TARGET_OBJ VARCHAR(2000), ROWS_AFFECTED DECIMAL(18,0), ELAPSED_MS DECIMAL(18,0), RESULT_FLAG VARCHAR(20), SQL_TEXT VARCHAR(2000000), ERROR_MESSAGE VARCHAR(20000), SPLIT_STRATEGY VARCHAR(32), SPLIT_KEY VARCHAR(256), PARALLEL_REQUESTED VARCHAR(16), PARALLEL_EFFECTIVE DECIMAL(4,0)"
 
 function is_null(value)
     return value == nil or value == null or value == NULL
@@ -219,11 +219,28 @@ function is_executable_statement(sql_text)
     return string.sub(text, 1, 2) ~= '--'
 end
 
-function build_row(step_kind, target_obj, rows_affected, elapsed_ms, result_flag, sql_text, error_message)
-    return {step_kind, target_obj, rows_affected, elapsed_ms, result_flag, sql_text, error_message}
+function audit_or_nulls(audit)
+    if audit == nil then
+        return NULL, NULL, NULL, NULL
+    end
+    local strategy = audit.strategy
+    if strategy == nil then strategy = NULL end
+    local key = audit.key
+    if key == nil then key = NULL end
+    local requested = audit.requested
+    if requested == nil then requested = NULL end
+    local effective = audit.effective
+    if effective == nil then effective = NULL end
+    return strategy, key, requested, effective
 end
 
-function normalize_rows(res)
+function build_row(step_kind, target_obj, rows_affected, elapsed_ms, result_flag, sql_text, error_message, audit)
+    local strategy, key, requested, effective = audit_or_nulls(audit)
+    return {step_kind, target_obj, rows_affected, elapsed_ms, result_flag, sql_text, error_message, strategy, key, requested, effective}
+end
+
+function normalize_rows(res, decisions)
+    decisions = decisions or {}
     local summary = {}
     local tables_count = 0
     for i = 1, #res do
@@ -236,13 +253,14 @@ function normalize_rows(res)
         end
         local flag = row.RESULT_FLAG or row.SUCCESS or row[5] or row[2] or 'PREVIEW'
         local err = row.ERROR_MESSAGE or row[7] or row[3] or NULL
-        summary[#summary + 1] = build_row(kind, target, NULL, NULL, flag, sql_text, err)
+        summary[#summary + 1] = build_row(kind, target, NULL, NULL, flag, sql_text, err, decisions[i])
     end
     summary[#summary + 1] = build_row('SUMMARY', 'Plan: ' .. tables_count .. ' table(s) to create', NULL, NULL, 'PREVIEW', NULL, NULL)
     return summary
 end
 
-function execute_generated_sql(res)
+function execute_generated_sql(res, decisions)
+    decisions = decisions or {}
     local summary = {}
     local fail_count = 0
     local executed_count = 0
@@ -254,6 +272,7 @@ function execute_generated_sql(res)
         local sql_text = first_sql_text(res[i])
         local kind = classify_step(sql_text)
         local target = extract_target_obj(sql_text, kind)
+        local audit = decisions[i]
         if is_executable_statement(sql_text) then
             executed_count = executed_count + 1
             local t0 = os.clock()
@@ -271,13 +290,13 @@ function execute_generated_sql(res)
                 if kind == 'CREATE_TABLE' then
                     tables_created = tables_created + 1
                 end
-                summary[#summary + 1] = build_row(kind, target, rows_affected, elapsed, 'OK', sql_text, NULL)
+                summary[#summary + 1] = build_row(kind, target, rows_affected, elapsed, 'OK', sql_text, NULL, audit)
             else
                 fail_count = fail_count + 1
-                summary[#summary + 1] = build_row(kind, target, NULL, elapsed, 'ERROR', sql_text, info.error_message)
+                summary[#summary + 1] = build_row(kind, target, NULL, elapsed, 'ERROR', sql_text, info.error_message, audit)
             end
         else
-            summary[#summary + 1] = build_row(kind, target, NULL, NULL, 'SKIPPED', sql_text, NULL)
+            summary[#summary + 1] = build_row(kind, target, NULL, NULL, 'SKIPPED', sql_text, NULL, audit)
         end
     end
 
@@ -547,12 +566,9 @@ function collect_metadata_pairs(res, options)
     if res == nil then return pair_list end
 
     local threshold = parse_threshold(options)
-    local split_directive_ok, split_directive = pcall(parse_split_directive, options)
-    local split_off = split_directive_ok and split_directive.mode == 'OFF'
-    local resolved_n = resolve_split_n(options, nil)
-    local splitter_disabled = split_off or resolved_n < 2
+    local splitter_active = splitter_potentially_active(options)
 
-    if threshold <= 0 and splitter_disabled then return pair_list end
+    if threshold <= 0 and not splitter_active then return pair_list end
 
     for i = 1, #res do
         local sql_text = first_sql_text(res[i])
@@ -561,7 +577,7 @@ function collect_metadata_pairs(res, options)
             local relevant = false
             if clauses > 1 and threshold > 0 then
                 relevant = true
-            elseif clauses == 1 and not splitter_disabled and threshold > 0 then
+            elseif clauses == 1 and splitter_active and threshold > 0 then
                 relevant = true
             end
             if relevant then
@@ -652,13 +668,24 @@ function transform_for_metadata(res, source_type, connection_name, options)
     return { available = true, rows = rows, info_rows = {} }
 end
 
+function raw_parallel_requested(options)
+    local raw = blank_to_nil(opt(options, 'PARALLEL_STATEMENTS', 'AUTO')) or 'AUTO'
+    local up = string.upper(raw)
+    if up == 'AUTO' then return 'AUTO' end
+    return tostring(raw)
+end
+
 -- Speq 1 gate: collapses multi-statement IMPORTs whose source row count is below
 -- `PARALLEL_ROW_THRESHOLD` to a single statement. Consumes the shared metadata cache
 -- populated by `transform_for_metadata`; never issues its own source-side query.
-function transform_for_gate(res, options, cache)
+-- Writes a decision record per multi-statement IMPORT row it touches so the
+-- audit transform can later populate SPLIT_STRATEGY / PARALLEL_EFFECTIVE.
+function transform_for_gate(res, options, cache, decisions)
     if res == nil or #res == 0 then return res end
+    decisions = decisions or {}
 
     local threshold = parse_threshold(options)
+    local requested = raw_parallel_requested(options)
 
     local out = {}
     for j = 1, #res do out[j] = res[j] end
@@ -678,14 +705,20 @@ function transform_for_gate(res, options, cache)
 
     for i = 1, #res do
         local sql_text = first_sql_text(res[i])
-        if classify_step(sql_text) == 'IMPORT' and count_statement_clauses(sql_text) > 1 then
-            local src_schema, src_table = extract_source_ref_from_import(sql_text)
-            if src_schema ~= nil and src_table ~= nil then
-                local meta = cache.rows[src_schema .. '\t' .. src_table]
-                local rowcount = meta and meta.src_rows
-                local effective = tonumber(rowcount) or 0
-                if effective < threshold then
-                    out[i] = replace_row_sql(out[i], rewrite_to_first_statement(sql_text))
+        if classify_step(sql_text) == 'IMPORT' then
+            local clause_count = count_statement_clauses(sql_text)
+            if clause_count > 1 then
+                local src_schema, src_table = extract_source_ref_from_import(sql_text)
+                if src_schema ~= nil and src_table ~= nil then
+                    local meta = cache.rows[src_schema .. '\t' .. src_table]
+                    local rowcount = meta and meta.src_rows
+                    local effective = tonumber(rowcount) or 0
+                    if effective < threshold then
+                        out[i] = replace_row_sql(out[i], rewrite_to_first_statement(sql_text))
+                        decisions[i] = { strategy = 'SINGLE', key = nil, requested = requested, effective = 1 }
+                    else
+                        decisions[i] = { strategy = 'MULTI_PASSTHROUGH', key = nil, requested = requested, effective = clause_count }
+                    end
                 end
             end
         end
@@ -715,18 +748,89 @@ function parse_split_directive(options)
     error('Invalid PARALLEL_SPLIT value: ' .. tostring(raw))
 end
 
--- Phase 2 N-resolver: explicit positive integer in PARALLEL_STATEMENTS yields N.
--- AUTO is a Phase-3 feature; it currently short-circuits to 1 (= no split). The
--- splitter is still wired so that Phase 3 only needs to swap this function out
--- for the row-count heuristic specified in parallel-auto-ceiling.
-function resolve_split_n(options, src_rows)
-    local raw = blank_to_nil(opt(options, 'PARALLEL_STATEMENTS', 'AUTO')) or 'AUTO'
-    if string.upper(raw) == 'AUTO' then return 1 end
+function parse_auto_ceiling(options)
+    local raw = blank_to_nil(opt(options, 'PARALLEL_AUTO_CEILING', '12')) or '12'
     local n = tonumber(raw)
-    if n == nil then return 1 end
-    n = math.floor(n)
-    if n < 1 then return 1 end
-    return n
+    if n == nil or n < 1 or math.floor(n) ~= n then
+        error('Invalid PARALLEL_AUTO_CEILING (must be positive integer): ' .. tostring(raw))
+    end
+    return math.floor(n)
+end
+
+-- Resolves PARALLEL_STATEMENTS to a per-table (effective_n, requested) pair.
+-- AUTO heuristic: min(ceiling, max(1, ceil(src_rows / 5_000_000))).
+-- AUTO with NULL or non-positive src_rows -> effective_n = 1 (gate-collapse semantics).
+-- Explicit positive integer bypasses the ceiling.
+-- Invalid values raise.
+function resolve_parallel_statements(options, src_rows)
+    local raw = blank_to_nil(opt(options, 'PARALLEL_STATEMENTS', 'AUTO')) or 'AUTO'
+    local up = string.upper(raw)
+    if up == 'AUTO' then
+        local rows = tonumber(src_rows)
+        if rows == nil or rows <= 0 then
+            return { effective = 1, requested = 'AUTO' }
+        end
+        local ceiling = parse_auto_ceiling(options)
+        local heuristic = math.ceil(rows / 5000000)
+        if heuristic < 1 then heuristic = 1 end
+        if heuristic > ceiling then heuristic = ceiling end
+        return { effective = heuristic, requested = 'AUTO' }
+    end
+    local n = tonumber(raw)
+    if n == nil or n < 1 or math.floor(n) ~= n then
+        error('Invalid PARALLEL_STATEMENTS (must be AUTO or positive integer): ' .. tostring(raw))
+    end
+    return { effective = math.floor(n), requested = tostring(math.floor(n)) }
+end
+
+-- Adapter-call helper: Oracle (and any future adapter that takes an integer
+-- PARALLEL_STATEMENTS) consumes its OPTIONS value directly. AUTO is a master-
+-- script concept; downstream adapters receive `default_n` instead. Invalid
+-- explicit values raise here so adapter SQL is never constructed.
+function resolve_parallel_statements_for_adapter(options, default_n)
+    local raw = blank_to_nil(opt(options, 'PARALLEL_STATEMENTS', nil))
+    if raw == nil then return tostring(default_n) end
+    if string.upper(raw) == 'AUTO' then return tostring(default_n) end
+    local n = tonumber(raw)
+    if n == nil or n < 1 or math.floor(n) ~= n then
+        error('Invalid PARALLEL_STATEMENTS (must be AUTO or positive integer): ' .. tostring(raw))
+    end
+    return tostring(math.floor(n))
+end
+
+-- Validates every PARALLEL_* OPTIONS key before any adapter SQL is constructed
+-- or any source-side query fires. Raises on invalid values per spec contract
+-- (parallel-auto-ceiling: "MUST NOT execute any adapter SQL nor any source-side
+-- query" on validation failure).
+function validate_parallel_options(options)
+    local ps_raw = blank_to_nil(opt(options, 'PARALLEL_STATEMENTS', nil))
+    if ps_raw ~= nil and string.upper(ps_raw) ~= 'AUTO' then
+        local n = tonumber(ps_raw)
+        if n == nil or n < 1 or math.floor(n) ~= n then
+            error('Invalid PARALLEL_STATEMENTS (must be AUTO or positive integer): ' .. tostring(ps_raw))
+        end
+    end
+    local ac_raw = blank_to_nil(opt(options, 'PARALLEL_AUTO_CEILING', nil))
+    if ac_raw ~= nil then
+        local n = tonumber(ac_raw)
+        if n == nil or n < 1 or math.floor(n) ~= n then
+            error('Invalid PARALLEL_AUTO_CEILING (must be positive integer): ' .. tostring(ac_raw))
+        end
+    end
+    parse_split_directive(options)
+end
+
+-- Returns true when the splitter MIGHT fire for at least one IMPORT in this
+-- migration; used by collect_metadata_pairs to decide whether to fetch metadata
+-- for single-statement IMPORTs.
+function splitter_potentially_active(options)
+    local split_raw = string.upper(blank_to_nil(opt(options, 'PARALLEL_SPLIT', 'AUTO')) or 'AUTO')
+    if split_raw == 'OFF' then return false end
+    local ps_raw = string.upper(blank_to_nil(opt(options, 'PARALLEL_STATEMENTS', 'AUTO')) or 'AUTO')
+    if ps_raw == 'AUTO' then return true end
+    local n = tonumber(ps_raw)
+    if n and n >= 2 then return true end
+    return false
 end
 
 function is_numeric_pk_type(type_str)
@@ -965,8 +1069,9 @@ end
 -- IMPORTs are left untouched (the adapter already chose its split). Any failure
 -- inside the splitter logs an INFO row and leaves the IMPORT unchanged - the
 -- splitter is an optimization and MUST NOT break a migration.
-function transform_for_split(res, options, cache, source_type)
+function transform_for_split(res, options, cache, source_type, decisions)
     if res == nil or #res == 0 then return res end
+    decisions = decisions or {}
 
     local directive_ok, directive = pcall(parse_split_directive, options)
     if not directive_ok then return res end
@@ -977,6 +1082,7 @@ function transform_for_split(res, options, cache, source_type)
     if threshold <= 0 then return res end
 
     local dialect = DIALECT_BY_SOURCE[source_type]
+    local requested = raw_parallel_requested(options)
 
     local out = {}
     for j = 1, #res do out[j] = res[j] end
@@ -991,7 +1097,8 @@ function transform_for_split(res, options, cache, source_type)
                 local meta = cache.rows[src_schema .. '\t' .. src_table]
                 local rowcount = meta and tonumber(meta.src_rows) or 0
                 if rowcount >= threshold then
-                    local n = resolve_split_n(options, rowcount)
+                    local resolved = resolve_parallel_statements(options, rowcount)
+                    local n = resolved.effective
                     if n >= 2 then
                         local decision, reason = pick_split_strategy(meta, options, dialect, source_type)
                         if decision ~= nil then
@@ -1006,16 +1113,26 @@ function transform_for_split(res, options, cache, source_type)
                                 local rewritten = rewrite_import_to_multi_stmt(sql_text, where_per_k, n)
                                 if rewritten ~= nil then
                                     out[i] = replace_row_sql(out[i], rewritten)
+                                    decisions[i] = { strategy = decision.strategy, key = decision.key, requested = resolved.requested, effective = n }
                                 else
                                     info_rows[#info_rows + 1] = '-- PARALLEL_SPLIT: rewrite failed for ' .. src_schema .. '.' .. src_table .. ' -- IMPORT left unchanged'
+                                    decisions[i] = { strategy = 'SINGLE', key = nil, requested = resolved.requested, effective = 1 }
                                 end
                             else
                                 info_rows[#info_rows + 1] = '-- PARALLEL_SPLIT: WHERE-builder failed for ' .. src_schema .. '.' .. src_table .. ' -- IMPORT left unchanged'
+                                decisions[i] = { strategy = 'SINGLE', key = nil, requested = resolved.requested, effective = 1 }
                             end
-                        elseif reason ~= nil then
-                            info_rows[#info_rows + 1] = '-- PARALLEL_SPLIT: ' .. src_schema .. '.' .. src_table .. ' -> SINGLE (' .. reason .. ')'
+                        else
+                            if reason ~= nil then
+                                info_rows[#info_rows + 1] = '-- PARALLEL_SPLIT: ' .. src_schema .. '.' .. src_table .. ' -> SINGLE (' .. reason .. ')'
+                            end
+                            decisions[i] = { strategy = 'SINGLE', key = nil, requested = resolved.requested, effective = 1 }
                         end
+                    else
+                        decisions[i] = { strategy = 'SINGLE', key = nil, requested = resolved.requested, effective = 1 }
                     end
+                else
+                    decisions[i] = { strategy = 'SINGLE', key = nil, requested = requested, effective = 1 }
                 end
             end
         end
@@ -1027,23 +1144,47 @@ function transform_for_split(res, options, cache, source_type)
     return out
 end
 
+-- Fills default SINGLE decisions for any IMPORT row neither gate nor splitter
+-- touched (e.g. when the metadata round-trip was skipped or the cache returned
+-- unavailable). Non-IMPORT rows are left without a decision so audit cols stay NULL.
+function transform_for_audit(res, options, decisions)
+    if res == nil or #res == 0 then return end
+    decisions = decisions or {}
+    local requested = raw_parallel_requested(options)
+    for i = 1, #res do
+        if decisions[i] == nil then
+            local sql_text = first_sql_text(res[i])
+            if classify_step(sql_text) == 'IMPORT' then
+                local clauses = count_statement_clauses(sql_text)
+                if clauses > 1 then
+                    decisions[i] = { strategy = 'MULTI_PASSTHROUGH', key = nil, requested = requested, effective = clauses }
+                else
+                    decisions[i] = { strategy = 'SINGLE', key = nil, requested = requested, effective = 1 }
+                end
+            end
+        end
+    end
+end
+
 function execute_adapter(adapter_sql, debug, ctx)
     local success, res = pquery(adapter_sql)
     if not success then
         error('"' .. res.error_message .. '" Caught while executing: "' .. res.statement_text .. '"')
     end
 
+    local decisions = {}
     if ctx ~= nil then
         local cache = transform_for_metadata(res, ctx.source_type, ctx.connection_name, ctx.options)
-        res = transform_for_gate(res, ctx.options, cache)
-        res = transform_for_split(res, ctx.options, cache, ctx.source_type)
+        res = transform_for_gate(res, ctx.options, cache, decisions)
+        res = transform_for_split(res, ctx.options, cache, ctx.source_type, decisions)
+        transform_for_audit(res, ctx.options, decisions)
     end
 
     if not debug then
-        return execute_generated_sql(res), OUT_COLUMNS
+        return execute_generated_sql(res, decisions), OUT_COLUMNS
     end
 
-    return normalize_rows(res), OUT_COLUMNS
+    return normalize_rows(res, decisions), OUT_COLUMNS
 end
 
 local source = normalize_source_type(SOURCE_TYPE)
@@ -1056,6 +1197,8 @@ local target_schema = blank_to_nil(TARGET_SCHEMA)
 local identifier_case_insensitive = parse_bool(IDENTIFIER_CASE_INSENSITIVE, true, 'IDENTIFIER_CASE_INSENSITIVE')
 local debug = parse_bool(DEBUG, true, 'DEBUG')
 local options = parse_options(OPTIONS)
+
+validate_parallel_options(options)
 
 local adapter_sql = nil
 
@@ -1166,7 +1309,7 @@ elseif source == 'ORACLE' then
         .. sql_bool(identifier_case_insensitive) .. ','
         .. sql_string(schema_filter) .. ','
         .. sql_string(table_filter) .. ','
-        .. opt_sql_number(options, 'PARALLEL_STATEMENTS', 1) .. ','
+        .. resolve_parallel_statements_for_adapter(options, 1) .. ','
         .. sql_bool(opt_bool(options, 'CREATE_PK', false)) .. ','
         .. sql_bool(opt_bool(options, 'CREATE_FK', false)) .. ','
         .. sql_bool(opt_bool(options, 'CHECK_MIGRATION', false)) .. ')'

--- a/migrate_to_exasol.sql
+++ b/migrate_to_exasol.sql
@@ -298,10 +298,236 @@ function execute_generated_sql(res)
     return summary
 end
 
-function execute_adapter(adapter_sql, debug)
+ROW_COUNT_SQL_BY_SOURCE = {
+    ORACLE = {
+        mode = 'sql',
+        template = "select owner, table_name, num_rows from all_tables where (<PREDICATE>)",
+        pair = "(owner = '%s' and table_name = '%s')",
+    },
+    POSTGRES = {
+        mode = 'sql',
+        template = "select n.nspname, c.relname, c.reltuples::bigint from pg_class c join pg_namespace n on n.oid = c.relnamespace where c.relkind in ('r','p') and (<PREDICATE>)",
+        pair = "(n.nspname = '%s' and c.relname = '%s')",
+    },
+    MYSQL = {
+        mode = 'sql',
+        template = "select table_schema, table_name, table_rows from information_schema.tables where (<PREDICATE>)",
+        pair = "(table_schema = '%s' and table_name = '%s')",
+    },
+    SQLSERVER = {
+        mode = 'sql',
+        template = "select s.name as schema_name, t.name as table_name, sum(ps.row_count) as row_count from sys.tables t join sys.schemas s on s.schema_id = t.schema_id join sys.dm_db_partition_stats ps on ps.object_id = t.object_id and ps.index_id in (0,1) where (<PREDICATE>) group by s.name, t.name",
+        pair = "(s.name = '%s' and t.name = '%s')",
+    },
+    SNOWFLAKE = {
+        mode = 'sql',
+        template = "select table_schema, table_name, row_count from information_schema.tables where (<PREDICATE>)",
+        pair = "(table_schema = '%s' and table_name = '%s')",
+    },
+    BIGQUERY = {
+        mode = 'skip_with_info',
+        reason = 'per-dataset INFORMATION_SCHEMA lookup not yet implemented',
+    },
+    REDSHIFT = {
+        mode = 'sql',
+        template = [[select "schema", "table", tbl_rows from svv_table_info where (<PREDICATE>)]],
+        pair = [[("schema" = '%s' and "table" = '%s')]],
+    },
+    VERTICA = {
+        mode = 'sql',
+        template = "select projection_schema, anchor_table_name, row_count from projection_storage where (<PREDICATE>)",
+        pair = "(projection_schema = '%s' and anchor_table_name = '%s')",
+    },
+    DB2 = {
+        mode = 'sql',
+        template = "select tabschema, tabname, card from syscat.tables where (<PREDICATE>)",
+        pair = "(tabschema = '%s' and tabname = '%s')",
+    },
+    HANA = {
+        mode = 'sql',
+        template = "select schema_name, table_name, record_count from sys.m_tables where (<PREDICATE>)",
+        pair = "(schema_name = '%s' and table_name = '%s')",
+    },
+    NETEZZA = {
+        mode = 'sql',
+        template = [[select schema, tablename, reltuples from _v_table where (<PREDICATE>)]],
+        pair = [[(schema = '%s' and tablename = '%s')]],
+    },
+    TERADATA = {
+        mode = 'sql',
+        template = "select databasename, tablename, currentpermspace from dbc.tablesizev where (<PREDICATE>)",
+        pair = "(databasename = '%s' and tablename = '%s')",
+    },
+    DATABRICKS = {
+        mode = 'sql',
+        template = "select table_schema, table_name, cast(null as bigint) as row_count from information_schema.tables where (<PREDICATE>)",
+        pair = "(table_schema = '%s' and table_name = '%s')",
+    },
+}
+ROW_COUNT_SQL_BY_SOURCE.MARIADB = ROW_COUNT_SQL_BY_SOURCE.MYSQL
+ROW_COUNT_SQL_BY_SOURCE.AZURE_SQL = ROW_COUNT_SQL_BY_SOURCE.SQLSERVER
+
+function count_statement_clauses(sql)
+    if sql == nil then return 0 end
+    local n = 0
+    for _ in string.gmatch(sql, "[Ss][Tt][Aa][Tt][Ee][Mm][Ee][Nn][Tt]%s+'") do
+        n = n + 1
+    end
+    return n
+end
+
+function extract_source_ref_from_import(sql)
+    if sql == nil then return nil, nil end
+    local schema, table_name = sql:match('[Ff][Rr][Oo][Mm]%s+"([^"]+)"%."([^"]+)"')
+    return schema, table_name
+end
+
+function rewrite_to_first_statement(sql)
+    if sql == nil then return sql end
+    local stmt_kw_start = string.find(sql:lower(), "statement%s+'")
+    if not stmt_kw_start then return sql end
+    local quote_open = sql:find("'", stmt_kw_start)
+    if not quote_open then return sql end
+    local i = quote_open + 1
+    while i <= #sql do
+        local c = sql:sub(i, i)
+        if c == "'" then
+            if sql:sub(i + 1, i + 1) == "'" then
+                i = i + 2
+            else
+                return sql:sub(1, i)
+            end
+        else
+            i = i + 1
+        end
+    end
+    return sql
+end
+
+function replace_row_sql(row, new_sql)
+    return { SQL_TEXT = new_sql, [1] = new_sql }
+end
+
+function transform_for_gate(res, source_type, connection_name, options)
+    if res == nil or #res == 0 then return res end
+
+    local threshold_raw = opt(options, 'PARALLEL_ROW_THRESHOLD', '1000000')
+    local threshold = tonumber(threshold_raw)
+    if threshold == nil then
+        error('Invalid numeric option PARALLEL_ROW_THRESHOLD: ' .. tostring(threshold_raw))
+    end
+    if threshold <= 0 then
+        return res
+    end
+
+    local imports = {}
+    local pair_list = {}
+    local pairs_seen = {}
+    local needs_lookup = false
+    for i = 1, #res do
+        local sql_text = first_sql_text(res[i])
+        if classify_step(sql_text) == 'IMPORT' then
+            local n = count_statement_clauses(sql_text)
+            if n > 1 then
+                local src_schema, src_table = extract_source_ref_from_import(sql_text)
+                imports[#imports + 1] = {
+                    idx = i,
+                    sql = sql_text,
+                    schema = src_schema,
+                    table_name = src_table,
+                }
+                if src_schema ~= nil and src_table ~= nil then
+                    local key = src_schema .. '\t' .. src_table
+                    if not pairs_seen[key] then
+                        pairs_seen[key] = true
+                        pair_list[#pair_list + 1] = { schema = src_schema, table_name = src_table }
+                    end
+                    needs_lookup = true
+                end
+            end
+        end
+    end
+
+    if not needs_lookup then
+        return res
+    end
+
+    local function append_info(out, message)
+        out[#out + 1] = { SQL_TEXT = '-- ' .. message }
+        return out
+    end
+
+    local dispatch = ROW_COUNT_SQL_BY_SOURCE[source_type]
+    if dispatch == nil or dispatch.mode == 'skip_with_info' then
+        local reason
+        if dispatch == nil then
+            reason = 'no row-count SQL configured for source type ' .. tostring(source_type)
+        else
+            reason = dispatch.reason or 'gate skipped'
+        end
+        local out = {}
+        for j = 1, #res do out[j] = res[j] end
+        append_info(out, 'PARALLEL_ROW_THRESHOLD gate skipped: ' .. reason)
+        return out
+    end
+
+    local pair_clauses = {}
+    for _, p in ipairs(pair_list) do
+        local esc_schema = escape_sql_literal(p.schema)
+        local esc_table = escape_sql_literal(p.table_name)
+        pair_clauses[#pair_clauses + 1] = string.format(dispatch.pair, esc_schema, esc_table)
+    end
+    local predicate = table.concat(pair_clauses, ' or ')
+    local row_count_sql = (dispatch.template:gsub('<PREDICATE>', function() return predicate end))
+
+    local outer_sql = "select * from (import into (src_schema varchar(2000), src_table varchar(2000), src_rows decimal(36,0)) from jdbc at "
+        .. connection_name
+        .. " statement '"
+        .. escape_sql_literal(row_count_sql)
+        .. "')"
+
+    local success, lookup_res = pquery(outer_sql)
+    if not success then
+        local out = {}
+        for j = 1, #res do out[j] = res[j] end
+        local err = (lookup_res and lookup_res.error_message) or 'unknown error'
+        append_info(out, 'PARALLEL_ROW_THRESHOLD gate skipped: row-count lookup failed (' .. tostring(err) .. ')')
+        return out
+    end
+
+    local lookup = {}
+    for i = 1, #lookup_res do
+        local r = lookup_res[i]
+        local s = r.SRC_SCHEMA or r[1]
+        local t = r.SRC_TABLE or r[2]
+        local n = r.SRC_ROWS or r[3]
+        if s ~= nil and t ~= nil then
+            lookup[tostring(s) .. '\t' .. tostring(t)] = n
+        end
+    end
+
+    local out = {}
+    for j = 1, #res do out[j] = res[j] end
+    for _, im in ipairs(imports) do
+        if im.schema ~= nil and im.table_name ~= nil then
+            local rowcount = lookup[im.schema .. '\t' .. im.table_name]
+            local effective = tonumber(rowcount) or 0
+            if effective < threshold then
+                out[im.idx] = replace_row_sql(out[im.idx], rewrite_to_first_statement(im.sql))
+            end
+        end
+    end
+    return out
+end
+
+function execute_adapter(adapter_sql, debug, gate_ctx)
     local success, res = pquery(adapter_sql)
     if not success then
         error('"' .. res.error_message .. '" Caught while executing: "' .. res.statement_text .. '"')
+    end
+
+    if gate_ctx ~= nil then
+        res = transform_for_gate(res, gate_ctx.source_type, gate_ctx.connection_name, gate_ctx.options)
     end
 
     if not debug then
@@ -476,7 +702,13 @@ else
     error('Unsupported SOURCE_TYPE: ' .. tostring(SOURCE_TYPE))
 end
 
-return execute_adapter(adapter_sql, debug)
+local gate_ctx = {
+    source_type = source,
+    connection_name = connection_name,
+    options = options,
+}
+
+return execute_adapter(adapter_sql, debug, gate_ctx)
 /
 
 /*

--- a/migrate_to_exasol.sql
+++ b/migrate_to_exasol.sql
@@ -424,6 +424,7 @@ SOURCE_METADATA_BY_SOURCE.AZURE_SQL = SOURCE_METADATA_BY_SOURCE.SQLSERVER
 -- entry fall through to SINGLE in the split hierarchy.
 DIALECT_BY_SOURCE = {
     POSTGRES = {
+        pk_where = function(col, n, k) return 'MOD("' .. col .. '", ' .. n .. ') = ' .. k end,
         month_fn = function(col) return 'EXTRACT(MONTH FROM "' .. col .. '")' end,
         day_fn = function(col) return 'EXTRACT(DAY FROM "' .. col .. '")' end,
         year_month_fn = function(col) return '(EXTRACT(YEAR FROM "' .. col .. '") * 12 + EXTRACT(MONTH FROM "' .. col .. '"))' end,
@@ -433,6 +434,8 @@ DIALECT_BY_SOURCE = {
         rowid_where = function(n, k) return 'MOD(ABS(HASHTEXT(ctid::text)), ' .. n .. ') = ' .. k end,
     },
     SQLSERVER = {
+        -- T-SQL has no MOD() function; the modulo operator is `%`.
+        pk_where = function(col, n, k) return '("' .. col .. '" % ' .. n .. ') = ' .. k end,
         month_fn = function(col) return 'MONTH("' .. col .. '")' end,
         day_fn = function(col) return 'DAY("' .. col .. '")' end,
         year_month_fn = function(col) return '(YEAR("' .. col .. '") * 12 + MONTH("' .. col .. '"))' end,
@@ -442,13 +445,18 @@ DIALECT_BY_SOURCE = {
         rowid_where = function(n, k) return '(ABS(CHECKSUM(%%physloc%%)) % ' .. n .. ') = ' .. k end,
     },
     MYSQL = {
-        month_fn = function(col) return 'MONTH("' .. col .. '")' end,
-        day_fn = function(col) return 'DAY("' .. col .. '")' end,
-        year_month_fn = function(col) return '(YEAR("' .. col .. '") * 12 + MONTH("' .. col .. '"))' end,
-        hash_where = function(col, n, k) return '(CONV(SUBSTRING(MD5(CAST("' .. col .. '" AS CHAR)), 1, 8), 16, 10) MOD ' .. n .. ') = ' .. k end,
+        -- MySQL's default sql_mode rejects double-quoted identifiers (treats
+        -- them as string literals). Adapters consistently emit backticks for
+        -- source-side identifiers, so the WHERE we AND in must match.
+        pk_where = function(col, n, k) return '(`' .. col .. '` MOD ' .. n .. ') = ' .. k end,
+        month_fn = function(col) return 'MONTH(`' .. col .. '`)' end,
+        day_fn = function(col) return 'DAY(`' .. col .. '`)' end,
+        year_month_fn = function(col) return '(YEAR(`' .. col .. '`) * 12 + MONTH(`' .. col .. '`))' end,
+        hash_where = function(col, n, k) return '(CONV(SUBSTRING(MD5(CAST(`' .. col .. '` AS CHAR)), 1, 8), 16, 10) MOD ' .. n .. ') = ' .. k end,
         rowid_supported = false,
     },
     SNOWFLAKE = {
+        pk_where = function(col, n, k) return 'MOD("' .. col .. '", ' .. n .. ') = ' .. k end,
         month_fn = function(col) return 'MONTH("' .. col .. '")' end,
         day_fn = function(col) return 'DAY("' .. col .. '")' end,
         year_month_fn = function(col) return '(YEAR("' .. col .. '") * 12 + MONTH("' .. col .. '"))' end,
@@ -456,6 +464,7 @@ DIALECT_BY_SOURCE = {
         rowid_supported = false,
     },
     ORACLE = {
+        pk_where = function(col, n, k) return 'MOD("' .. col .. '", ' .. n .. ') = ' .. k end,
         month_fn = function(col) return 'EXTRACT(MONTH FROM "' .. col .. '")' end,
         day_fn = function(col) return 'EXTRACT(DAY FROM "' .. col .. '")' end,
         year_month_fn = function(col) return '(EXTRACT(YEAR FROM "' .. col .. '") * 12 + EXTRACT(MONTH FROM "' .. col .. '"))' end,
@@ -465,6 +474,7 @@ DIALECT_BY_SOURCE = {
         rowid_where = function(n, k) return 'MOD(ORA_HASH(ROWID), ' .. n .. ') = ' .. k end,
     },
     DB2 = {
+        pk_where = function(col, n, k) return 'MOD("' .. col .. '", ' .. n .. ') = ' .. k end,
         month_fn = function(col) return 'MONTH("' .. col .. '")' end,
         day_fn = function(col) return 'DAY("' .. col .. '")' end,
         year_month_fn = function(col) return '(YEAR("' .. col .. '") * 12 + MONTH("' .. col .. '"))' end,
@@ -474,6 +484,7 @@ DIALECT_BY_SOURCE = {
         rowid_where = function(n, k) return 'MOD(HASH4(RID_BIT(t)), ' .. n .. ') = ' .. k end,
     },
     VERTICA = {
+        pk_where = function(col, n, k) return 'MOD("' .. col .. '", ' .. n .. ') = ' .. k end,
         month_fn = function(col) return 'MONTH("' .. col .. '")' end,
         day_fn = function(col) return 'DAY("' .. col .. '")' end,
         year_month_fn = function(col) return '(YEAR("' .. col .. '") * 12 + MONTH("' .. col .. '"))' end,
@@ -481,6 +492,7 @@ DIALECT_BY_SOURCE = {
         rowid_supported = false,
     },
     HANA = {
+        pk_where = function(col, n, k) return 'MOD("' .. col .. '", ' .. n .. ') = ' .. k end,
         month_fn = function(col) return 'MONTH("' .. col .. '")' end,
         day_fn = function(col) return 'DAYOFMONTH("' .. col .. '")' end,
         year_month_fn = function(col) return '(YEAR("' .. col .. '") * 12 + MONTH("' .. col .. '"))' end,
@@ -488,6 +500,8 @@ DIALECT_BY_SOURCE = {
         rowid_supported = false,
     },
     REDSHIFT = {
+        -- Redshift inherits Postgres modulo semantics.
+        pk_where = function(col, n, k) return '("' .. col .. '" % ' .. n .. ') = ' .. k end,
         month_fn = function(col) return 'EXTRACT(MONTH FROM "' .. col .. '")' end,
         day_fn = function(col) return 'EXTRACT(DAY FROM "' .. col .. '")' end,
         year_month_fn = function(col) return '(EXTRACT(YEAR FROM "' .. col .. '") * 12 + EXTRACT(MONTH FROM "' .. col .. '"))' end,
@@ -495,6 +509,7 @@ DIALECT_BY_SOURCE = {
         rowid_supported = false,
     },
     DATABRICKS = {
+        pk_where = function(col, n, k) return 'PMOD(`' .. col .. '`, ' .. n .. ') = ' .. k end,
         month_fn = function(col) return 'MONTH(`' .. col .. '`)' end,
         day_fn = function(col) return 'DAY(`' .. col .. '`)' end,
         year_month_fn = function(col) return '(YEAR(`' .. col .. '`) * 12 + MONTH(`' .. col .. '`))' end,
@@ -530,6 +545,10 @@ function extract_source_ref_from_import(sql)
     local db_b, sch_b, tab_b = sql:match('[Ff][Rr][Oo][Mm]%s+`([^`]+)`%.`([^`]+)`%.`([^`]+)`')
     if db_b and sch_b and tab_b then return sch_b, tab_b end
     schema, table_name = sql:match('[Ff][Rr][Oo][Mm]%s+`([^`]+)`%.`([^`]+)`')
+    if schema and table_name then return schema, table_name end
+    -- MySQL adapter emits unquoted `from <db>.<table>` (case-insensitive by default).
+    -- This branch runs last so quoted variants always win when present.
+    schema, table_name = sql:match('[Ff][Rr][Oo][Mm]%s+([%w_]+)%.([%w_]+)')
     if schema and table_name then return schema, table_name end
     return nil, nil
 end
@@ -987,6 +1006,10 @@ end
 function build_where_for_split(decision, dialect, n, k)
     if decision == nil then return nil end
     if decision.strategy == 'PK_RANGE' or decision.strategy == 'UNIQUE_NUM' then
+        if dialect and dialect.pk_where then
+            return dialect.pk_where(decision.key, n, k)
+        end
+        -- Conservative fallback for sources without a dialect entry.
         return 'MOD("' .. decision.key .. '", ' .. n .. ') = ' .. k
     end
     if decision.strategy == 'DATE_BUCKET' then

--- a/migrate_to_exasol.sql
+++ b/migrate_to_exasol.sql
@@ -25,7 +25,7 @@ create or replace script database_migration.MIGRATE_TO_EXASOL(
 ) RETURNS TABLE
 AS
 
-local OUT_COLUMNS = "SQL_TEXT VARCHAR(2000000), SUCCESS VARCHAR(10), ERROR_MESSAGE VARCHAR(20000)"
+local OUT_COLUMNS = "STEP_KIND VARCHAR(40), TARGET_OBJ VARCHAR(2000), ROWS_AFFECTED DECIMAL(18,0), ELAPSED_MS DECIMAL(18,0), RESULT_FLAG VARCHAR(20), SQL_TEXT VARCHAR(2000000), ERROR_MESSAGE VARCHAR(20000)"
 
 function is_null(value)
     return value == nil or value == null or value == NULL
@@ -170,16 +170,45 @@ function first_sql_text(row)
     return tostring(row)
 end
 
-function normalize_rows(res)
-    local summary = {}
-    for i = 1, #res do
-        local row = res[i]
-        local sql_text = first_sql_text(row)
-        local success = row.SUCCESS or row[2] or 'PREVIEW'
-        local error_message = row.ERROR_MESSAGE or row[3] or NULL
-        summary[#summary + 1] = {sql_text, success, error_message}
+function classify_step(sql_text)
+    local text = blank_to_nil(sql_text)
+    if text == nil then
+        return 'INFO'
     end
-    return summary
+    if string.sub(text, 1, 2) == '--' then
+        return 'INFO'
+    end
+    local lower = string.lower(text)
+    if string.find(lower, '^%s*create%s+schema') then
+        return 'CREATE_SCHEMA'
+    elseif string.find(lower, '^%s*create%s+or%s+replace%s+table')
+        or string.find(lower, '^%s*create%s+table') then
+        return 'CREATE_TABLE'
+    elseif string.find(lower, '^%s*alter%s+table') then
+        return 'ALTER_TABLE'
+    elseif string.find(lower, '^%s*import%s+into') then
+        return 'IMPORT'
+    elseif string.find(lower, '^%s*insert%s+into') then
+        return 'IMPORT'
+    end
+    return 'OTHER'
+end
+
+function extract_target_obj(sql_text, step_kind)
+    local text = blank_to_nil(sql_text)
+    if text == nil then
+        return NULL
+    end
+    if step_kind == 'CREATE_SCHEMA' then
+        local schema = text:match('[Cc][Rr][Ee][Aa][Tt][Ee]%s+[Ss][Cc][Hh][Ee][Mm][Aa]%s+[Ii][Ff]%s+[Nn][Oo][Tt]%s+[Ee][Xx][Ii][Ss][Tt][Ss]%s+"([^"]+)"')
+            or text:match('[Cc][Rr][Ee][Aa][Tt][Ee]%s+[Ss][Cc][Hh][Ee][Mm][Aa]%s+"([^"]+)"')
+            or text:match('[Cc][Rr][Ee][Aa][Tt][Ee]%s+[Ss][Cc][Hh][Ee][Mm][Aa]%s+([%w_]+)')
+        if schema then return schema end
+    elseif step_kind == 'CREATE_TABLE' or step_kind == 'ALTER_TABLE' or step_kind == 'IMPORT' then
+        local schema, table_name = text:match('"([^"]+)"%."([^"]+)"')
+        if schema and table_name then return schema .. '.' .. table_name end
+    end
+    return NULL
 end
 
 function is_executable_statement(sql_text)
@@ -190,34 +219,81 @@ function is_executable_statement(sql_text)
     return string.sub(text, 1, 2) ~= '--'
 end
 
+function build_row(step_kind, target_obj, rows_affected, elapsed_ms, result_flag, sql_text, error_message)
+    return {step_kind, target_obj, rows_affected, elapsed_ms, result_flag, sql_text, error_message}
+end
+
+function normalize_rows(res)
+    local summary = {}
+    local tables_count = 0
+    for i = 1, #res do
+        local row = res[i]
+        local sql_text = first_sql_text(row)
+        local kind = classify_step(sql_text)
+        local target = extract_target_obj(sql_text, kind)
+        if kind == 'CREATE_TABLE' then
+            tables_count = tables_count + 1
+        end
+        local flag = row.RESULT_FLAG or row.SUCCESS or row[5] or row[2] or 'PREVIEW'
+        local err = row.ERROR_MESSAGE or row[7] or row[3] or NULL
+        summary[#summary + 1] = build_row(kind, target, NULL, NULL, flag, sql_text, err)
+    end
+    summary[#summary + 1] = build_row('SUMMARY', 'Plan: ' .. tables_count .. ' table(s) to create', NULL, NULL, 'PREVIEW', NULL, NULL)
+    return summary
+end
+
 function execute_generated_sql(res)
     local summary = {}
     local fail_count = 0
     local executed_count = 0
+    local tables_created = 0
+    local total_rows = 0
+    local total_elapsed = 0
 
     for i = 1, #res do
         local sql_text = first_sql_text(res[i])
+        local kind = classify_step(sql_text)
+        local target = extract_target_obj(sql_text, kind)
         if is_executable_statement(sql_text) then
             executed_count = executed_count + 1
+            local t0 = os.clock()
             local success, info = pquery(sql_text)
+            local elapsed = math.floor((os.clock() - t0) * 1000)
+            total_elapsed = total_elapsed + elapsed
             if success then
-                summary[#summary + 1] = {sql_text, 'TRUE', NULL}
+                local rows_affected = NULL
+                if info ~= nil and info.rows_affected ~= nil then
+                    rows_affected = tonumber(info.rows_affected) or NULL
+                    if kind == 'IMPORT' and type(rows_affected) == 'number' then
+                        total_rows = total_rows + rows_affected
+                    end
+                end
+                if kind == 'CREATE_TABLE' then
+                    tables_created = tables_created + 1
+                end
+                summary[#summary + 1] = build_row(kind, target, rows_affected, elapsed, 'OK', sql_text, NULL)
             else
                 fail_count = fail_count + 1
-                summary[#summary + 1] = {sql_text, 'FALSE', info.error_message}
+                summary[#summary + 1] = build_row(kind, target, NULL, elapsed, 'ERROR', sql_text, info.error_message)
             end
         else
-            summary[#summary + 1] = {sql_text, 'SKIPPED', 'Comment or empty'}
+            summary[#summary + 1] = build_row(kind, target, NULL, NULL, 'SKIPPED', sql_text, NULL)
         end
     end
 
+    local summary_obj
+    local summary_flag
     if executed_count == 0 then
-        table.insert(summary, 1, {'-- No executable SQL statements were generated.', 'SKIPPED', NULL})
+        summary_obj = 'No executable SQL generated'
+        summary_flag = 'SKIPPED'
     elseif fail_count == 0 then
-        table.insert(summary, 1, {'-- The following statements were executed successfully.', 'SKIPPED', NULL})
+        summary_obj = 'Completed: ' .. tables_created .. ' table(s), ' .. total_rows .. ' row(s) loaded'
+        summary_flag = 'OK'
     else
-        table.insert(summary, 1, {'-- Execution completed with ' .. fail_count .. ' error(s). See ERROR_MESSAGE column for details.', 'SKIPPED', NULL})
+        summary_obj = 'Completed with ' .. fail_count .. ' error(s); ' .. tables_created .. ' table(s) created, ' .. total_rows .. ' row(s) loaded'
+        summary_flag = 'ERROR'
     end
+    summary[#summary + 1] = build_row('SUMMARY', summary_obj, total_rows, total_elapsed, summary_flag, NULL, NULL)
 
     return summary
 end

--- a/migrate_to_exasol.sql
+++ b/migrate_to_exasol.sql
@@ -193,10 +193,12 @@ end
 function execute_generated_sql(res)
     local summary = {}
     local fail_count = 0
+    local executed_count = 0
 
     for i = 1, #res do
         local sql_text = first_sql_text(res[i])
         if is_executable_statement(sql_text) then
+            executed_count = executed_count + 1
             local success, info = pquery(sql_text)
             if success then
                 summary[#summary + 1] = {sql_text, 'TRUE', NULL}
@@ -209,7 +211,9 @@ function execute_generated_sql(res)
         end
     end
 
-    if fail_count == 0 then
+    if executed_count == 0 then
+        table.insert(summary, 1, {'-- No executable SQL statements were generated.', 'SKIPPED', NULL})
+    elseif fail_count == 0 then
         table.insert(summary, 1, {'-- The following statements were executed successfully.', 'SKIPPED', NULL})
     else
         table.insert(summary, 1, {'-- Execution completed with ' .. fail_count .. ' error(s). See ERROR_MESSAGE column for details.', 'SKIPPED', NULL})

--- a/migrate_to_exasol.sql
+++ b/migrate_to_exasol.sql
@@ -298,30 +298,35 @@ function execute_generated_sql(res)
     return summary
 end
 
-ROW_COUNT_SQL_BY_SOURCE = {
+-- Per-source metadata SQL. Each template returns 8 columns in this order:
+--   src_schema, src_table, src_rows,
+--   src_pk_col, src_pk_type, src_date_col, src_num_col, src_partitioned
+-- Phase 1 emits only src_rows; remaining columns are NULL placeholders.
+-- Phase 2+ enriches per-source SQL with PK / date / numeric / partition detection.
+SOURCE_METADATA_BY_SOURCE = {
     ORACLE = {
         mode = 'sql',
-        template = "select owner, table_name, num_rows from all_tables where (<PREDICATE>)",
+        template = "select owner, table_name, num_rows, NULL, NULL, NULL, NULL, NULL from all_tables where (<PREDICATE>)",
         pair = "(owner = '%s' and table_name = '%s')",
     },
     POSTGRES = {
         mode = 'sql',
-        template = "select n.nspname, c.relname, c.reltuples::bigint from pg_class c join pg_namespace n on n.oid = c.relnamespace where c.relkind in ('r','p') and (<PREDICATE>)",
+        template = "select n.nspname, c.relname, c.reltuples::bigint, NULL, NULL, NULL, NULL, NULL from pg_class c join pg_namespace n on n.oid = c.relnamespace where c.relkind in ('r','p') and (<PREDICATE>)",
         pair = "(n.nspname = '%s' and c.relname = '%s')",
     },
     MYSQL = {
         mode = 'sql',
-        template = "select table_schema, table_name, table_rows from information_schema.tables where (<PREDICATE>)",
+        template = "select table_schema, table_name, table_rows, NULL, NULL, NULL, NULL, NULL from information_schema.tables where (<PREDICATE>)",
         pair = "(table_schema = '%s' and table_name = '%s')",
     },
     SQLSERVER = {
         mode = 'sql',
-        template = "select s.name as schema_name, t.name as table_name, sum(ps.row_count) as row_count from sys.tables t join sys.schemas s on s.schema_id = t.schema_id join sys.dm_db_partition_stats ps on ps.object_id = t.object_id and ps.index_id in (0,1) where (<PREDICATE>) group by s.name, t.name",
+        template = "select s.name as schema_name, t.name as table_name, sum(ps.row_count) as row_count, NULL, NULL, NULL, NULL, NULL from sys.tables t join sys.schemas s on s.schema_id = t.schema_id join sys.dm_db_partition_stats ps on ps.object_id = t.object_id and ps.index_id in (0,1) where (<PREDICATE>) group by s.name, t.name",
         pair = "(s.name = '%s' and t.name = '%s')",
     },
     SNOWFLAKE = {
         mode = 'sql',
-        template = "select table_schema, table_name, row_count from information_schema.tables where (<PREDICATE>)",
+        template = "select table_schema, table_name, row_count, NULL, NULL, NULL, NULL, NULL from information_schema.tables where (<PREDICATE>)",
         pair = "(table_schema = '%s' and table_name = '%s')",
     },
     BIGQUERY = {
@@ -330,42 +335,42 @@ ROW_COUNT_SQL_BY_SOURCE = {
     },
     REDSHIFT = {
         mode = 'sql',
-        template = [[select "schema", "table", tbl_rows from svv_table_info where (<PREDICATE>)]],
+        template = [[select "schema", "table", tbl_rows, NULL, NULL, NULL, NULL, NULL from svv_table_info where (<PREDICATE>)]],
         pair = [[("schema" = '%s' and "table" = '%s')]],
     },
     VERTICA = {
         mode = 'sql',
-        template = "select projection_schema, anchor_table_name, row_count from projection_storage where (<PREDICATE>)",
+        template = "select projection_schema, anchor_table_name, row_count, NULL, NULL, NULL, NULL, NULL from projection_storage where (<PREDICATE>)",
         pair = "(projection_schema = '%s' and anchor_table_name = '%s')",
     },
     DB2 = {
         mode = 'sql',
-        template = "select tabschema, tabname, card from syscat.tables where (<PREDICATE>)",
+        template = "select tabschema, tabname, card, NULL, NULL, NULL, NULL, NULL from syscat.tables where (<PREDICATE>)",
         pair = "(tabschema = '%s' and tabname = '%s')",
     },
     HANA = {
         mode = 'sql',
-        template = "select schema_name, table_name, record_count from sys.m_tables where (<PREDICATE>)",
+        template = "select schema_name, table_name, record_count, NULL, NULL, NULL, NULL, NULL from sys.m_tables where (<PREDICATE>)",
         pair = "(schema_name = '%s' and table_name = '%s')",
     },
     NETEZZA = {
         mode = 'sql',
-        template = [[select schema, tablename, reltuples from _v_table where (<PREDICATE>)]],
+        template = [[select schema, tablename, reltuples, NULL, NULL, NULL, NULL, NULL from _v_table where (<PREDICATE>)]],
         pair = [[(schema = '%s' and tablename = '%s')]],
     },
     TERADATA = {
         mode = 'sql',
-        template = "select databasename, tablename, currentpermspace from dbc.tablesizev where (<PREDICATE>)",
+        template = "select databasename, tablename, currentpermspace, NULL, NULL, NULL, NULL, NULL from dbc.tablesizev where (<PREDICATE>)",
         pair = "(databasename = '%s' and tablename = '%s')",
     },
     DATABRICKS = {
         mode = 'sql',
-        template = "select table_schema, table_name, cast(null as bigint) as row_count from information_schema.tables where (<PREDICATE>)",
+        template = "select table_schema, table_name, cast(null as bigint) as row_count, NULL, NULL, NULL, NULL, NULL from information_schema.tables where (<PREDICATE>)",
         pair = "(table_schema = '%s' and table_name = '%s')",
     },
 }
-ROW_COUNT_SQL_BY_SOURCE.MARIADB = ROW_COUNT_SQL_BY_SOURCE.MYSQL
-ROW_COUNT_SQL_BY_SOURCE.AZURE_SQL = ROW_COUNT_SQL_BY_SOURCE.SQLSERVER
+SOURCE_METADATA_BY_SOURCE.MARIADB = SOURCE_METADATA_BY_SOURCE.MYSQL
+SOURCE_METADATA_BY_SOURCE.AZURE_SQL = SOURCE_METADATA_BY_SOURCE.SQLSERVER
 
 function count_statement_clauses(sql)
     if sql == nil then return 0 end
@@ -408,126 +413,165 @@ function replace_row_sql(row, new_sql)
     return { SQL_TEXT = new_sql, [1] = new_sql }
 end
 
-function transform_for_gate(res, source_type, connection_name, options)
-    if res == nil or #res == 0 then return res end
-
-    local threshold_raw = opt(options, 'PARALLEL_ROW_THRESHOLD', '1000000')
-    local threshold = tonumber(threshold_raw)
-    if threshold == nil then
-        error('Invalid numeric option PARALLEL_ROW_THRESHOLD: ' .. tostring(threshold_raw))
+function parse_threshold(options)
+    local raw = opt(options, 'PARALLEL_ROW_THRESHOLD', '1000000')
+    local n = tonumber(raw)
+    if n == nil then
+        error('Invalid numeric option PARALLEL_ROW_THRESHOLD: ' .. tostring(raw))
     end
-    if threshold <= 0 then
-        return res
-    end
+    return n
+end
 
-    local imports = {}
+-- Collects unique source (schema, table) pairs the metadata round-trip needs.
+-- Phase 1: gate is the only consumer, so only multi-statement IMPORTs require a lookup.
+-- Phase 2 will broaden this when the splitter goes live.
+function collect_metadata_pairs(res, options)
     local pair_list = {}
     local pairs_seen = {}
-    local needs_lookup = false
+    if res == nil then return pair_list end
+
+    local threshold = parse_threshold(options)
+    if threshold <= 0 then return pair_list end
+
     for i = 1, #res do
         local sql_text = first_sql_text(res[i])
-        if classify_step(sql_text) == 'IMPORT' then
-            local n = count_statement_clauses(sql_text)
-            if n > 1 then
-                local src_schema, src_table = extract_source_ref_from_import(sql_text)
-                imports[#imports + 1] = {
-                    idx = i,
-                    sql = sql_text,
-                    schema = src_schema,
-                    table_name = src_table,
-                }
-                if src_schema ~= nil and src_table ~= nil then
-                    local key = src_schema .. '\t' .. src_table
-                    if not pairs_seen[key] then
-                        pairs_seen[key] = true
-                        pair_list[#pair_list + 1] = { schema = src_schema, table_name = src_table }
-                    end
-                    needs_lookup = true
+        if classify_step(sql_text) == 'IMPORT' and count_statement_clauses(sql_text) > 1 then
+            local src_schema, src_table = extract_source_ref_from_import(sql_text)
+            if src_schema ~= nil and src_table ~= nil then
+                local key = src_schema .. '\t' .. src_table
+                if not pairs_seen[key] then
+                    pairs_seen[key] = true
+                    pair_list[#pair_list + 1] = { schema = src_schema, table_name = src_table }
                 end
             end
         end
     end
+    return pair_list
+end
 
-    if not needs_lookup then
-        return res
-    end
+-- Returns a metadata cache describing every source table referenced by IMPORTs in `res`.
+-- Shape:
+--   { available = bool, rows = { ["schema\ttable"] = {src_rows, src_pk_col, ...} },
+--     info_rows = { "-- ..." } }
+-- `available = false` means downstream consumers MUST pass IMPORTs through unchanged
+-- (Speq 2's soft-fail invariant for the splitter; matches Speq 1's gate behavior for
+-- lookup failure / unsupported source type).
+function transform_for_metadata(res, source_type, connection_name, options)
+    local empty = { available = false, rows = {}, info_rows = {} }
+    if res == nil or #res == 0 then return empty end
 
-    local function append_info(out, message)
-        out[#out + 1] = { SQL_TEXT = '-- ' .. message }
-        return out
-    end
+    local pair_list = collect_metadata_pairs(res, options)
+    if #pair_list == 0 then return empty end
 
-    local dispatch = ROW_COUNT_SQL_BY_SOURCE[source_type]
+    local dispatch = SOURCE_METADATA_BY_SOURCE[source_type]
     if dispatch == nil or dispatch.mode == 'skip_with_info' then
         local reason
         if dispatch == nil then
             reason = 'no row-count SQL configured for source type ' .. tostring(source_type)
         else
-            reason = dispatch.reason or 'gate skipped'
+            reason = dispatch.reason or 'metadata skipped'
         end
-        local out = {}
-        for j = 1, #res do out[j] = res[j] end
-        append_info(out, 'PARALLEL_ROW_THRESHOLD gate skipped: ' .. reason)
-        return out
+        return {
+            available = false,
+            rows = {},
+            info_rows = { '-- PARALLEL_ROW_THRESHOLD gate skipped: ' .. reason },
+        }
     end
 
     local pair_clauses = {}
     for _, p in ipairs(pair_list) do
-        local esc_schema = escape_sql_literal(p.schema)
-        local esc_table = escape_sql_literal(p.table_name)
-        pair_clauses[#pair_clauses + 1] = string.format(dispatch.pair, esc_schema, esc_table)
+        pair_clauses[#pair_clauses + 1] = string.format(dispatch.pair,
+            escape_sql_literal(p.schema), escape_sql_literal(p.table_name))
     end
     local predicate = table.concat(pair_clauses, ' or ')
-    local row_count_sql = (dispatch.template:gsub('<PREDICATE>', function() return predicate end))
+    local metadata_sql = (dispatch.template:gsub('<PREDICATE>', function() return predicate end))
 
-    local outer_sql = "select * from (import into (src_schema varchar(2000), src_table varchar(2000), src_rows decimal(36,0)) from jdbc at "
+    local outer_sql = "select * from (import into (src_schema varchar(2000), src_table varchar(2000), src_rows decimal(36,0), src_pk_col varchar(2000), src_pk_type varchar(200), src_date_col varchar(2000), src_num_col varchar(2000), src_partitioned boolean) from jdbc at "
         .. connection_name
         .. " statement '"
-        .. escape_sql_literal(row_count_sql)
+        .. escape_sql_literal(metadata_sql)
         .. "')"
 
     local success, lookup_res = pquery(outer_sql)
     if not success then
-        local out = {}
-        for j = 1, #res do out[j] = res[j] end
         local err = (lookup_res and lookup_res.error_message) or 'unknown error'
-        append_info(out, 'PARALLEL_ROW_THRESHOLD gate skipped: row-count lookup failed (' .. tostring(err) .. ')')
-        return out
+        return {
+            available = false,
+            rows = {},
+            info_rows = { '-- PARALLEL_ROW_THRESHOLD gate skipped: row-count lookup failed (' .. tostring(err) .. ')' },
+        }
     end
 
-    local lookup = {}
+    local rows = {}
     for i = 1, #lookup_res do
         local r = lookup_res[i]
         local s = r.SRC_SCHEMA or r[1]
         local t = r.SRC_TABLE or r[2]
-        local n = r.SRC_ROWS or r[3]
         if s ~= nil and t ~= nil then
-            lookup[tostring(s) .. '\t' .. tostring(t)] = n
+            rows[tostring(s) .. '\t' .. tostring(t)] = {
+                src_rows = r.SRC_ROWS or r[3],
+                src_pk_col = r.SRC_PK_COL or r[4],
+                src_pk_type = r.SRC_PK_TYPE or r[5],
+                src_date_col = r.SRC_DATE_COL or r[6],
+                src_num_col = r.SRC_NUM_COL or r[7],
+                src_partitioned = r.SRC_PARTITIONED or r[8],
+            }
         end
     end
 
+    return { available = true, rows = rows, info_rows = {} }
+end
+
+-- Speq 1 gate: collapses multi-statement IMPORTs whose source row count is below
+-- `PARALLEL_ROW_THRESHOLD` to a single statement. Consumes the shared metadata cache
+-- populated by `transform_for_metadata`; never issues its own source-side query.
+function transform_for_gate(res, options, cache)
+    if res == nil or #res == 0 then return res end
+
+    local threshold = parse_threshold(options)
+
     local out = {}
     for j = 1, #res do out[j] = res[j] end
-    for _, im in ipairs(imports) do
-        if im.schema ~= nil and im.table_name ~= nil then
-            local rowcount = lookup[im.schema .. '\t' .. im.table_name]
-            local effective = tonumber(rowcount) or 0
-            if effective < threshold then
-                out[im.idx] = replace_row_sql(out[im.idx], rewrite_to_first_statement(im.sql))
+
+    if cache ~= nil then
+        for _, info_text in ipairs(cache.info_rows) do
+            out[#out + 1] = { SQL_TEXT = info_text }
+        end
+    end
+
+    if threshold <= 0 then
+        return out
+    end
+    if cache == nil or not cache.available then
+        return out
+    end
+
+    for i = 1, #res do
+        local sql_text = first_sql_text(res[i])
+        if classify_step(sql_text) == 'IMPORT' and count_statement_clauses(sql_text) > 1 then
+            local src_schema, src_table = extract_source_ref_from_import(sql_text)
+            if src_schema ~= nil and src_table ~= nil then
+                local meta = cache.rows[src_schema .. '\t' .. src_table]
+                local rowcount = meta and meta.src_rows
+                local effective = tonumber(rowcount) or 0
+                if effective < threshold then
+                    out[i] = replace_row_sql(out[i], rewrite_to_first_statement(sql_text))
+                end
             end
         end
     end
     return out
 end
 
-function execute_adapter(adapter_sql, debug, gate_ctx)
+function execute_adapter(adapter_sql, debug, ctx)
     local success, res = pquery(adapter_sql)
     if not success then
         error('"' .. res.error_message .. '" Caught while executing: "' .. res.statement_text .. '"')
     end
 
-    if gate_ctx ~= nil then
-        res = transform_for_gate(res, gate_ctx.source_type, gate_ctx.connection_name, gate_ctx.options)
+    if ctx ~= nil then
+        local cache = transform_for_metadata(res, ctx.source_type, ctx.connection_name, ctx.options)
+        res = transform_for_gate(res, ctx.options, cache)
     end
 
     if not debug then
@@ -702,13 +746,13 @@ else
     error('Unsupported SOURCE_TYPE: ' .. tostring(SOURCE_TYPE))
 end
 
-local gate_ctx = {
+local ctx = {
     source_type = source,
     connection_name = connection_name,
     options = options,
 }
 
-return execute_adapter(adapter_sql, debug, gate_ctx)
+return execute_adapter(adapter_sql, debug, ctx)
 /
 
 /*

--- a/migrate_to_exasol.sql
+++ b/migrate_to_exasol.sql
@@ -1,0 +1,417 @@
+create schema if not exists database_migration;
+
+/*
+    Unified entry point for database migration scripts.
+
+    This script keeps the existing source-specific scripts intact and exposes one
+    standardized call surface. It dispatches to the current adapter script, then
+    either returns generated SQL (DEBUG = TRUE) or executes generated SQL
+    (DEBUG = FALSE).
+
+    Source-specific settings live in OPTIONS as key=value pairs separated by ';'.
+*/
+--/
+create or replace script database_migration.MIGRATE_TO_EXASOL(
+    SOURCE_TYPE,                  -- migration source, e.g. MYSQL, POSTGRES, DATABRICKS, SNOWFLAKE
+    CONNECTION_NAME,              -- name of the source database connection inside Exasol
+    CONNECTION_TYPE,              -- Exasol-to-Exasol only: JDBC or EXA
+    DB_FILTER,                    -- database/catalog filter where supported, else '%'
+    SCHEMA_FILTER,                -- schema filter, e.g. 'MY_SCHEMA', 'MART_%', or '%'
+    TABLE_FILTER,                 -- table filter, e.g. 'MY_TABLE', 'FACT_%', or '%'
+    TARGET_SCHEMA,                -- target schema override where supported, or NULL
+    IDENTIFIER_CASE_INSENSITIVE,  -- TRUE stores generated identifiers uppercase
+    DEBUG,                        -- TRUE previews generated SQL, FALSE executes it
+    OPTIONS                       -- source-specific KEY=VALUE pairs separated by semicolons
+) RETURNS TABLE
+AS
+
+local OUT_COLUMNS = "SQL_TEXT VARCHAR(2000000), SUCCESS VARCHAR(10), ERROR_MESSAGE VARCHAR(20000)"
+
+function is_null(value)
+    return value == nil or value == null or value == NULL
+end
+
+function trim(value)
+    if is_null(value) then
+        return nil
+    end
+    return tostring(value):gsub("^%s*(.-)%s*$", "%1")
+end
+
+function blank_to_nil(value)
+    local result = trim(value)
+    if result == nil or result == '' then
+        return nil
+    end
+    return result
+end
+
+function escape_sql_literal(value)
+    return tostring(value):gsub("'", "''")
+end
+
+function sql_string(value)
+    local result = blank_to_nil(value)
+    if result == nil then
+        return "NULL"
+    end
+    return "'" .. escape_sql_literal(result) .. "'"
+end
+
+function sql_bool(value)
+    if value then
+        return "TRUE"
+    end
+    return "FALSE"
+end
+
+function parse_bool(value, default_value, param_name)
+    if is_null(value) or blank_to_nil(value) == nil then
+        return default_value
+    end
+    if type(value) == 'boolean' then
+        return value
+    end
+
+    local normalized = string.upper(trim(value))
+    if normalized == 'TRUE' or normalized == 'T' or normalized == 'YES' or normalized == 'Y' or normalized == '1' then
+        return true
+    elseif normalized == 'FALSE' or normalized == 'F' or normalized == 'NO' or normalized == 'N' or normalized == '0' then
+        return false
+    end
+
+    error('Invalid boolean for ' .. param_name .. ': ' .. tostring(value))
+end
+
+function parse_options(raw_options)
+    local parsed = {}
+    local raw = blank_to_nil(raw_options)
+    if raw == nil then
+        return parsed
+    end
+
+    for entry in string.gmatch(raw, "([^;]+)") do
+        local key, value = entry:match("^%s*([^=]+)%s*=%s*(.-)%s*$")
+        if key == nil then
+            error('Invalid OPTIONS entry: ' .. entry .. '. Use KEY=VALUE pairs separated by semicolons.')
+        end
+        parsed[string.upper(trim(key))] = trim(value)
+    end
+
+    return parsed
+end
+
+function opt(options, key, default_value)
+    local value = options[string.upper(key)]
+    if blank_to_nil(value) == nil then
+        return default_value
+    end
+    return value
+end
+
+function opt_bool(options, key, default_value)
+    return parse_bool(opt(options, key, nil), default_value, key)
+end
+
+function opt_sql_number(options, key, default_value)
+    local value = opt(options, key, default_value)
+    if blank_to_nil(value) == nil then
+        return "NULL"
+    end
+    local number_value = tonumber(value)
+    if number_value == nil then
+        error('Invalid numeric option ' .. key .. ': ' .. tostring(value))
+    end
+    return tostring(number_value)
+end
+
+function normalize_source_type(source_type)
+    local source = string.upper(blank_to_nil(source_type) or '')
+    source = source:gsub("%s+", "_"):gsub("-", "_")
+
+    if source == 'AZURESQL' or source == 'AZURE_SQL_SERVER' then
+        return 'AZURE_SQL'
+    elseif source == 'BIG_QUERY' or source == 'GOOGLE_BIGQUERY' or source == 'GOOGLE_BIG_QUERY' then
+        return 'BIGQUERY'
+    elseif source == 'DBX' or source == 'DATABRICKS_SQL' then
+        return 'DATABRICKS'
+    elseif source == 'POSTGRESQL' then
+        return 'POSTGRES'
+    elseif source == 'SQL_SERVER' or source == 'MSSQL' or source == 'MICROSOFT_SQL_SERVER' then
+        return 'SQLSERVER'
+    elseif source == 'SAP_HANA' or source == 'SAPHANA' then
+        return 'HANA'
+    elseif source == 'EXA' then
+        return 'EXASOL'
+    elseif source == 'NZ' then
+        return 'NETEZZA'
+    elseif source == 'ACTIAN' or source == 'ACTIAN_VECTOR' then
+        return 'VECTORWISE'
+    end
+
+    return source
+end
+
+function require_value(value, name)
+    local result = blank_to_nil(value)
+    if result == nil then
+        error(name .. ' is required')
+    end
+    return result
+end
+
+function first_sql_text(row)
+    if row.SQL_TEXT ~= nil then
+        return row.SQL_TEXT
+    end
+    if row[1] ~= nil then
+        return row[1]
+    end
+    return tostring(row)
+end
+
+function normalize_rows(res)
+    local summary = {}
+    for i = 1, #res do
+        local row = res[i]
+        local sql_text = first_sql_text(row)
+        local success = row.SUCCESS or row[2] or 'PREVIEW'
+        local error_message = row.ERROR_MESSAGE or row[3] or NULL
+        summary[#summary + 1] = {sql_text, success, error_message}
+    end
+    return summary
+end
+
+function is_executable_statement(sql_text)
+    local text = blank_to_nil(sql_text)
+    if text == nil then
+        return false
+    end
+    return string.sub(text, 1, 2) ~= '--'
+end
+
+function execute_generated_sql(res)
+    local summary = {}
+    local fail_count = 0
+
+    for i = 1, #res do
+        local sql_text = first_sql_text(res[i])
+        if is_executable_statement(sql_text) then
+            local success, info = pquery(sql_text)
+            if success then
+                summary[#summary + 1] = {sql_text, 'TRUE', NULL}
+            else
+                fail_count = fail_count + 1
+                summary[#summary + 1] = {sql_text, 'FALSE', info.error_message}
+            end
+        else
+            summary[#summary + 1] = {sql_text, 'SKIPPED', 'Comment or empty'}
+        end
+    end
+
+    if fail_count == 0 then
+        table.insert(summary, 1, {'-- The following statements were executed successfully.', 'SKIPPED', NULL})
+    else
+        table.insert(summary, 1, {'-- Execution completed with ' .. fail_count .. ' error(s). See ERROR_MESSAGE column for details.', 'SKIPPED', NULL})
+    end
+
+    return summary
+end
+
+function execute_adapter(adapter_sql, debug)
+    local success, res = pquery(adapter_sql)
+    if not success then
+        error('"' .. res.error_message .. '" Caught while executing: "' .. res.statement_text .. '"')
+    end
+
+    if not debug then
+        return execute_generated_sql(res), OUT_COLUMNS
+    end
+
+    return normalize_rows(res), OUT_COLUMNS
+end
+
+local source = normalize_source_type(SOURCE_TYPE)
+local connection_name = require_value(CONNECTION_NAME, 'CONNECTION_NAME')
+local connection_type = string.upper(blank_to_nil(CONNECTION_TYPE) or 'JDBC')
+local db_filter = blank_to_nil(DB_FILTER) or '%'
+local schema_filter = blank_to_nil(SCHEMA_FILTER) or '%'
+local table_filter = blank_to_nil(TABLE_FILTER) or '%'
+local target_schema = blank_to_nil(TARGET_SCHEMA)
+local identifier_case_insensitive = parse_bool(IDENTIFIER_CASE_INSENSITIVE, true, 'IDENTIFIER_CASE_INSENSITIVE')
+local debug = parse_bool(DEBUG, true, 'DEBUG')
+local options = parse_options(OPTIONS)
+
+local adapter_sql = nil
+
+if source == 'MYSQL' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.MYSQL_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(table_filter) .. ')'
+
+elseif source == 'MARIADB' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.MARIADB_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(table_filter) .. ')'
+
+elseif source == 'POSTGRES' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.POSTGRES_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(table_filter) .. ','
+        .. sql_string(target_schema) .. ')'
+
+elseif source == 'REDSHIFT' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.REDSHIFT_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(table_filter) .. ')'
+
+elseif source == 'DB2' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.DB2_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(table_filter) .. ')'
+
+elseif source == 'VERTICA' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.VERTICA_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(table_filter) .. ')'
+
+elseif source == 'HANA' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.HANA_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(table_filter) .. ')'
+
+elseif source == 'AZURE_SQL' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.AZURE_SQL_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(table_filter) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ')'
+
+elseif source == 'BIGQUERY' then
+    local project_id = opt(options, 'PROJECT_ID', nil)
+    if blank_to_nil(project_id) == nil and db_filter ~= '%' then
+        project_id = db_filter
+    end
+    project_id = require_value(project_id, 'OPTIONS PROJECT_ID for BIGQUERY')
+
+    adapter_sql = 'EXECUTE SCRIPT database_migration.BIGQUERY_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ','
+        .. sql_string(project_id) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(table_filter) .. ')'
+
+elseif source == 'DATABRICKS' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.DATABRICKS_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(opt_bool(options, 'CATALOG2SCHEMA', true)) .. ','
+        .. sql_string(db_filter) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(target_schema) .. ','
+        .. sql_string(table_filter) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ')'
+
+elseif source == 'SQLSERVER' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.SQLSERVER_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(opt_bool(options, 'DB2SCHEMA', false)) .. ','
+        .. sql_string(db_filter) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(target_schema) .. ','
+        .. sql_string(table_filter) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ')'
+
+elseif source == 'SNOWFLAKE' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.SNOWFLAKE_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(opt_bool(options, 'DB2SCHEMA', false)) .. ','
+        .. sql_string(db_filter) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(target_schema) .. ','
+        .. sql_string(table_filter) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ')'
+
+elseif source == 'ORACLE' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.ORACLE_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(table_filter) .. ','
+        .. opt_sql_number(options, 'PARALLEL_STATEMENTS', 1) .. ','
+        .. sql_bool(opt_bool(options, 'CREATE_PK', false)) .. ','
+        .. sql_bool(opt_bool(options, 'CREATE_FK', false)) .. ','
+        .. sql_bool(opt_bool(options, 'CHECK_MIGRATION', false)) .. ')'
+
+elseif source == 'TERADATA' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.TERADATA_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(table_filter) .. ','
+        .. sql_bool(opt_bool(options, 'CHECK_MIGRATION', false)) .. ')'
+
+elseif source == 'EXASOL' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.EXASOL_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_string(connection_type) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(table_filter) .. ','
+        .. sql_string(opt(options, 'GENERATE_VIEWS', 'FALSE')) .. ','
+        .. sql_string(opt(options, 'VIEW_FILTER', '%')) .. ','
+        .. sql_string(opt(options, 'PK_SETTING', 'DISABLE')) .. ')'
+
+elseif source == 'NETEZZA' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.NETEZZA_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_string(db_filter) .. ','
+        .. sql_string(schema_filter) .. ','
+        .. sql_string(table_filter) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ')'
+
+elseif source == 'VECTORWISE' then
+    adapter_sql = 'EXECUTE SCRIPT database_migration.VECTORWISE_TO_EXASOL('
+        .. sql_string(connection_name) .. ','
+        .. sql_bool(identifier_case_insensitive) .. ','
+        .. sql_string(table_filter) .. ')'
+
+elseif source == 'S3' then
+    error('S3 is not supported by MIGRATE_TO_EXASOL. Use DATABASE_MIGRATION.S3_PARALLEL_READ directly.')
+
+else
+    error('Unsupported SOURCE_TYPE: ' .. tostring(SOURCE_TYPE))
+end
+
+return execute_adapter(adapter_sql, debug)
+/
+
+/*
+Example:
+
+execute script database_migration.MIGRATE_TO_EXASOL(
+    'SNOWFLAKE',
+    'SNOWFLAKE_CONNECTION',
+    'JDBC',
+    '%',
+    '%',
+    '%',
+    NULL,
+    TRUE,
+    TRUE,
+    'DB2SCHEMA=true'
+);
+*/

--- a/postgres_to_exasol.sql
+++ b/postgres_to_exasol.sql
@@ -20,7 +20,7 @@ if IDENTIFIER_CASE_INSENSITIVE == true then
 	exa_upper_begin='upper('
 	exa_upper_end=')'
 end
-if DEST_SCHEMA then
+if DEST_SCHEMA ~= nil and DEST_SCHEMA ~= null then
 	exa_table_schema_clause=[[']]..DEST_SCHEMA..[[']]
 else
 	exa_table_schema_clause=exa_upper_begin..[["table_schema"]]..exa_upper_end

--- a/postgres_to_exasol.sql
+++ b/postgres_to_exasol.sql
@@ -27,7 +27,7 @@ else
 end
 res = query([[
 with vv_pg_columns as (
-	select ]]..exa_upper_begin..[["table_catalog"]]..exa_upper_end..[[ as "exa_table_catalog", ]]..exa_table_schema_clause..[[ as "exa_table_schema", ]]..exa_upper_begin..[["table_name"]]..exa_upper_end..[[ as "exa_table_name", ]]..exa_upper_begin..[["column_name"]]..exa_upper_end..[[ as "exa_column_name", pg.* from  
+	select ]]..exa_upper_begin..[["table_catalog"]]..exa_upper_end..[[ as "exa_table_catalog", ]]..exa_table_schema_clause..[[ as "exa_table_schema", ]]..exa_upper_begin..[["table_name"]]..exa_upper_end..[[ as "exa_table_name", ]]..exa_upper_begin..[["column_name"]]..exa_upper_end..[[ as "exa_column_name", '"' || replace("table_schema", '"', '""') || '"' as "source_table_schema", '"' || replace("table_name", '"', '""') || '"' as "source_table_name", '"' || replace("column_name", '"', '""') || '"' as "source_column_name", pg.* from
 		(import from jdbc at ]]..CONNECTION_NAME..[[ statement 
 			'select table_catalog, table_schema, table_name, column_name, ordinal_position, case when is_nullable=''NO'' then ''NOT NULL'' else ''NULL'' end as not_null_constraint, data_type, character_maximum_length, numeric_precision, numeric_scale, datetime_precision  
 				from information_schema.columns join information_schema.tables using (table_catalog, table_schema, table_name) 
@@ -105,40 +105,40 @@ with vv_pg_columns as (
 , vv_imports as (
 	select 'import into "' || "exa_table_schema" || '"."' || "exa_table_name" || '" from jdbc at ]]..CONNECTION_NAME..[[ statement ''select ' || group_concat( 
 	case 
-	when "data_type" = 'ARRAY' then "column_name" ||'::text'
-	when "data_type" = 'USER-DEFINED' then "column_name" ||'::text' 
-	when "data_type" = 'bit' then "column_name" ||'::text'
-	when "data_type" = 'bit varying' then "column_name" ||'::text'
-	when "data_type" = 'box' then "column_name" ||'::text'
-	when "data_type" = 'bytea' then "column_name" ||'::text'
-	when "data_type" = 'cidr' then "column_name" ||'::text' 
-	when "data_type" = 'circle' then "column_name" ||'::text' 
-	when "data_type" = 'inet' then "column_name" ||'::text'
-	when "data_type" = 'interval' then "column_name" ||'::text' 
-	when "data_type" = 'json' then "column_name" ||'::text'
-	when "data_type" = 'jsonb' then "column_name" ||'::text'
-	when "data_type" = 'line' then "column_name" ||'::text'
-	when "data_type" = 'lseg' then "column_name" ||'::text'
-	when "data_type" = 'name' then "column_name" ||'::text'
-	when "data_type" = 'macaddr' then "column_name" ||'::text'
-	when "data_type" = 'money' then "column_name" ||'::text'
-	when "data_type" = 'point' then "column_name" ||'::text'
-	when "data_type" = 'path' then "column_name" ||'::text'
-	when "data_type" = 'pg_lsn' then "column_name" ||'::text'
-	when "data_type" = 'polygon' then "column_name" ||'::text'
-	when "data_type" = 'timestamp with time zone' then 'case when  '||"column_name"||' > ''''9999-12-31 23:59:59.999'''' then ''''9999-12-31 23:59:59.999'''' when '||"column_name" ||' < ''''0001-01-01'''' then ''''0001-01-01'''' else '||"column_name" ||' end'
-	when "data_type" = 'timestamp without time zone' then 'case when  '||"column_name"||' > ''''9999-12-31 23:59:59.999'''' then ''''9999-12-31 23:59:59.999'''' when '||"column_name" ||' < ''''0001-01-01'''' then ''''0001-01-01'''' else '||"column_name" ||' end'
-	when "data_type" = 'tsquery' then "column_name" ||'::text'
-	when "data_type" = 'tsvector' then "column_name" ||'::text'
-	when "data_type" = 'txid_snapshot' then "column_name" ||'::text'
-	when "data_type" = 'uuid' then "column_name" ||'::text'
-	when "data_type" = 'xml' then "column_name" ||'::text'
+	when "data_type" = 'ARRAY' then "source_column_name" ||'::text'
+	when "data_type" = 'USER-DEFINED' then "source_column_name" ||'::text'
+	when "data_type" = 'bit' then "source_column_name" ||'::text'
+	when "data_type" = 'bit varying' then "source_column_name" ||'::text'
+	when "data_type" = 'box' then "source_column_name" ||'::text'
+	when "data_type" = 'bytea' then "source_column_name" ||'::text'
+	when "data_type" = 'cidr' then "source_column_name" ||'::text'
+	when "data_type" = 'circle' then "source_column_name" ||'::text'
+	when "data_type" = 'inet' then "source_column_name" ||'::text'
+	when "data_type" = 'interval' then "source_column_name" ||'::text'
+	when "data_type" = 'json' then "source_column_name" ||'::text'
+	when "data_type" = 'jsonb' then "source_column_name" ||'::text'
+	when "data_type" = 'line' then "source_column_name" ||'::text'
+	when "data_type" = 'lseg' then "source_column_name" ||'::text'
+	when "data_type" = 'name' then "source_column_name" ||'::text'
+	when "data_type" = 'macaddr' then "source_column_name" ||'::text'
+	when "data_type" = 'money' then "source_column_name" ||'::text'
+	when "data_type" = 'point' then "source_column_name" ||'::text'
+	when "data_type" = 'path' then "source_column_name" ||'::text'
+	when "data_type" = 'pg_lsn' then "source_column_name" ||'::text'
+	when "data_type" = 'polygon' then "source_column_name" ||'::text'
+	when "data_type" = 'timestamp with time zone' then 'case when  '||"source_column_name"||' > ''''9999-12-31 23:59:59.999'''' then ''''9999-12-31 23:59:59.999'''' when '||"source_column_name" ||' < ''''0001-01-01'''' then ''''0001-01-01'''' else '||"source_column_name" ||' end'
+	when "data_type" = 'timestamp without time zone' then 'case when  '||"source_column_name"||' > ''''9999-12-31 23:59:59.999'''' then ''''9999-12-31 23:59:59.999'''' when '||"source_column_name" ||' < ''''0001-01-01'''' then ''''0001-01-01'''' else '||"source_column_name" ||' end'
+	when "data_type" = 'tsquery' then "source_column_name" ||'::text'
+	when "data_type" = 'tsvector' then "source_column_name" ||'::text'
+	when "data_type" = 'txid_snapshot' then "source_column_name" ||'::text'
+	when "data_type" = 'uuid' then "source_column_name" ||'::text'
+	when "data_type" = 'xml' then "source_column_name" ||'::text'
 	when "data_type" in ('bigint', 'boolean', 'character', 'character varying', 'date', 'double precision', 'integer', 'numeric', 'oid', 'real', 'smallint', 'text', 'time with time zone', 'time without time zone')
-	then "column_name"
+	then "source_column_name"
 	end
-	order by "ordinal_position") || ' from ' || "table_schema"|| '.' || "table_name"|| ''';' as sql_text
-	from vv_pg_columns group by "exa_table_catalog","exa_table_schema","exa_table_name", "table_schema","table_name"
-	order by "exa_table_catalog", "exa_table_schema","exa_table_name", "table_schema","table_name"
+	order by "ordinal_position") || ' from ' || "source_table_schema"|| '.' || "source_table_name"|| ''';' as sql_text
+	from vv_pg_columns group by "exa_table_catalog","exa_table_schema","exa_table_name", "source_table_schema","source_table_name"
+	order by "exa_table_catalog", "exa_table_schema","exa_table_name", "source_table_schema","source_table_name"
 )
 select SQL_TEXT from (
 select 1 as ord, a.* from vv_create_schemas a

--- a/specs/_plans/parallel-import-source-optimization/PLAN.md
+++ b/specs/_plans/parallel-import-source-optimization/PLAN.md
@@ -1,0 +1,240 @@
+# Plan: Per-source parallel IMPORT optimization
+
+## Status
+Drafted 2026-05-17. Sibling speq landed as `parallel-row-threshold-dispatcher-gate/` (commit 928d30c on `feat/parallel-row-threshold`). Plan refactored 2026-05-17 (post-gate) to (1) introduce a cross-cutting split-strategy hierarchy that every adapter follows, (2) add **date-bucket** as a first-class strategy ahead of generic hash-modulo, (3) cap `PARALLEL_STATEMENTS=AUTO` at 12 to spare source systems.
+
+## Motivation
+Today only the Oracle adapter emits multi-statement parallel IMPORT. Its partition strategy is bin-pack on `all_tab_partitions` when partitions exist, else modulo split on `ora_hash(rowid)`. This works but:
+- It is Oracle-only. Other adapters (`PostgreSQL`, `MySQL`, `MariaDB`, `SQL Server`, `Snowflake`, `BigQuery`, `Redshift`, `Vertica`, `Teradata`, `DB2`, `Trino`, `Dremio`, `ClickHouse`, `Databricks`, `DuckDB`, `StarRocks`, `Vectorwise`, `SAP HANA`) emit single-statement IMPORTs regardless of table size — there is no parallel option to offer the user, even when the source could clearly support it.
+- Even within Oracle, `ora_hash(rowid)` ignores actual data layout. On a heavily-partitioned table where bin-pack works, fine; on a non-partitioned monster table on a NUMERIC primary key, `ora_hash(rowid)` may produce N statements that all hit the same physical blocks, giving worse parallelism than `MOD(pk, N)` would.
+
+This speq covers both axes — improving Oracle's existing strategy AND bringing parallel emission to adapters that lack it, each using the source's native partitioning / hashing primitives.
+
+## Dependencies
+- **Hard dependency satisfied**: `parallel-row-threshold-dispatcher-gate/` shipped 2026-05-17 (commit 928d30c). Gate operates at dispatcher layer, so this speq's per-adapter parallel emission inherits the threshold collapse for free.
+- Soft dependency on the wrapper audit table from PR #42 (`harden-master-migration-entrypoint`) — the new partition strategy column (see Audit changes below) should reuse that table's schema.
+
+## Split-strategy hierarchy (cross-cutting)
+
+Every adapter walks this ordered hierarchy per table; stops at first hit:
+
+| # | Strategy | Selector key | Why this position |
+|---|----------|--------------|-------------------|
+| 1 | `PARTITION` — per native partition / sub-partition | source partition metadata view | engine-validated even distribution; pushdown-perfect |
+| 2 | `PK_RANGE` / `PK_MOD` — numeric singleton PK | declared primary key, numeric | sequential IDs → uniform split; cheapest WHERE |
+| 3 | `UNIQUE_NUM` — numeric singleton unique index | unique constraint | semantically equivalent to PK |
+| 4 | `DATE_BUCKET` — date / timestamp column **(NEW)** | first DATE/TIMESTAMP col matching `*(_)?(date\|dt\|time\|day\|created\|loaded\|event\|posted)$`, else first DATE/TIMESTAMP by ordinal | pushdown-friendly on indexed cols; readable in audit; cheaper than hash; resilient where PK is composite / UUID |
+| 5 | `HASH_NUM` — first numeric not-null col, hash modulo | column metadata | catches integer surrogate cols not flagged as PK |
+| 6 | `ROWID` — engine-specific physical row identifier | dialect (Oracle `ROWID` / PG `ctid` / MSSQL `%%physloc%%` / DB2 `RID_BIT`) | always works on heap; zero metadata needed |
+| 7 | `SINGLE` — emit one STATEMENT + `INFO` row "no parallel split found" | — | safe fallback; matches today's behavior |
+
+`PARALLEL_SPLIT` OPTIONS knob (per migration; not per table):
+- `AUTO` (default) — walk hierarchy
+- `PARTITION` — force step 1; fail-soft to SINGLE if no partition
+- `PK` — force step 2/3; fail-soft to SINGLE
+- `DATE` — force step 4; auto-pick column
+- `DATE:<col>` — force step 4 with named column
+- `DATE:<col>:<grain>` — force step 4 with `MONTH` / `QUARTER` / `YEAR_MONTH` granularity
+- `HASH:<col>` — force step 5 with named column
+- `ROWID` — force step 6
+- `OFF` — force SINGLE (equivalent to `PARALLEL_STATEMENTS=1`)
+
+### Date-bucket details
+
+Granularity auto-selected to evenly cover `PARALLEL_STATEMENTS=N`:
+
+| N | Bucket size | Selector pattern |
+|---|-------------|------------------|
+| 2 | half-year | `MONTH("dt") IN (1..6)` / `(7..12)` |
+| 3 | tri-mester | `MONTH("dt") IN (1..4)` / `(5..8)` / `(9..12)` |
+| 4 | quarter | `MONTH("dt") IN (1,2,3)` ... `(10,11,12)` |
+| 6 | bimonth | `MONTH("dt") IN (1,2)` ... `(11,12)` |
+| 12 | month | `MONTH("dt") = k` |
+| ≤ 31 | day-of-month | `DAY("dt") = k` (with bucket N-1 catching k≥N) |
+| > 31 | year × month | `(YEAR("dt")*12 + MONTH("dt")) MOD N = k` |
+
+Per-source dialect template (add to dispatch table alongside row-count SQL):
+
+| Source | MONTH fn | DAY fn |
+|---|---|---|
+| Oracle / Postgres / Redshift / BigQuery / Teradata | `EXTRACT(MONTH FROM "dt")` | `EXTRACT(DAY FROM "dt")` |
+| MySQL / MariaDB / Snowflake / Vertica / DB2 / HANA / Databricks | `MONTH("dt")` | `DAY("dt")` |
+| SQL Server / Azure SQL | `DATEPART(month, "dt")` | `DATEPART(day, "dt")` |
+
+NULL handling: append `OR "dt" IS NULL` to bucket 0.
+TZ handling: timestamp-with-zone normalize to UTC at adapter level; document; offer `PARALLEL_SPLIT=DATE:<col>:UTC` override.
+
+### `PARALLEL_STATEMENTS=AUTO` ceiling
+
+`PARALLEL_STATEMENTS` accepts an integer or the literal `AUTO`:
+
+- explicit int N → use N (no ceiling; user knows their source)
+- `AUTO` → heuristic: `min(12, max(1, ceil(row_count / 5_000_000)))` per table, using the row-count already fetched for the threshold gate
+- ceiling = **12** (rationale below)
+- `1` from heuristic → emits SINGLE (same as below-threshold collapse)
+
+Rationale for ceiling = 12:
+- Source-side complaint surface: every IMPORT STATEMENT opens its own JDBC connection. >12 concurrent reads on a transactional OLTP source (Postgres / MySQL / MSSQL) saturates connection pools and triggers DBA paging.
+- Snowflake / BigQuery slot-based engines absorb more, but Exasol-side ingest concurrency past 12 yields diminishing returns vs network bandwidth.
+- 12 = clean fit with `MONTH`-grain date bucketing (one stmt per month).
+- Users with high-CPU Exasol + warehouse sources can bypass: `PARALLEL_STATEMENTS=32` (or whatever).
+
+Audit row should record both the requested value and the effective value (`PARALLEL_STATEMENTS=AUTO -> 8` etc.).
+
+## Two axes of work
+
+### Axis A: Align Oracle adapter with the cross-cutting hierarchy
+Current implementation (`oracle_to_exasol.sql:142-298`):
+1. Probe `all_tab_partitions` for partitioned tables. If partitions exist, run per-partition `count(*)` IMPORT, bin-pack partitions across `PARALLEL_STATEMENTS` bins.
+2. If no partitions, fall back to `ora_hash(rowid) MOD N = i` per statement.
+
+Maps to hierarchy steps **1** (PARTITION) → jumps straight to **6** (ROWID-equivalent via `ora_hash(rowid)`). Steps 2-5 missing. Improvements:
+- **Step 2 (PK_RANGE)**: numeric singleton PK detected via `all_constraints` / `all_cons_columns` → emit `WHERE pk BETWEEN lo AND hi` ranges. Min/max from `dba_tab_statistics`.
+- **Step 4 (DATE_BUCKET)**: detect first DATE col via `all_tab_columns`; emit `EXTRACT(MONTH FROM "dt")` buckets per `PARALLEL_STATEMENTS`.
+- **Step 5 (HASH_NUM)**: first numeric column hash modulo via `ORA_HASH("col", N-1)`.
+- **Step 6 (ROWID)**: keep existing `ora_hash(rowid) MOD N`, demoted to last resort.
+- **Subpartition awareness** (step 1 enhancement): today's bin-pack ignores `all_tab_subpartitions`. Treat sub-partitions as leaves when present.
+- **Histogram-informed bin-pack** (step 1 enhancement): use `dba_tab_col_statistics.histogram` to detect heavy skew on the partition key, fall back to row-count bin-pack only when histograms are flat.
+
+### Axis B: Port parallel emission to adapters that lack it
+Each adapter follows the **same cross-cutting hierarchy**. Per-source notes capture engine-specific selector syntax and metadata sources only.
+
+Every adapter takes `PARALLEL_STATEMENTS` (int or `AUTO`) + inherits `PARALLEL_SPLIT` from OPTIONS via dispatcher passthrough. Adapter only chooses the selector syntax per step.
+
+#### B1. PostgreSQL (`postgres_to_exasol.sql`)
+| Step | Selector | Metadata |
+|---|---|---|
+| 1 PARTITION | child table per `pg_inherits` row | `pg_partitioned_table` / `pg_inherits` |
+| 2 PK_RANGE | `WHERE "pk" BETWEEN lo AND hi` | `pg_constraint.contype='p'`, `pg_stats` for min/max |
+| 3 UNIQUE_NUM | same as PK | `pg_index.indisunique` |
+| 4 DATE_BUCKET | `extract(month from "dt")` | `pg_attribute` typename in `('date','timestamp','timestamptz')` |
+| 5 HASH_NUM | `MOD(abs(hashtext("col"::text)), N) = k` | `pg_attribute` numeric typename |
+| 6 ROWID | `ctid >= '(N,0)' and ctid < '(M,0)'` (heap only) | `pg_class.relpages` |
+
+Row count for threshold gate: `pg_class.reltuples::bigint` (already wired in Speq 1).
+
+#### B2. SQL Server / Azure SQL (`sqlserver_to_exasol.sql`, alias)
+| Step | Selector | Metadata |
+|---|---|---|
+| 1 PARTITION | `$PARTITION.<fn>("col") = p` per partition | `sys.partitions` × `sys.indexes` × `sys.partition_schemes` |
+| 2 PK_RANGE | `WHERE "pk" BETWEEN lo AND hi` | `sys.key_constraints type='PK'`, `sys.stats` |
+| 4 DATE_BUCKET | `DATEPART(month, "dt")` | `sys.columns.system_type_id IN (40,41,42,43,58,61)` |
+| 5 HASH_NUM | `ABS(CHECKSUM("col")) % N = k` | `sys.columns` numeric types |
+| 6 ROWID | `convert(varbinary(8), %%physloc%%)` ranges (heap + clustered) | `sys.partitions.partition_id` |
+
+Row count: `sys.dm_db_partition_stats.row_count` (already wired Speq 1).
+
+#### B3. Snowflake (`snowflake_to_exasol.sql`)
+| Step | Selector | Metadata |
+|---|---|---|
+| 1 PARTITION | n/a (micro-partitions opaque) | — |
+| 2 PK_RANGE | `WHERE "pk" BETWEEN lo AND hi` | `INFORMATION_SCHEMA.TABLE_CONSTRAINTS` (not enforced; informational only) |
+| 4 DATE_BUCKET | `MONTH("dt")` | `INFORMATION_SCHEMA.COLUMNS data_type LIKE 'TIMESTAMP%' OR 'DATE'` |
+| 5 HASH_NUM | `MOD(HASH("col"), N) = k` | `INFORMATION_SCHEMA.COLUMNS` numeric types |
+| 6 ROWID | n/a → fall to 5 or SINGLE | — |
+
+Row count: `INFORMATION_SCHEMA.TABLES.ROW_COUNT` (exact, free).
+
+#### B4. BigQuery (`bigquery_to_exasol.sql`)
+| Step | Selector | Metadata |
+|---|---|---|
+| 1 PARTITION | `_PARTITIONDATE` ranges (time-partitioned) or partition value bands (range-partitioned) | `INFORMATION_SCHEMA.PARTITIONS`, `INFORMATION_SCHEMA.TABLES.PARTITIONING_TYPE` |
+| 2 PK_RANGE | `WHERE "pk" BETWEEN lo AND hi` (informational PK only) | `INFORMATION_SCHEMA.TABLE_CONSTRAINTS` |
+| 4 DATE_BUCKET | `EXTRACT(MONTH FROM "dt")` | `INFORMATION_SCHEMA.COLUMNS data_type IN ('DATE','DATETIME','TIMESTAMP')` |
+| 5 HASH_NUM | `MOD(FARM_FINGERPRINT(CAST("col" AS STRING)), N) = k` | `INFORMATION_SCHEMA.COLUMNS` numeric types |
+| 6 ROWID | n/a → fall to 5 or SINGLE | — |
+
+Row count: revisit `INFORMATION_SCHEMA.PARTITIONS` aggregate so threshold-gate flips BIGQUERY from `skip_with_info` to `sql` mode at the same time.
+
+#### B5. MySQL / MariaDB (`mysql_to_exasol.sql`, `mariadb_to_exasol.sql`)
+| Step | Selector | Metadata |
+|---|---|---|
+| 1 PARTITION | `PARTITION (p)` selector in SELECT | `information_schema.PARTITIONS` |
+| 2 PK_RANGE | `WHERE "pk" BETWEEN lo AND hi` | `information_schema.STATISTICS index_name='PRIMARY'` |
+| 4 DATE_BUCKET | `MONTH("dt")` | `information_schema.COLUMNS data_type IN ('date','datetime','timestamp')` |
+| 5 HASH_NUM | `MOD(CRC32("col"), N) = k` | `information_schema.COLUMNS` numeric types |
+| 6 ROWID | not exposed without PK → fall to SINGLE + INFO | — |
+
+Row count: `information_schema.TABLES.TABLE_ROWS` (already wired Speq 1).
+
+#### B6. Redshift (`redshift_to_exasol.sql`)
+| Step | Selector | Metadata |
+|---|---|---|
+| 1 PARTITION | n/a (Redshift has no user-defined partitions) | — |
+| 2 PK_RANGE | `WHERE "pk" BETWEEN lo AND hi` (PK informational only) | `pg_constraint` (Redshift compat catalog) |
+| 4 DATE_BUCKET | `extract(month from "dt")` | `pg_attribute` date types |
+| 5 HASH_NUM | `MOD(STRTOL(MD5("col"::varchar),16), N) = k` | `pg_attribute` numeric types |
+| 6 ROWID | n/a → SINGLE | — |
+
+Distkey / sortkey detection (special-case for step 5 acceleration): `svv_table_info.distkey` / `sortkey1` — prefer hash on these cols when present.
+
+Row count: `svv_table_info.tbl_rows` (already wired Speq 1).
+
+#### B7-B12. Lower-priority sources
+Vertica, Teradata, DB2, Trino, Dremio, ClickHouse, Databricks, DuckDB, StarRocks, Vectorwise, SAP HANA — defer to follow-up speqs each. None are blockers for v1 of this speq.
+
+### Recommended sequencing
+1. Axis A first (Oracle improvements) — same adapter we already understand, lowest risk.
+2. Axis B1 (PostgreSQL) — highest-value port, cleanest catalog.
+3. Axis B2 (SQL Server) — second-highest usage in customer demos.
+4. Axis B3-B5 (Snowflake, BigQuery, MySQL/MariaDB) — round out the top tier.
+5. B6+ as separate per-source mini-speqs.
+
+Each adapter port is its own commit on its own branch. Do **not** bundle them — review surface explodes.
+
+## Audit-table additions (incremental over Speq 1's)
+Speq 1 did **not** add audit columns (deferred to a separate plan per its own §Non-goals). This speq introduces them in one shot:
+- `SPLIT_STRATEGY VARCHAR(32)` — one of `PARTITION` / `PK_RANGE` / `PK_MOD` / `UNIQUE_NUM` / `DATE_BUCKET` / `HASH_NUM` / `ROWID` / `SINGLE`
+- `SPLIT_KEY VARCHAR(256)` — the column / pseudo-column / partition name used (`"CREATED_AT"`, `ROWID`, `ctid`, `p_2024_q1`, etc.)
+- `PARALLEL_REQUESTED VARCHAR(16)` — raw `PARALLEL_STATEMENTS` OPTIONS value (`AUTO`, `8`, etc.)
+- `PARALLEL_EFFECTIVE DECIMAL(4,0)` — number of `STATEMENT` clauses actually emitted (post-AUTO heuristic, post-threshold-gate collapse)
+
+Four new columns. Users query the audit table to compare strategies across migrations and identify where the planner picked sub-optimal strategies.
+
+## Non-goals
+- **NOT** changing the threshold-gate mechanic from Speq 1. This speq layers on top.
+- **NOT** introducing concurrent execution of IMPORTs across different tables (inter-table parallelism). Each IMPORT remains its own serial statement; this speq only changes what's emitted *inside* one IMPORT.
+- **NOT** writing a partition planner that picks strategy automatically based on source-side stats. v1 picks strategy by adapter type + presence of native partitions. Smarter heuristics are a follow-up.
+
+## Test plan
+
+### Tier 1 — Lua unit (per adapter)
+Extend `test/test_<source>_to_exasol.lua`. Fixtures per adapter (≥ 6 cases):
+1. **partitioned table** → expect step 1 (`SPLIT_STRATEGY=PARTITION`) with N stmts ≈ N partitions
+2. **non-partitioned + numeric PK** → expect step 2 (`PK_RANGE`)
+3. **no PK + date column named `created_at`** → expect step 4 (`DATE_BUCKET`), grain auto-selected per N
+4. **no PK + no date + numeric col** → expect step 5 (`HASH_NUM`)
+5. **no PK + no date + no numeric** → expect step 6 (ROWID if engine supports) or step 7 (SINGLE + INFO)
+6. **`PARALLEL_SPLIT=DATE:CREATED_AT:QUARTER` override** → expect step 4 with explicit grain ignoring auto-pick
+7. **`PARALLEL_STATEMENTS=AUTO` with row_count fixture** → expect heuristic = `min(12, ceil(rows/5M))`, capped at 12
+8. **`PARALLEL_STATEMENTS=24` (explicit > ceiling)** → expect 24 stmts (no cap on explicit)
+
+Mock pquery returns metadata + row-count rows; assertions on emitted IMPORT SQL (statement count, WHERE clause shape, SPLIT_STRATEGY audit column).
+
+### Tier 2 — live smoke (per adapter)
+One `_reference/smoke_parallel_<source>.py` per adapter (pattern of `_reference/smoke_parallel_row_threshold.py`):
+- container boot (Oracle, PG, MySQL, MSSQL, Vertica, DB2 community, HANA Express, Databricks via dbx-runtime image)
+- live-account-gated env var (Snowflake, BigQuery, Redshift) — skip if env not set
+- 4 fixtures: partitioned + numeric-PK + dated + plain
+- run preview with `PARALLEL_STATEMENTS=4;PARALLEL_ROW_THRESHOLD=100`; assert each fixture lands on expected strategy
+- run preview with `PARALLEL_STATEMENTS=AUTO`; assert ceiling respected
+- execute mode end-to-end for at least one fixture per adapter to validate IMPORT actually loads
+
+### Tier 0 — dispatcher (cross-cutting)
+Add cases in `test/test_migrate_to_exasol.lua`:
+- `PARALLEL_STATEMENTS=AUTO` resolves to ceiling-bounded heuristic
+- `PARALLEL_SPLIT=date:CREATED_AT:MONTH` forwarded to adapter signature
+- audit row carries `SPLIT_STRATEGY` + `PARALLEL_REQUESTED` + `PARALLEL_EFFECTIVE` columns
+
+## Estimated effort
+- Axis A (Oracle improvements): 1-2 implementer-days.
+- Axis B1 (PG): 1-2 implementer-days plus 1 day for live smoke + driver-quirk wrangling.
+- Each subsequent adapter: ~1 implementer-day if catalog is well-documented, more if quirks.
+- Total to ship top-5 sources (Oracle improvements + PG + SQLServer + Snowflake + BigQuery + MySQL): roughly 2 implementer-weeks.
+
+## Open questions
+1. ~~Should `PARALLEL_STATEMENTS` parameter be exposed on every adapter~~ → **resolved**: yes, via cross-cutting `PARALLEL_STATEMENTS=AUTO` + `PARALLEL_SPLIT=AUTO` defaults; adapter without a parallel mechanism falls to SINGLE + INFO row.
+2. ~~How to communicate strategy choice to the user~~ → **resolved**: audit columns `SPLIT_STRATEGY` / `SPLIT_KEY` / `PARALLEL_REQUESTED` / `PARALLEL_EFFECTIVE`.
+3. Driver-side parallelism vs server-side parallelism: some sources (BigQuery's StorageRead API, Snowflake's Arrow result format) parallelize result-set fetch on the driver side. Does emitting multi-statement on top of that help, hurt, or duplicate work? Bench on a per-source basis before assuming. **AUTO ceiling of 12 mitigates worst case** — even if multi-stmt is redundant with driver parallelism, 12 concurrent JDBC sessions won't overwhelm the source.
+4. NDV validation cost: step 4 (DATE_BUCKET) detection benefits from sampling `count(distinct MONTH("dt"))` to confirm even split — but that's an extra round-trip per table. v1 should skip validation and trust the planner; ship NDV-validation as a follow-up speq if real-world skew bites.
+5. AUTO ceiling = 12 is a default. Should it be tunable via OPTIONS (`PARALLEL_AUTO_CEILING=24`)? Decide before v1 ships — recommend yes, but with documentation warning users about source-side connection saturation.

--- a/specs/_plans/parallel-import-source-optimization/PLAN.md
+++ b/specs/_plans/parallel-import-source-optimization/PLAN.md
@@ -1,240 +1,370 @@
-# Plan: Per-source parallel IMPORT optimization
+# Plan: Per-source parallel IMPORT optimization (dispatcher-only)
 
 ## Status
-Drafted 2026-05-17. Sibling speq landed as `parallel-row-threshold-dispatcher-gate/` (commit 928d30c on `feat/parallel-row-threshold`). Plan refactored 2026-05-17 (post-gate) to (1) introduce a cross-cutting split-strategy hierarchy that every adapter follows, (2) add **date-bucket** as a first-class strategy ahead of generic hash-modulo, (3) cap `PARALLEL_STATEMENTS=AUTO` at 12 to spare source systems.
 
-## Motivation
-Today only the Oracle adapter emits multi-statement parallel IMPORT. Its partition strategy is bin-pack on `all_tab_partitions` when partitions exist, else modulo split on `ora_hash(rowid)`. This works but:
-- It is Oracle-only. Other adapters (`PostgreSQL`, `MySQL`, `MariaDB`, `SQL Server`, `Snowflake`, `BigQuery`, `Redshift`, `Vertica`, `Teradata`, `DB2`, `Trino`, `Dremio`, `ClickHouse`, `Databricks`, `DuckDB`, `StarRocks`, `Vectorwise`, `SAP HANA`) emit single-statement IMPORTs regardless of table size — there is no parallel option to offer the user, even when the source could clearly support it.
-- Even within Oracle, `ora_hash(rowid)` ignores actual data layout. On a heavily-partitioned table where bin-pack works, fine; on a non-partitioned monster table on a NUMERIC primary key, `ora_hash(rowid)` may produce N statements that all hit the same physical blocks, giving worse parallelism than `MOD(pk, N)` would.
+Drafted 2026-05-17. **Not started.** Sibling `parallel-row-threshold-dispatcher-gate/` shipped 2026-05-17 (commit `928d30c` on `feat/parallel-row-threshold`).
 
-This speq covers both axes — improving Oracle's existing strategy AND bringing parallel emission to adapters that lack it, each using the source's native partitioning / hashing primitives.
+This plan supersedes earlier per-adapter Axis A / Axis B drafts. Final design lives entirely in `migrate_to_exasol.sql`. Adapter scripts (`oracle_to_exasol.sql`, `postgres_to_exasol.sql`, etc.) are **never touched** — they remain authoritative for source-specific schema discovery, type mapping, identifier quoting, DDL generation, and IMPORT shape. The master script wraps them with a cross-cutting parallel-expansion pass, exactly the way Speq 1's gate wraps them with a threshold-collapse pass.
 
-## Dependencies
-- **Hard dependency satisfied**: `parallel-row-threshold-dispatcher-gate/` shipped 2026-05-17 (commit 928d30c). Gate operates at dispatcher layer, so this speq's per-adapter parallel emission inherits the threshold collapse for free.
-- Soft dependency on the wrapper audit table from PR #42 (`harden-master-migration-entrypoint`) — the new partition strategy column (see Audit changes below) should reuse that table's schema.
+## Summary
 
-## Split-strategy hierarchy (cross-cutting)
+`MIGRATE_TO_EXASOL` adds a second post-processing transform — `transform_for_split` — that sits next to the existing `transform_for_gate`. For every single-statement `IMPORT INTO ...` row the adapter emits whose source row count is **at or above** `PARALLEL_ROW_THRESHOLD`, the dispatcher walks a configurable split-strategy hierarchy, fetches the necessary source-side metadata in a single `IMPORT FROM JDBC` round-trip, and rewrites the IMPORT into N parallel `STATEMENT '...'` clauses with WHERE selectors that the source engine can push down.
 
-Every adapter walks this ordered hierarchy per table; stops at first hit:
+Multi-statement IMPORTs (today: only Oracle adapter emits these) pass through unchanged — the source-specific adapter already made an informed split decision; the dispatcher does not second-guess it. The threshold gate continues to collapse multi-stmt IMPORTs back to single when row count is below the threshold.
+
+Result: every adapter that emits single-statement IMPORTs today (Postgres, MySQL/MariaDB, SQL Server/Azure SQL, Snowflake, BigQuery, Redshift, Vertica, DB2, HANA, Netezza, Teradata, Databricks, Dremio, ClickHouse, DuckDB, Starrocks, Trino, Vectorwise, plus any new adapter added later) gains parallel emission automatically through `MIGRATE_TO_EXASOL` — without a line of code touching their adapter scripts.
+
+## Design
+
+### Context
+
+- The dispatcher pattern (master script post-processes adapter output) is validated by Speq 1. The gate collapses multi → single below threshold. Speq 2 introduces the inverse axis: expand single → multi above threshold.
+- The SE team and existing customers call adapter scripts directly today (`EXECUTE SCRIPT database_migration.POSTGRES_TO_EXASOL(...)`). That entry point must keep working byte-for-byte. The master script is purely additive: an optional smarter front door.
+- The dispatcher already has a per-source dispatch table (`ROW_COUNT_SQL_BY_SOURCE`) introduced in Speq 1. Extending it to a richer `SOURCE_METADATA_BY_SOURCE` covers all needs of Speq 2 (PK col, date col, partition info, first numeric col) plus future speqs.
+- Goal: **zero net change to any adapter script.** Master script grows; adapters frozen.
+
+Goals
+- A single `transform_for_split` post-processor in `migrate_to_exasol.sql` that operates uniformly on every source.
+- A cross-cutting split-strategy hierarchy that picks the best parallel selector per table without per-source code branches.
+- `PARALLEL_STATEMENTS=AUTO` mode with a sensible default ceiling (12) to spare OLTP source connection pools.
+- Audit columns that record what the dispatcher chose so operators can post-hoc analyze migrations.
+- A test surface that fully mocks adapter output + source-metadata round-trip so 99% of coverage runs without a live source DB.
+
+Non-Goals
+- Not touching any `<source>_to_exasol.sql` adapter — they stay frozen at current shape forever.
+- Not adding new audit columns to the existing output schema beyond the four enumerated below.
+- Not introducing inter-table parallelism (one IMPORT at a time remains the contract).
+- Not adding a smart planner that picks `PARALLEL_STATEMENTS` per-table; AUTO is a coarse heuristic only.
+- Not modifying Speq 1's threshold-gate semantics. The gate runs first; the splitter runs only on rows the gate left as single-stmt.
+
+### Decision
+
+#### Architecture
+
+```
+caller
+  └─ EXECUTE SCRIPT database_migration.MIGRATE_TO_EXASOL('PG', conn, ..., OPTIONS)
+       │
+       ├─ master parses OPTIONS
+       ├─ master executes adapter: EXECUTE SCRIPT database_migration.POSTGRES_TO_EXASOL(...)
+       │     └─ adapter returns rows of generated SQL (DDL + IMPORTs, all single-statement)
+       │
+       ├─ master post-processes rows:
+       │     ├─ transform_for_metadata   ← NEW. ONE source-side round-trip per migration,
+       │     │                              fetches (schema, table, row_count, pk_col, pk_type,
+       │     │                              date_col, first_numeric_col, partition_info) for
+       │     │                              every IMPORT seen in adapter output.
+       │     │
+       │     ├─ transform_for_gate        ← Speq 1 (shipped). Collapses multi-stmt IMPORTs
+       │     │                              whose source rows are below PARALLEL_ROW_THRESHOLD.
+       │     │
+       │     ├─ transform_for_split       ← NEW. For each *single-stmt* IMPORT whose source
+       │     │                              rows are at-or-above threshold, walks the split
+       │     │                              hierarchy and rewrites into N STATEMENT clauses.
+       │     │
+       │     └─ transform_for_audit       ← NEW. Populates SPLIT_STRATEGY / SPLIT_KEY /
+       │                                    PARALLEL_REQUESTED / PARALLEL_EFFECTIVE audit cols.
+       │
+       └─ master returns rows (DEBUG=TRUE) OR executes (DEBUG=FALSE)
+```
+
+#### Order of transforms (critical)
+
+1. **`transform_for_metadata`** runs first. Caches per-(schema, table) metadata into a Lua lookup. Both downstream transforms reuse it (one round-trip, not two).
+2. **`transform_for_gate`** runs second (unchanged from Speq 1 except it now reads row counts from the cache, not from a fresh lookup).
+3. **`transform_for_split`** runs third. Only acts on rows still single-stmt after the gate.
+4. **`transform_for_audit`** runs last. Decorates each row's audit-column values based on what gate + split did.
+
+#### Per-table decision tree
+
+For each IMPORT row in adapter output:
+
+```
+                       ┌────────────────────────────┐
+                       │  STATEMENT clause count?    │
+                       └─────────────┬──────────────┘
+                          1          │          ≥2
+                ┌─────────────────┐  │  ┌──────────────────────────┐
+                │ single-stmt     │  │  │ multi-stmt (Oracle today) │
+                └────────┬────────┘  │  └────────────┬─────────────┘
+                         │           │               │
+                         ▼           │               ▼
+              ┌──────────────────┐   │   ┌────────────────────────┐
+              │ row_count ≥      │   │   │ row_count < threshold? │
+              │ threshold?        │   │   │  yes → transform_for_  │
+              │  no  → leave      │   │   │  gate collapses to 1   │
+              │  yes → expand     │   │   │  no  → pass through    │
+              └──────────────────┘   │   └────────────────────────┘
+                         │
+                         ▼
+              ┌──────────────────────┐
+              │ walk split hierarchy │
+              │ + rewrite into N     │
+              │ STATEMENT clauses    │
+              └──────────────────────┘
+```
+
+Multi-stmt IMPORTs are **never** expanded. Adapters that emit multi-stmt today (Oracle) own that decision; the dispatcher trusts them.
+
+#### Split-strategy hierarchy
+
+Walked per IMPORT, stops at first hit:
 
 | # | Strategy | Selector key | Why this position |
 |---|----------|--------------|-------------------|
-| 1 | `PARTITION` — per native partition / sub-partition | source partition metadata view | engine-validated even distribution; pushdown-perfect |
-| 2 | `PK_RANGE` / `PK_MOD` — numeric singleton PK | declared primary key, numeric | sequential IDs → uniform split; cheapest WHERE |
-| 3 | `UNIQUE_NUM` — numeric singleton unique index | unique constraint | semantically equivalent to PK |
-| 4 | `DATE_BUCKET` — date / timestamp column **(NEW)** | first DATE/TIMESTAMP col matching `*(_)?(date\|dt\|time\|day\|created\|loaded\|event\|posted)$`, else first DATE/TIMESTAMP by ordinal | pushdown-friendly on indexed cols; readable in audit; cheaper than hash; resilient where PK is composite / UUID |
-| 5 | `HASH_NUM` — first numeric not-null col, hash modulo | column metadata | catches integer surrogate cols not flagged as PK |
-| 6 | `ROWID` — engine-specific physical row identifier | dialect (Oracle `ROWID` / PG `ctid` / MSSQL `%%physloc%%` / DB2 `RID_BIT`) | always works on heap; zero metadata needed |
-| 7 | `SINGLE` — emit one STATEMENT + `INFO` row "no parallel split found" | — | safe fallback; matches today's behavior |
+| 1 | `PARTITION` — per native partition | source partition metadata view | Engine-validated even distribution; pushdown-perfect. **Skipped** in v1 — adapters that have partitioned tables typically already emit multi-stmt; revisit in a follow-up speq if any single-stmt adapter starts shipping with partition metadata. |
+| 2 | `PK_RANGE` — `WHERE "pk" BETWEEN lo AND hi` | declared numeric singleton primary key | Sequential IDs → uniform split; cheapest WHERE; engine uses index. |
+| 3 | `UNIQUE_NUM` — same shape as PK_RANGE | numeric singleton unique index | Semantic equivalent to PK when PK absent. |
+| 4 | `DATE_BUCKET` — `<dialect MONTH fn>("dt") IN (...)` | first DATE/TIMESTAMP col matching `*(_)?(date\|dt\|time\|day\|created\|loaded\|event\|posted)$` (case-insensitive), else first DATE/TIMESTAMP by ordinal | Pushdown-friendly; readable in audit; cheaper than hash; resilient where PK is composite / UUID. |
+| 5 | `HASH_NUM` — `MOD(<dialect hash fn>("col"), N) = k` | first numeric not-null column | Catches integer surrogate cols not flagged as PK. |
+| 6 | `ROWID` — engine-specific physical row identifier ranges | dialect (`ctid` for PG, `%%physloc%%` for MSSQL, `RID_BIT` for DB2) | Always works on heap; zero metadata needed. v1 ships PG + MSSQL + DB2 only. |
+| 7 | `SINGLE` — emit one STATEMENT + `INFO` row | — | Safe fallback. |
 
 `PARALLEL_SPLIT` OPTIONS knob (per migration; not per table):
+
 - `AUTO` (default) — walk hierarchy
-- `PARTITION` — force step 1; fail-soft to SINGLE if no partition
-- `PK` — force step 2/3; fail-soft to SINGLE
+- `PARTITION` — force step 1; fail-soft to SINGLE if no partition metadata
+- `PK` — force step 2 (or step 3 if no PK); fail-soft to SINGLE
 - `DATE` — force step 4; auto-pick column
 - `DATE:<col>` — force step 4 with named column
-- `DATE:<col>:<grain>` — force step 4 with `MONTH` / `QUARTER` / `YEAR_MONTH` granularity
+- `DATE:<col>:<grain>` — force step 4 with explicit grain (`MONTH` / `QUARTER` / `HALF` / `DAY` / `YEAR_MONTH`)
 - `HASH:<col>` — force step 5 with named column
 - `ROWID` — force step 6
 - `OFF` — force SINGLE (equivalent to `PARALLEL_STATEMENTS=1`)
 
-### Date-bucket details
+#### Date-bucket details
 
-Granularity auto-selected to evenly cover `PARALLEL_STATEMENTS=N`:
+Granularity auto-selected per `PARALLEL_STATEMENTS=N`:
 
-| N | Bucket size | Selector pattern |
-|---|-------------|------------------|
+| N | Bucket | Selector pattern |
+|---|--------|------------------|
 | 2 | half-year | `MONTH("dt") IN (1..6)` / `(7..12)` |
 | 3 | tri-mester | `MONTH("dt") IN (1..4)` / `(5..8)` / `(9..12)` |
 | 4 | quarter | `MONTH("dt") IN (1,2,3)` ... `(10,11,12)` |
 | 6 | bimonth | `MONTH("dt") IN (1,2)` ... `(11,12)` |
 | 12 | month | `MONTH("dt") = k` |
-| ≤ 31 | day-of-month | `DAY("dt") = k` (with bucket N-1 catching k≥N) |
+| ≤ 31 | day-of-month | `DAY("dt") = k` (bucket N-1 catches `k ≥ N`) |
 | > 31 | year × month | `(YEAR("dt")*12 + MONTH("dt")) MOD N = k` |
 
-Per-source dialect template (add to dispatch table alongside row-count SQL):
-
-| Source | MONTH fn | DAY fn |
-|---|---|---|
-| Oracle / Postgres / Redshift / BigQuery / Teradata | `EXTRACT(MONTH FROM "dt")` | `EXTRACT(DAY FROM "dt")` |
-| MySQL / MariaDB / Snowflake / Vertica / DB2 / HANA / Databricks | `MONTH("dt")` | `DAY("dt")` |
-| SQL Server / Azure SQL | `DATEPART(month, "dt")` | `DATEPART(day, "dt")` |
-
 NULL handling: append `OR "dt" IS NULL` to bucket 0.
-TZ handling: timestamp-with-zone normalize to UTC at adapter level; document; offer `PARALLEL_SPLIT=DATE:<col>:UTC` override.
+Time-zone: TIMESTAMP-WITH-ZONE values normalized to UTC at the dispatcher layer via the source-dialect cast. Document; override via `PARALLEL_SPLIT=DATE:<col>:UTC`.
 
-### `PARALLEL_STATEMENTS=AUTO` ceiling
+#### `PARALLEL_STATEMENTS=AUTO` resolution
 
 `PARALLEL_STATEMENTS` accepts an integer or the literal `AUTO`:
 
-- explicit int N → use N (no ceiling; user knows their source)
-- `AUTO` → heuristic: `min(12, max(1, ceil(row_count / 5_000_000)))` per table, using the row-count already fetched for the threshold gate
-- ceiling = **12** (rationale below)
-- `1` from heuristic → emits SINGLE (same as below-threshold collapse)
+- explicit int `N` → use N (no ceiling; user knows their source)
+- `AUTO` (default) → per-table heuristic: `min(12, max(1, ceil(row_count / 5_000_000)))`
+- ceiling = **12** (rationale: >12 concurrent JDBC sessions saturate OLTP source connection pools; 12 fits MONTH-grain bucketing cleanly; high-CPU sources can bypass via explicit `PARALLEL_STATEMENTS=24` or similar)
+- `1` from heuristic → behaves identically to threshold-collapsed single-stmt
 
-Rationale for ceiling = 12:
-- Source-side complaint surface: every IMPORT STATEMENT opens its own JDBC connection. >12 concurrent reads on a transactional OLTP source (Postgres / MySQL / MSSQL) saturates connection pools and triggers DBA paging.
-- Snowflake / BigQuery slot-based engines absorb more, but Exasol-side ingest concurrency past 12 yields diminishing returns vs network bandwidth.
-- 12 = clean fit with `MONTH`-grain date bucketing (one stmt per month).
-- Users with high-CPU Exasol + warehouse sources can bypass: `PARALLEL_STATEMENTS=32` (or whatever).
+`AUTO` ceiling is itself a `PARALLEL_AUTO_CEILING` OPTIONS knob (default 12) so high-end Exasol clusters with high-end source DBs can raise the auto-cap without losing the AUTO heuristic shape.
 
-Audit row should record both the requested value and the effective value (`PARALLEL_STATEMENTS=AUTO -> 8` etc.).
+#### Per-source metadata SQL (`SOURCE_METADATA_BY_SOURCE`)
 
-## Two axes of work
+One round-trip per migration. The dispatcher builds a single `IMPORT FROM JDBC AT <CONN> statement '<per-source SQL>'` that returns, for every IMPORT seen in adapter output, a row of:
 
-### Axis A: Align Oracle adapter with the cross-cutting hierarchy
-Current implementation (`oracle_to_exasol.sql:142-298`):
-1. Probe `all_tab_partitions` for partitioned tables. If partitions exist, run per-partition `count(*)` IMPORT, bin-pack partitions across `PARALLEL_STATEMENTS` bins.
-2. If no partitions, fall back to `ora_hash(rowid) MOD N = i` per statement.
+```
+src_schema   VARCHAR(...)
+src_table    VARCHAR(...)
+src_rows     DECIMAL(36,0)        -- already wired in Speq 1
+src_pk_col   VARCHAR(...)         -- single-col numeric PK if any
+src_pk_type  VARCHAR(...)
+src_date_col VARCHAR(...)         -- best DATE/TIMESTAMP col by heuristic
+src_num_col  VARCHAR(...)         -- first numeric not-null col (excluding PK)
+src_partitioned  BOOLEAN          -- has any partition metadata?
+```
 
-Maps to hierarchy steps **1** (PARTITION) → jumps straight to **6** (ROWID-equivalent via `ora_hash(rowid)`). Steps 2-5 missing. Improvements:
-- **Step 2 (PK_RANGE)**: numeric singleton PK detected via `all_constraints` / `all_cons_columns` → emit `WHERE pk BETWEEN lo AND hi` ranges. Min/max from `dba_tab_statistics`.
-- **Step 4 (DATE_BUCKET)**: detect first DATE col via `all_tab_columns`; emit `EXTRACT(MONTH FROM "dt")` buckets per `PARALLEL_STATEMENTS`.
-- **Step 5 (HASH_NUM)**: first numeric column hash modulo via `ORA_HASH("col", N-1)`.
-- **Step 6 (ROWID)**: keep existing `ora_hash(rowid) MOD N`, demoted to last resort.
-- **Subpartition awareness** (step 1 enhancement): today's bin-pack ignores `all_tab_subpartitions`. Treat sub-partitions as leaves when present.
-- **Histogram-informed bin-pack** (step 1 enhancement): use `dba_tab_col_statistics.histogram` to detect heavy skew on the partition key, fall back to row-count bin-pack only when histograms are flat.
+Per-source SQL strings live in a single dispatch table inside `migrate_to_exasol.sql`. Extending `ROW_COUNT_SQL_BY_SOURCE` into this richer schema is one of the v1 implementation tasks. Sources that cannot report all columns (e.g. Databricks: no row count) emit NULL for the missing fields; the hierarchy walker treats NULL as a step-skip signal.
 
-### Axis B: Port parallel emission to adapters that lack it
-Each adapter follows the **same cross-cutting hierarchy**. Per-source notes capture engine-specific selector syntax and metadata sources only.
+| Source | Metadata SQL sketch | Notes |
+|--------|---------------------|-------|
+| ORACLE | `dba_tables` + `dba_constraints` + `dba_tab_columns` joined on owner.table | Numeric PK detection via `dba_constraints.constraint_type='P'` + `dba_cons_columns`. |
+| POSTGRES | `pg_class` + `pg_namespace` + `pg_constraint` + `pg_attribute` joined | Date col via `pg_attribute.atttypid IN (date, timestamp, timestamptz)`. |
+| MYSQL / MARIADB | `information_schema.tables` + `key_column_usage` + `columns` | Identical SQL works for both. |
+| SQLSERVER / AZURE_SQL | `sys.tables` + `sys.indexes` + `sys.key_constraints` + `sys.columns` | Same SQL across both. |
+| SNOWFLAKE | `INFORMATION_SCHEMA.TABLES` + `TABLE_CONSTRAINTS` + `COLUMNS` | Constraints informational only. |
+| BIGQUERY | `INFORMATION_SCHEMA.TABLES` + `COLUMNS` (per-dataset) | Lifts BQ from Speq 1's `skip_with_info` to fully supported in v1 of this speq — splitter falls through gracefully when partition / PK info is absent. |
+| REDSHIFT | `svv_table_info` + `pg_constraint` + `pg_attribute` | Reuse Speq 1's row-count source. |
+| VERTICA | `tables` + `primary_keys` + `columns` | |
+| DB2 | `syscat.tables` + `tabconst` + `columns` | |
+| HANA | `sys.m_tables` + `sys.indexes` + `sys.table_columns` | |
+| NETEZZA / TERADATA | catalog views; mock-only test coverage | |
+| DATABRICKS | `information_schema.tables` + `columns`; row_count NULL | Row count permanently NULL → splitter never fires; gate already documents NULL → single. |
 
-Every adapter takes `PARALLEL_STATEMENTS` (int or `AUTO`) + inherits `PARALLEL_SPLIT` from OPTIONS via dispatcher passthrough. Adapter only chooses the selector syntax per step.
+If the metadata round-trip fails for any reason, `transform_for_metadata` populates the cache with all-NULL rows and logs an `INFO` row. Downstream transforms see NULL everywhere → behave conservatively (gate skipped, splitter skipped). Migration continues with single-statement IMPORTs.
 
-#### B1. PostgreSQL (`postgres_to_exasol.sql`)
-| Step | Selector | Metadata |
-|---|---|---|
-| 1 PARTITION | child table per `pg_inherits` row | `pg_partitioned_table` / `pg_inherits` |
-| 2 PK_RANGE | `WHERE "pk" BETWEEN lo AND hi` | `pg_constraint.contype='p'`, `pg_stats` for min/max |
-| 3 UNIQUE_NUM | same as PK | `pg_index.indisunique` |
-| 4 DATE_BUCKET | `extract(month from "dt")` | `pg_attribute` typename in `('date','timestamp','timestamptz')` |
-| 5 HASH_NUM | `MOD(abs(hashtext("col"::text)), N) = k` | `pg_attribute` numeric typename |
-| 6 ROWID | `ctid >= '(N,0)' and ctid < '(M,0)'` (heap only) | `pg_class.relpages` |
+#### Audit columns
 
-Row count for threshold gate: `pg_class.reltuples::bigint` (already wired in Speq 1).
+Four new columns appended to the existing output schema:
 
-#### B2. SQL Server / Azure SQL (`sqlserver_to_exasol.sql`, alias)
-| Step | Selector | Metadata |
-|---|---|---|
-| 1 PARTITION | `$PARTITION.<fn>("col") = p` per partition | `sys.partitions` × `sys.indexes` × `sys.partition_schemes` |
-| 2 PK_RANGE | `WHERE "pk" BETWEEN lo AND hi` | `sys.key_constraints type='PK'`, `sys.stats` |
-| 4 DATE_BUCKET | `DATEPART(month, "dt")` | `sys.columns.system_type_id IN (40,41,42,43,58,61)` |
-| 5 HASH_NUM | `ABS(CHECKSUM("col")) % N = k` | `sys.columns` numeric types |
-| 6 ROWID | `convert(varbinary(8), %%physloc%%)` ranges (heap + clustered) | `sys.partitions.partition_id` |
-
-Row count: `sys.dm_db_partition_stats.row_count` (already wired Speq 1).
-
-#### B3. Snowflake (`snowflake_to_exasol.sql`)
-| Step | Selector | Metadata |
-|---|---|---|
-| 1 PARTITION | n/a (micro-partitions opaque) | — |
-| 2 PK_RANGE | `WHERE "pk" BETWEEN lo AND hi` | `INFORMATION_SCHEMA.TABLE_CONSTRAINTS` (not enforced; informational only) |
-| 4 DATE_BUCKET | `MONTH("dt")` | `INFORMATION_SCHEMA.COLUMNS data_type LIKE 'TIMESTAMP%' OR 'DATE'` |
-| 5 HASH_NUM | `MOD(HASH("col"), N) = k` | `INFORMATION_SCHEMA.COLUMNS` numeric types |
-| 6 ROWID | n/a → fall to 5 or SINGLE | — |
-
-Row count: `INFORMATION_SCHEMA.TABLES.ROW_COUNT` (exact, free).
-
-#### B4. BigQuery (`bigquery_to_exasol.sql`)
-| Step | Selector | Metadata |
-|---|---|---|
-| 1 PARTITION | `_PARTITIONDATE` ranges (time-partitioned) or partition value bands (range-partitioned) | `INFORMATION_SCHEMA.PARTITIONS`, `INFORMATION_SCHEMA.TABLES.PARTITIONING_TYPE` |
-| 2 PK_RANGE | `WHERE "pk" BETWEEN lo AND hi` (informational PK only) | `INFORMATION_SCHEMA.TABLE_CONSTRAINTS` |
-| 4 DATE_BUCKET | `EXTRACT(MONTH FROM "dt")` | `INFORMATION_SCHEMA.COLUMNS data_type IN ('DATE','DATETIME','TIMESTAMP')` |
-| 5 HASH_NUM | `MOD(FARM_FINGERPRINT(CAST("col" AS STRING)), N) = k` | `INFORMATION_SCHEMA.COLUMNS` numeric types |
-| 6 ROWID | n/a → fall to 5 or SINGLE | — |
-
-Row count: revisit `INFORMATION_SCHEMA.PARTITIONS` aggregate so threshold-gate flips BIGQUERY from `skip_with_info` to `sql` mode at the same time.
-
-#### B5. MySQL / MariaDB (`mysql_to_exasol.sql`, `mariadb_to_exasol.sql`)
-| Step | Selector | Metadata |
-|---|---|---|
-| 1 PARTITION | `PARTITION (p)` selector in SELECT | `information_schema.PARTITIONS` |
-| 2 PK_RANGE | `WHERE "pk" BETWEEN lo AND hi` | `information_schema.STATISTICS index_name='PRIMARY'` |
-| 4 DATE_BUCKET | `MONTH("dt")` | `information_schema.COLUMNS data_type IN ('date','datetime','timestamp')` |
-| 5 HASH_NUM | `MOD(CRC32("col"), N) = k` | `information_schema.COLUMNS` numeric types |
-| 6 ROWID | not exposed without PK → fall to SINGLE + INFO | — |
-
-Row count: `information_schema.TABLES.TABLE_ROWS` (already wired Speq 1).
-
-#### B6. Redshift (`redshift_to_exasol.sql`)
-| Step | Selector | Metadata |
-|---|---|---|
-| 1 PARTITION | n/a (Redshift has no user-defined partitions) | — |
-| 2 PK_RANGE | `WHERE "pk" BETWEEN lo AND hi` (PK informational only) | `pg_constraint` (Redshift compat catalog) |
-| 4 DATE_BUCKET | `extract(month from "dt")` | `pg_attribute` date types |
-| 5 HASH_NUM | `MOD(STRTOL(MD5("col"::varchar),16), N) = k` | `pg_attribute` numeric types |
-| 6 ROWID | n/a → SINGLE | — |
-
-Distkey / sortkey detection (special-case for step 5 acceleration): `svv_table_info.distkey` / `sortkey1` — prefer hash on these cols when present.
-
-Row count: `svv_table_info.tbl_rows` (already wired Speq 1).
-
-#### B7-B12. Lower-priority sources
-Vertica, Teradata, DB2, Trino, Dremio, ClickHouse, Databricks, DuckDB, StarRocks, Vectorwise, SAP HANA — defer to follow-up speqs each. None are blockers for v1 of this speq.
-
-### Recommended sequencing
-1. Axis A first (Oracle improvements) — same adapter we already understand, lowest risk.
-2. Axis B1 (PostgreSQL) — highest-value port, cleanest catalog.
-3. Axis B2 (SQL Server) — second-highest usage in customer demos.
-4. Axis B3-B5 (Snowflake, BigQuery, MySQL/MariaDB) — round out the top tier.
-5. B6+ as separate per-source mini-speqs.
-
-Each adapter port is its own commit on its own branch. Do **not** bundle them — review surface explodes.
-
-## Audit-table additions (incremental over Speq 1's)
-Speq 1 did **not** add audit columns (deferred to a separate plan per its own §Non-goals). This speq introduces them in one shot:
-- `SPLIT_STRATEGY VARCHAR(32)` — one of `PARTITION` / `PK_RANGE` / `PK_MOD` / `UNIQUE_NUM` / `DATE_BUCKET` / `HASH_NUM` / `ROWID` / `SINGLE`
-- `SPLIT_KEY VARCHAR(256)` — the column / pseudo-column / partition name used (`"CREATED_AT"`, `ROWID`, `ctid`, `p_2024_q1`, etc.)
+- `SPLIT_STRATEGY VARCHAR(32)` — one of `PARTITION` / `PK_RANGE` / `UNIQUE_NUM` / `DATE_BUCKET` / `HASH_NUM` / `ROWID` / `SINGLE` / `MULTI_PASSTHROUGH`
+- `SPLIT_KEY VARCHAR(256)` — column / pseudo-column / partition name actually used (`CREATED_AT`, `ctid`, `RID_BIT`, `p_2024_q1`)
 - `PARALLEL_REQUESTED VARCHAR(16)` — raw `PARALLEL_STATEMENTS` OPTIONS value (`AUTO`, `8`, etc.)
-- `PARALLEL_EFFECTIVE DECIMAL(4,0)` — number of `STATEMENT` clauses actually emitted (post-AUTO heuristic, post-threshold-gate collapse)
+- `PARALLEL_EFFECTIVE DECIMAL(4,0)` — number of `STATEMENT` clauses actually emitted after AUTO heuristic + gate collapse
 
-Four new columns. Users query the audit table to compare strategies across migrations and identify where the planner picked sub-optimal strategies.
+These columns are populated by `transform_for_audit` for every row, not just IMPORTs. Non-IMPORT rows get `NULL` in all four. Adding them to the output schema is a breaking change to the audit-table column contract; document in CHANGELOG and bump the example schema in any reference docs.
 
-## Non-goals
-- **NOT** changing the threshold-gate mechanic from Speq 1. This speq layers on top.
-- **NOT** introducing concurrent execution of IMPORTs across different tables (inter-table parallelism). Each IMPORT remains its own serial statement; this speq only changes what's emitted *inside* one IMPORT.
-- **NOT** writing a partition planner that picks strategy automatically based on source-side stats. v1 picks strategy by adapter type + presence of native partitions. Smarter heuristics are a follow-up.
+### Patterns
 
-## Test plan
+| Pattern | Where | Why |
+|---------|-------|-----|
+| Per-source dispatch table | `SOURCE_METADATA_BY_SOURCE` extending `ROW_COUNT_SQL_BY_SOURCE` | One place to add new sources, mirrors Speq 1's pattern. |
+| Single source-side round-trip | `transform_for_metadata` builds one IMPORT FROM JDBC per migration with OR-predicate of all needed `(schema, table)` pairs | Adapters that never emit parallel pay only the metadata round-trip cost. |
+| Lazy hierarchy walk | `transform_for_split` walks per-table, stops at first hit | No wasted metadata fetches; falls through gracefully on NULLs. |
+| Soft-fail | Any error in metadata fetch or rewrite → emit INFO row and leave IMPORTs unchanged | The splitter is an optimization; a metadata outage must never break a migration. |
+| Dialect-template table | `<source>_DIALECT = { month_fn = "EXTRACT(MONTH FROM %s)", hash_fn = "MOD(MD5(%s::TEXT), %d) = %d", ... }` inside the master | One place to add new sources; templates are pure data. |
+| Adapter contract immutable | Adapters are invoked exactly as today via `EXECUTE SCRIPT database_migration.<SRC>_TO_EXASOL(...)`; their output rows are post-processed but their source code is not modified | Holy-grail invariant: master grows, adapters frozen. |
 
-### Tier 1 — Lua unit (per adapter)
-Extend `test/test_<source>_to_exasol.lua`. Fixtures per adapter (≥ 6 cases):
-1. **partitioned table** → expect step 1 (`SPLIT_STRATEGY=PARTITION`) with N stmts ≈ N partitions
-2. **non-partitioned + numeric PK** → expect step 2 (`PK_RANGE`)
-3. **no PK + date column named `created_at`** → expect step 4 (`DATE_BUCKET`), grain auto-selected per N
-4. **no PK + no date + numeric col** → expect step 5 (`HASH_NUM`)
-5. **no PK + no date + no numeric** → expect step 6 (ROWID if engine supports) or step 7 (SINGLE + INFO)
-6. **`PARALLEL_SPLIT=DATE:CREATED_AT:QUARTER` override** → expect step 4 with explicit grain ignoring auto-pick
-7. **`PARALLEL_STATEMENTS=AUTO` with row_count fixture** → expect heuristic = `min(12, ceil(rows/5M))`, capped at 12
-8. **`PARALLEL_STATEMENTS=24` (explicit > ceiling)** → expect 24 stmts (no cap on explicit)
+### Consequences
 
-Mock pquery returns metadata + row-count rows; assertions on emitted IMPORT SQL (statement count, WHERE clause shape, SPLIT_STRATEGY audit column).
+| Decision | Alternatives Considered | Rationale |
+|----------|------------------------|-----------|
+| Dispatcher-only implementation | (a) per-adapter parallel emission ports; (b) external orchestrator script | The dispatcher pattern is validated by Speq 1. Per-adapter ports duplicate logic 18 times; external orchestrator forks the entry-point story. |
+| Adapter scripts frozen forever | Edit each adapter to expose richer signatures | Holy-grail principle: master grows, adapters do not. Existing direct adapter callers (SE team, customers) keep working byte-for-byte. |
+| `PARALLEL_STATEMENTS=AUTO` default | Default to `1` (off); default to explicit `4` | AUTO is the friendliest default — gives users the win without configuration; explicit overrides remain trivial. |
+| AUTO ceiling = 12 (tunable via `PARALLEL_AUTO_CEILING`) | Hard 12; hard 8; per-source cap | 12 covers MONTH-grain neatly + spares OLTP connection pools; high-end users tune up. |
+| Source-side metadata via one round-trip | Per-table round-trips; static metadata cache | One round-trip is cheap; static cache stale-ness defeats correctness. |
+| `transform_for_split` runs only on single-stmt IMPORTs | Always run, second-guess adapter | Trust the adapter's parallel decision when it made one. Avoids double-rewrite confusion for Oracle. |
+| Skip step 1 (PARTITION) in v1 | Implement partition-aware splitting in v1 | Partitioned tables are typically already handled by adapters that emit multi-stmt; v1 ships steps 2-7 only, partition support is a follow-up speq. |
 
-### Tier 2 — live smoke (per adapter)
-One `_reference/smoke_parallel_<source>.py` per adapter (pattern of `_reference/smoke_parallel_row_threshold.py`):
-- container boot (Oracle, PG, MySQL, MSSQL, Vertica, DB2 community, HANA Express, Databricks via dbx-runtime image)
-- live-account-gated env var (Snowflake, BigQuery, Redshift) — skip if env not set
-- 4 fixtures: partitioned + numeric-PK + dated + plain
-- run preview with `PARALLEL_STATEMENTS=4;PARALLEL_ROW_THRESHOLD=100`; assert each fixture lands on expected strategy
-- run preview with `PARALLEL_STATEMENTS=AUTO`; assert ceiling respected
-- execute mode end-to-end for at least one fixture per adapter to validate IMPORT actually loads
+## Features
 
-### Tier 0 — dispatcher (cross-cutting)
-Add cases in `test/test_migrate_to_exasol.lua`:
-- `PARALLEL_STATEMENTS=AUTO` resolves to ceiling-bounded heuristic
-- `PARALLEL_SPLIT=date:CREATED_AT:MONTH` forwarded to adapter signature
-- audit row carries `SPLIT_STRATEGY` + `PARALLEL_REQUESTED` + `PARALLEL_EFFECTIVE` columns
+| Feature | Status | Spec |
+|---------|--------|------|
+| parallel-split-dispatcher | NEW | `migrate-to-exasol/parallel-split-dispatcher/spec.md` |
+| source-metadata-roundtrip | NEW | `migrate-to-exasol/source-metadata-roundtrip/spec.md` |
+| parallel-auto-ceiling | NEW | `migrate-to-exasol/parallel-auto-ceiling/spec.md` |
+| split-audit-columns | NEW | `migrate-to-exasol/split-audit-columns/spec.md` |
 
-## Estimated effort
-- Axis A (Oracle improvements): 1-2 implementer-days.
-- Axis B1 (PG): 1-2 implementer-days plus 1 day for live smoke + driver-quirk wrangling.
-- Each subsequent adapter: ~1 implementer-day if catalog is well-documented, more if quirks.
-- Total to ship top-5 sources (Oracle improvements + PG + SQLServer + Snowflake + BigQuery + MySQL): roughly 2 implementer-weeks.
+(Spec files to be authored as part of Phase 0; see Implementation Tasks below.)
 
-## Open questions
-1. ~~Should `PARALLEL_STATEMENTS` parameter be exposed on every adapter~~ → **resolved**: yes, via cross-cutting `PARALLEL_STATEMENTS=AUTO` + `PARALLEL_SPLIT=AUTO` defaults; adapter without a parallel mechanism falls to SINGLE + INFO row.
-2. ~~How to communicate strategy choice to the user~~ → **resolved**: audit columns `SPLIT_STRATEGY` / `SPLIT_KEY` / `PARALLEL_REQUESTED` / `PARALLEL_EFFECTIVE`.
-3. Driver-side parallelism vs server-side parallelism: some sources (BigQuery's StorageRead API, Snowflake's Arrow result format) parallelize result-set fetch on the driver side. Does emitting multi-statement on top of that help, hurt, or duplicate work? Bench on a per-source basis before assuming. **AUTO ceiling of 12 mitigates worst case** — even if multi-stmt is redundant with driver parallelism, 12 concurrent JDBC sessions won't overwhelm the source.
-4. NDV validation cost: step 4 (DATE_BUCKET) detection benefits from sampling `count(distinct MONTH("dt"))` to confirm even split — but that's an extra round-trip per table. v1 should skip validation and trust the planner; ship NDV-validation as a follow-up speq if real-world skew bites.
-5. AUTO ceiling = 12 is a default. Should it be tunable via OPTIONS (`PARALLEL_AUTO_CEILING=24`)? Decide before v1 ships — recommend yes, but with documentation warning users about source-side connection saturation.
+## Dependencies
+
+- **Hard, satisfied:** `parallel-row-threshold-dispatcher-gate/` shipped (commit `928d30c`). The metadata round-trip introduced here subsumes the gate's row-count lookup; the gate gets refactored to read from the shared cache.
+- **None on adapter scripts.** All work in `migrate_to_exasol.sql`.
+
+## Migration
+
+| Current (post-Speq-1 state on `feat/parallel-row-threshold`) | After this speq |
+|--------------------------------------------------------------|-----------------|
+| Dispatcher invokes adapter, runs `transform_for_gate` (one source-side round-trip for row counts), emits normalized rows. | Dispatcher invokes adapter, runs `transform_for_metadata` (one source-side round-trip for full metadata), then `transform_for_gate` (reads from cache), then `transform_for_split` (rewrites single-stmt IMPORTs above threshold), then `transform_for_audit` (populates new cols), then emits rows. |
+| `OUT_COLUMNS` schema has 7 columns. | `OUT_COLUMNS` schema has 11 columns: existing 7 plus `SPLIT_STRATEGY`, `SPLIT_KEY`, `PARALLEL_REQUESTED`, `PARALLEL_EFFECTIVE`. |
+| OPTIONS: `PARALLEL_ROW_THRESHOLD`, plus adapter-specific knobs (`DB2SCHEMA`, `CATALOG2SCHEMA`, `PROJECT_ID`, `PARALLEL_STATEMENTS=<int>`, etc.). | OPTIONS adds: `PARALLEL_STATEMENTS=AUTO|<int>`, `PARALLEL_SPLIT=AUTO|PK|DATE[...]|HASH[...]|ROWID|OFF`, `PARALLEL_AUTO_CEILING=<int>`. |
+| Adapter scripts authoritative for parallel emission decisions per source. | Unchanged — adapters still authoritative for their own multi-stmt emission. The splitter only acts on single-stmt IMPORTs that adapters emit. |
+| Tests: 50 cases in `test_migrate_to_exasol.lua`. | Tests: ~80 cases — adds ~30 covering metadata round-trip, splitter, AUTO resolution, audit cols, and edge cases per spec scenarios. |
+
+## Implementation Tasks
+
+### Phase 0 — spec deltas + dispatch tables
+
+1. Author 4 spec files under `specs/_plans/parallel-import-source-optimization/migrate-to-exasol/` matching the Features table.
+2. Run `speq plan validate parallel-import-source-optimization` — must validate clean.
+3. Extend `ROW_COUNT_SQL_BY_SOURCE` into `SOURCE_METADATA_BY_SOURCE` with the 8-column return schema. Update Speq 1's gate to read row counts from the new richer cache instead of issuing its own query.
+
+### Phase 1 — metadata round-trip
+
+4. Implement `transform_for_metadata(res, source_type, connection_name)` that:
+   - parses every IMPORT in `res`, extracts source `(schema, table)` pair from the inner SELECT's `from "X"."Y"` (logic already in Speq 1's gate; refactor into shared helper)
+   - builds one `IMPORT FROM JDBC at <CONN> statement '<per-source metadata SQL>'`
+   - returns a Lua-table cache keyed by `(schema, table)` with all 8 fields
+   - soft-fails into an all-NULL cache + `INFO` row on any error
+5. Refactor `transform_for_gate` to consume the cache.
+
+### Phase 2 — splitter + dialect tables
+
+6. Author a `DIALECT_BY_SOURCE` table inside the master. Each entry: `month_fn`, `quarter_fn`, `day_fn`, `year_fn`, `hash_fn`, `rowid_expr`, `rowid_supported (bool)`, `partition_selector_template` (for the deferred step 1).
+7. Implement `pick_split_strategy(import_meta, options)` returning a `(strategy, key, hint)` triple by walking the hierarchy in order, respecting OPTIONS overrides.
+8. Implement `build_where_for_split(strategy, key, dialect, n, k)` returning the WHERE-clause fragment for stmt `k` of `N`.
+9. Implement `rewrite_import_to_multi_stmt(sql, where_per_k)` that takes the original single-stmt IMPORT, extracts its inner SELECT, and emits N STATEMENT clauses by AND-ing each WHERE fragment onto the inner SELECT.
+10. Implement `transform_for_split(res, cache, options)` that walks IMPORTs, calls the above helpers per applicable row, replaces the row's SQL.
+
+### Phase 3 — AUTO resolution + audit + wiring
+
+11. Implement `resolve_parallel_statements(options, row_count, ceiling)` returning `(effective_n, requested_value_string)`.
+12. Implement `transform_for_audit(res, decisions)` that decorates every row with the four new audit columns. (`decisions` is a per-row record produced cooperatively by gate + splitter — store it in a side table keyed by row index.)
+13. Bump `OUT_COLUMNS` to 11 columns. Adjust all paths (`build_row`, `normalize_rows`, `execute_generated_sql`, `transform_for_gate`'s INFO-row constructor) to emit 11-tuple rows.
+14. Wire `transform_for_metadata` → `transform_for_gate` → `transform_for_split` → `transform_for_audit` into `execute_adapter` in that order.
+
+### Phase 4 — tests
+
+15. Lua unit tests (extend `test_migrate_to_exasol.lua`):
+    - 11 metadata-round-trip scenarios (per `source-metadata-roundtrip` spec)
+    - 11 splitter scenarios (per `parallel-split-dispatcher` spec) covering each hierarchy step
+    - 7 AUTO-ceiling scenarios (per `parallel-auto-ceiling` spec)
+    - 6 audit-column scenarios (per `split-audit-columns` spec)
+    - 4 cross-feature integration scenarios (gate + splitter + AUTO + audit together)
+    Target: ~40 new test cases bringing total to ~90.
+16. Python runtime test additions in `test/test_migrate_to_exasol_runtime.py`: verify the new column count, audit-column population, and AUTO knob propagation.
+
+### Phase 5 — live smoke per source
+
+17. Extend `_reference/smoke_parallel_row_threshold.py` into `_reference/smoke_parallel_split_<source>.py` (one per source). Pattern: spin up source container (or env-gated cloud account), seed `SMALL_T` + `BIG_T` + `DATED_T` + `KEYLESS_T` fixtures, run preview + execute with `PARALLEL_STATEMENTS=AUTO`, assert strategies + statement counts.
+18. Tier 0 priority order: Postgres, SQL Server, MySQL, Snowflake, BigQuery. Tier 1: Vertica, DB2, HANA, Databricks. Tier 2 (mock-only): Redshift, Netezza, Teradata, Trino, Dremio, ClickHouse, DuckDB, Starrocks.
+
+### Phase 6 — documentation
+
+19. Update `README.md` section on `MIGRATE_TO_EXASOL` OPTIONS to enumerate the new knobs.
+20. Add a section to the wrapper README that explains the master-script architecture: master is a cross-cutting transform engine on top of frozen adapter scripts; adapters can still be invoked directly.
+21. Update `specs/mission.md` to canonicalize the "master script as orchestrator + cross-cutting transform engine; adapter scripts frozen" architectural principle.
+
+## Dead Code Removal
+
+None. Adapters frozen; their existing parallel logic (Oracle's `ORA_HASH(rowid)` plus partition bin-pack) is left in place and respected by `transform_for_split`'s "skip if multi-stmt already" rule.
+
+## Verification
+
+### Scenario Coverage
+
+Each scenario below corresponds to a `* GIVEN ... * WHEN ... * THEN ...` block in one of the four spec files. See those spec files for full text; this table summarizes test locations.
+
+| Scenario | Test Type | Test Location | Test Name |
+|----------|-----------|---------------|-----------|
+| Metadata round-trip fetches per-table fields in one IMPORT FROM JDBC | Integration (Lua) | `test/test_migrate_to_exasol.lua` | `metadata round-trip fires once per migration` |
+| Metadata round-trip soft-fails on lookup error | Integration (Lua) | `test/test_migrate_to_exasol.lua` | `metadata round-trip soft-fails to all-NULL cache` |
+| Below-threshold single-stmt IMPORT passes through (gate semantics preserved) | Integration (Lua) | `test/test_migrate_to_exasol.lua` | `splitter respects threshold gate decision` |
+| At-or-above-threshold single-stmt IMPORT with numeric PK → step 2 (PK_RANGE) | Integration (Lua) | `test/test_migrate_to_exasol.lua` | `splitter picks PK_RANGE on numeric PK` |
+| At-or-above-threshold single-stmt IMPORT with no PK + date col → step 4 (DATE_BUCKET) | Integration (Lua) | `test/test_migrate_to_exasol.lua` | `splitter picks DATE_BUCKET on date col` |
+| At-or-above-threshold single-stmt IMPORT with no PK + no date + numeric col → step 5 (HASH_NUM) | Integration (Lua) | `test/test_migrate_to_exasol.lua` | `splitter picks HASH_NUM on first numeric col` |
+| At-or-above-threshold single-stmt IMPORT with no PK + no date + no numeric + ROWID-supporting source → step 6 | Integration (Lua) | `test/test_migrate_to_exasol.lua` | `splitter picks ROWID on PG ctid` |
+| No usable split column → step 7 (SINGLE + INFO row) | Integration (Lua) | `test/test_migrate_to_exasol.lua` | `splitter falls to SINGLE with INFO row` |
+| Multi-stmt IMPORT (Oracle today) passes through splitter unchanged | Integration (Lua) | `test/test_migrate_to_exasol.lua` | `splitter respects pre-existing multi-stmt IMPORT` |
+| `PARALLEL_SPLIT=OFF` disables splitter regardless of metadata | Integration (Lua) | `test/test_migrate_to_exasol.lua` | `PARALLEL_SPLIT=OFF disables splitter` |
+| `PARALLEL_SPLIT=DATE:CREATED_AT:QUARTER` forces step 4 with explicit grain | Integration (Lua) | `test/test_migrate_to_exasol.lua` | `PARALLEL_SPLIT=DATE override picks named col + grain` |
+| `PARALLEL_SPLIT=HASH:CUSTOMER_ID` forces step 5 with named col | Integration (Lua) | `test/test_migrate_to_exasol.lua` | `PARALLEL_SPLIT=HASH override picks named col` |
+| `PARALLEL_STATEMENTS=AUTO` resolves to ceiling-bounded heuristic | Integration (Lua) | `test/test_migrate_to_exasol.lua` | `AUTO resolves via row_count heuristic capped at 12` |
+| `PARALLEL_STATEMENTS=AUTO` with `PARALLEL_AUTO_CEILING=24` | Integration (Lua) | `test/test_migrate_to_exasol.lua` | `PARALLEL_AUTO_CEILING raises AUTO cap` |
+| `PARALLEL_STATEMENTS=24` (explicit) bypasses ceiling | Integration (Lua) | `test/test_migrate_to_exasol.lua` | `explicit PARALLEL_STATEMENTS bypasses ceiling` |
+| Audit columns populated for IMPORT, DDL, INFO, SUMMARY rows correctly | Integration (Lua) | `test/test_migrate_to_exasol.lua` | `audit columns populated per row kind` |
+| Multiple IMPORTs in one migration audited independently | Integration (Lua) | `test/test_migrate_to_exasol.lua` | `audit cols per-IMPORT independent in one migration` |
+| Multiple IMPORTs share one metadata round-trip | Integration (Lua) | `test/test_migrate_to_exasol.lua` | `metadata round-trip batches all IMPORTs` |
+| Date-bucket NULL handling: bucket 0 includes IS NULL | Integration (Lua) | `test/test_migrate_to_exasol.lua` | `date bucket bucket-0 includes IS NULL` |
+| Date-bucket grain auto-selected per N | Integration (Lua) | `test/test_migrate_to_exasol.lua` | `date bucket grain matches PARALLEL_STATEMENTS` |
+| Live smoke: Postgres parallel split end-to-end | Manual (Python) | `_reference/smoke_parallel_split_postgres.py` | n/a |
+| Live smoke: SQL Server parallel split end-to-end | Manual (Python) | `_reference/smoke_parallel_split_sqlserver.py` | n/a |
+| Live smoke: MySQL parallel split end-to-end | Manual (Python) | `_reference/smoke_parallel_split_mysql.py` | n/a |
+| Live smoke: Snowflake parallel split end-to-end (env-gated) | Manual (Python) | `_reference/smoke_parallel_split_snowflake.py` | n/a |
+| Live smoke: BigQuery parallel split end-to-end (env-gated) | Manual (Python) | `_reference/smoke_parallel_split_bigquery.py` | n/a |
+
+(Spec files in Phase 0 expand each of the first ~20 rows into full GIVEN/WHEN/THEN form.)
+
+### Manual Testing
+
+| Feature | Command | Expected Output |
+|---------|---------|-----------------|
+| parallel-split-dispatcher | `python3 _reference/smoke_parallel_split_postgres.py` | `SMALL_T` → 1 stmt (gate-collapsed); `BIG_T` (5M rows numeric PK) → 4 stmts (`SPLIT_STRATEGY=PK_RANGE`); `DATED_T` (5M rows, no PK, `created_at`) → 4 stmts (`SPLIT_STRATEGY=DATE_BUCKET`); final `PASS` |
+| source-metadata-roundtrip | Same harness — assert exactly one `IMPORT FROM JDBC` lookup query against the source per migration regardless of number of tables | Inline assert in smoke harness |
+| parallel-auto-ceiling | `python3 _reference/smoke_parallel_split_postgres.py --auto` | `PARALLEL_STATEMENTS=AUTO` on a seeded 50M-row table → `PARALLEL_EFFECTIVE=10` (50M/5M = 10, under cap 12); same on a seeded 100M-row table → `PARALLEL_EFFECTIVE=12` (capped) |
+| split-audit-columns | Inspect the audit output of any smoke run | Four new columns populated per row; non-IMPORT rows have NULL in all four |
+
+### Checklist
+
+| Step | Command | Expected |
+|------|---------|----------|
+| Build | `python3 -c "import ast, pathlib; [ast.parse(pathlib.Path(p).read_text(), filename=p) for p in ('test/create_script.py','test/export_res.py','test/mock_test.py')]"` | Exit 0 |
+| Test (Lua, all adapters) | `for t in test/test_*.lua; do lua "$t" || exit 1; done` | All passing |
+| Test (Python runtime) | `python3 test/test_migrate_to_exasol_runtime.py` | Exit 0 |
+| Spec validation | `speq plan validate parallel-import-source-optimization` | `Plan ... validation passed`, 0 warnings |
+| Live smoke (one Tier-0 source, e.g. Postgres) | `python3 _reference/smoke_parallel_split_postgres.py` | `PASS` |
+| Lint | `git diff --check` | No errors |
+| Adapter no-touch | `git diff origin/master..HEAD -- '*_to_exasol.sql' | grep -v migrate_to_exasol` | Empty output — no adapter touched by this speq's commits |

--- a/specs/_plans/parallel-import-source-optimization/migrate-to-exasol/parallel-auto-ceiling/spec.md
+++ b/specs/_plans/parallel-import-source-optimization/migrate-to-exasol/parallel-auto-ceiling/spec.md
@@ -1,0 +1,89 @@
+# Feature: parallel-auto-ceiling
+
+The dispatcher (`MIGRATE_TO_EXASOL`) resolves the `PARALLEL_STATEMENTS` OPTIONS value into a per-table effective integer `N` consumed by `transform_for_split`. `AUTO` (the default) maps to a row-count heuristic capped by a separate `PARALLEL_AUTO_CEILING` OPTIONS knob (default 12). Explicit integer values bypass the cap. Resolution is purely a function of OPTIONS + cache; no source-side query is involved at resolution time. The resolved value is recorded in `PARALLEL_EFFECTIVE` (see `split-audit-columns`).
+
+## Background
+
+* All scenarios use `MIGRATE_TO_EXASOL` as the entry point.
+* `PARALLEL_STATEMENTS` accepts `AUTO` (default), or a positive integer `N ≥ 1`. Negative / zero / non-numeric / non-AUTO values are invalid and MUST raise.
+* `PARALLEL_AUTO_CEILING` accepts a positive integer (default `12`). Negative / zero / non-numeric values are invalid and MUST raise.
+* `AUTO` heuristic per table: `effective_n = min(ceiling, max(1, ceil(src_rows / 5_000_000)))`.
+* `AUTO` with NULL or unknown `src_rows` → `effective_n = 1` (the splitter cannot decide threshold eligibility anyway; gate-collapse semantics from Speq 1 apply).
+* `AUTO` with `src_rows` below `PARALLEL_ROW_THRESHOLD` → `effective_n = 1` (threshold gate decides; this is reported in the audit row but the splitter does not fire).
+* Explicit integer N bypasses the ceiling. Users who set `PARALLEL_STATEMENTS=24` are stating they know their source connection pool.
+* Resolution is per-IMPORT, not per-migration: two IMPORTs in the same migration with different row counts can resolve to different `effective_n` under `AUTO`.
+
+## Scenarios
+
+### Scenario: AUTO with src_rows below threshold resolves to 1
+
+* *GIVEN* the metadata cache reports `src_rows = 500000` for an IMPORT
+* *AND* `OPTIONS` contains `PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=AUTO`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* `resolve_parallel_statements` SHALL return `effective_n = 1` for this IMPORT
+* *AND* the audit row SHALL carry `PARALLEL_REQUESTED = 'AUTO'`, `PARALLEL_EFFECTIVE = 1`
+
+### Scenario: AUTO with mid-range row count resolves via heuristic
+
+* *GIVEN* the metadata cache reports `src_rows = 20000000` for an IMPORT
+* *AND* `OPTIONS` contains `PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=AUTO`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* `resolve_parallel_statements` SHALL return `effective_n = 4` (ceil(20M / 5M) = 4, under the default cap 12)
+* *AND* the audit row SHALL carry `PARALLEL_REQUESTED = 'AUTO'`, `PARALLEL_EFFECTIVE = 4`
+
+### Scenario: AUTO with row count exceeding default ceiling caps at 12
+
+* *GIVEN* the metadata cache reports `src_rows = 100000000` for an IMPORT
+* *AND* `OPTIONS` contains `PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=AUTO`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* `resolve_parallel_statements` SHALL return `effective_n = 12` (ceil(100M / 5M) = 20, capped at default ceiling 12)
+* *AND* the audit row SHALL carry `PARALLEL_REQUESTED = 'AUTO'`, `PARALLEL_EFFECTIVE = 12`
+
+### Scenario: PARALLEL_AUTO_CEILING raises the AUTO cap
+
+* *GIVEN* the metadata cache reports `src_rows = 100000000` for an IMPORT
+* *AND* `OPTIONS` contains `PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=AUTO;PARALLEL_AUTO_CEILING=24`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* `resolve_parallel_statements` SHALL return `effective_n = 20` (ceil(100M / 5M) = 20, under the raised cap 24)
+* *AND* the audit row SHALL carry `PARALLEL_REQUESTED = 'AUTO'`, `PARALLEL_EFFECTIVE = 20`
+
+### Scenario: Explicit PARALLEL_STATEMENTS bypasses the ceiling
+
+* *GIVEN* the metadata cache reports `src_rows = 100000000` for an IMPORT
+* *AND* `OPTIONS` contains `PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=24`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* `resolve_parallel_statements` SHALL return `effective_n = 24` (ignoring both the default ceiling 12 and any `PARALLEL_AUTO_CEILING` value)
+* *AND* the audit row SHALL carry `PARALLEL_REQUESTED = '24'`, `PARALLEL_EFFECTIVE = 24`
+
+### Scenario: AUTO with NULL row count resolves to 1
+
+* *GIVEN* the metadata cache reports `src_rows = NULL` for an IMPORT (e.g. Databricks, or post-soft-fail all-NULL cache)
+* *AND* `OPTIONS` contains `PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=AUTO`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* `resolve_parallel_statements` SHALL return `effective_n = 1`
+* *AND* the audit row SHALL carry `PARALLEL_REQUESTED = 'AUTO'`, `PARALLEL_EFFECTIVE = 1`
+* *AND* the splitter MUST NOT fire on this IMPORT regardless of metadata for other columns
+
+### Scenario: Per-IMPORT resolution within one migration
+
+* *GIVEN* an adapter emits three IMPORTs in one run
+* *AND* the metadata cache reports `src_rows = 500000` for `SMOKE.SMALL_T`, `src_rows = 20000000` for `SMOKE.BIG_T`, and `src_rows = 100000000` for `SMOKE.HUGE_T`
+* *AND* `OPTIONS` contains `PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=AUTO`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* the dispatcher SHALL resolve `effective_n = 1` for `SMOKE.SMALL_T`, `effective_n = 4` for `SMOKE.BIG_T`, and `effective_n = 12` for `SMOKE.HUGE_T`
+* *AND* the audit rows SHALL carry the three different `PARALLEL_EFFECTIVE` values
+* *AND* `PARALLEL_REQUESTED` SHALL be `'AUTO'` for all three rows
+
+### Scenario: Invalid PARALLEL_STATEMENTS value raises
+
+* *GIVEN* `OPTIONS` contains `PARALLEL_STATEMENTS=0`, `PARALLEL_STATEMENTS=-3`, or `PARALLEL_STATEMENTS=banana`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* the dispatcher MUST raise an error referencing the offending OPTIONS key and value
+* *AND* the dispatcher MUST NOT execute any adapter SQL nor any source-side query
+
+### Scenario: Invalid PARALLEL_AUTO_CEILING value raises
+
+* *GIVEN* `OPTIONS` contains `PARALLEL_AUTO_CEILING=0`, `PARALLEL_AUTO_CEILING=-1`, or `PARALLEL_AUTO_CEILING=many`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* the dispatcher MUST raise an error referencing the offending OPTIONS key and value
+* *AND* the dispatcher MUST NOT execute any adapter SQL nor any source-side query

--- a/specs/_plans/parallel-import-source-optimization/migrate-to-exasol/parallel-split-dispatcher/spec.md
+++ b/specs/_plans/parallel-import-source-optimization/migrate-to-exasol/parallel-split-dispatcher/spec.md
@@ -1,0 +1,167 @@
+# Feature: parallel-split-dispatcher
+
+The dispatcher (`MIGRATE_TO_EXASOL`) inspects every single-statement IMPORT row that adapters emit, walks a configurable split-strategy hierarchy backed by the shared source-metadata cache, and rewrites those IMPORTs into N parallel `statement '...'` clauses with WHERE selectors that the source engine can push down. The splitter lives entirely inside `migrate_to_exasol.sql`; adapter scripts are not modified, so any current or future adapter that emits single-statement IMPORTs gains parallel emission automatically. Multi-statement IMPORTs (Oracle today) are always passed through — the adapter already made an informed parallel decision.
+
+## Background
+
+* All scenarios use `MIGRATE_TO_EXASOL` as the entry point.
+* The splitter runs *after* `transform_for_gate` (Speq 1) and *only* on rows still single-statement at that point.
+* `PARALLEL_STATEMENTS` is provided as an `OPTIONS` key. Accepts `AUTO` (default) or a positive integer. `AUTO` resolution is specified in `parallel-auto-ceiling`.
+* `PARALLEL_SPLIT` is provided as an `OPTIONS` key. Accepts `AUTO` (default), `PARTITION`, `PK`, `DATE`, `DATE:<col>`, `DATE:<col>:<grain>`, `HASH:<col>`, `ROWID`, `OFF`. Forces a single step of the hierarchy (or disables it via `OFF`).
+* `PARALLEL_ROW_THRESHOLD` from Speq 1 still gates whether the splitter fires at all (only rows whose source row count is at-or-above threshold are eligible).
+* Per-table metadata (`src_rows`, `src_pk_col`, `src_pk_type`, `src_date_col`, `src_num_col`, `src_partitioned`) is read from the shared metadata cache populated by `transform_for_metadata`. The splitter never issues its own source-side query.
+* Split-strategy hierarchy (walked top-to-bottom, stops at first hit):
+
+  1. `PARTITION` — per native source partition. **Skipped in v1.**
+  2. `PK_RANGE` — `WHERE "pk" BETWEEN lo AND hi` on a declared numeric singleton primary key.
+  3. `UNIQUE_NUM` — same WHERE shape on a numeric singleton unique index when no PK.
+  4. `DATE_BUCKET` — dialect-specific MONTH/QUARTER/DAY function `IN (...)` over the best DATE/TIMESTAMP column.
+  5. `HASH_NUM` — `MOD(<dialect hash fn>("col"), N) = k` over the first numeric not-null column.
+  6. `ROWID` — dialect-specific physical row identifier ranges (`ctid` for PG, `%%physloc%%` for MSSQL, `RID_BIT` for DB2). v1 supports PG + MSSQL + DB2 only.
+  7. `SINGLE` — emit one STATEMENT + a `STEP_KIND = INFO` row noting no split column was found.
+* Date-bucket grain is auto-selected per `N`: 2 = half-year, 3 = tri-mester, 4 = quarter, 6 = bimonth, 12 = month, ≤31 = day-of-month, >31 = `(YEAR*12 + MONTH) MOD N`.
+* NULL handling for `DATE_BUCKET`: bucket `0` appends `OR "dt" IS NULL`.
+* When `transform_for_split` cannot rewrite an IMPORT (no usable strategy, dialect missing, helper raises), it MUST leave the row's SQL unchanged, log a `STEP_KIND = INFO` row, and continue with the rest of the migration. The splitter is an optimization; any failure inside it must NOT break a migration.
+
+## Scenarios
+
+### Scenario: Below-threshold single-statement IMPORT passes through
+
+* *GIVEN* an adapter emits a single-statement IMPORT for source `SMOKE.SMALL_T`
+* *AND* the metadata cache reports `src_rows = 500000` for `SMOKE.SMALL_T`
+* *AND* `OPTIONS` contains `PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=AUTO`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* the dispatcher SHALL pass the IMPORT through unchanged
+* *AND* the splitter MUST NOT walk the hierarchy for this row
+* *AND* the audit row for this IMPORT SHALL carry `SPLIT_STRATEGY = 'SINGLE'`, `PARALLEL_EFFECTIVE = 1`
+
+### Scenario: At-or-above-threshold IMPORT with numeric PK picks PK_RANGE
+
+* *GIVEN* an adapter emits a single-statement IMPORT for source `SMOKE.ORDERS`
+* *AND* the metadata cache reports `src_rows = 20000000`, `src_pk_col = 'ORDER_ID'`, `src_pk_type = 'NUMBER'`
+* *AND* `OPTIONS` contains `PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=4;PARALLEL_SPLIT=AUTO`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* the dispatcher SHALL rewrite the IMPORT into exactly 4 `statement '...'` clauses
+* *AND* each clause's inner SELECT MUST AND its source WHERE with a `"ORDER_ID" BETWEEN <lo> AND <hi>` predicate covering disjoint ranges of the PK domain
+* *AND* the audit row for this IMPORT SHALL carry `SPLIT_STRATEGY = 'PK_RANGE'`, `SPLIT_KEY = 'ORDER_ID'`, `PARALLEL_EFFECTIVE = 4`
+
+### Scenario: At-or-above-threshold IMPORT with no PK + numeric unique picks UNIQUE_NUM
+
+* *GIVEN* an adapter emits a single-statement IMPORT for source `SMOKE.LEGACY_ORDERS`
+* *AND* the metadata cache reports `src_rows = 20000000`, `src_pk_col = NULL`, and (per source-metadata-roundtrip) records a numeric singleton unique index column `LEGACY_ID`
+* *AND* `OPTIONS` contains `PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=4;PARALLEL_SPLIT=AUTO`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* the dispatcher SHALL rewrite the IMPORT into 4 `statement '...'` clauses using `"LEGACY_ID" BETWEEN <lo> AND <hi>` selectors
+* *AND* the audit row for this IMPORT SHALL carry `SPLIT_STRATEGY = 'UNIQUE_NUM'`, `SPLIT_KEY = 'LEGACY_ID'`
+
+### Scenario: At-or-above-threshold IMPORT with date col picks DATE_BUCKET
+
+* *GIVEN* an adapter emits a single-statement IMPORT for source `SMOKE.EVENTS`
+* *AND* the metadata cache reports `src_rows = 20000000`, `src_pk_col = NULL`, `src_date_col = 'EVENT_DT'`
+* *AND* `OPTIONS` contains `PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=4;PARALLEL_SPLIT=AUTO`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* the dispatcher SHALL rewrite the IMPORT into 4 `statement '...'` clauses
+* *AND* each clause MUST AND its inner SELECT with a `MONTH("EVENT_DT") IN (...)` predicate spanning a disjoint quarter (`(1,2,3)` / `(4,5,6)` / `(7,8,9)` / `(10,11,12)`)
+* *AND* the `(1,2,3)` clause SHALL also include `OR "EVENT_DT" IS NULL`
+* *AND* the audit row for this IMPORT SHALL carry `SPLIT_STRATEGY = 'DATE_BUCKET'`, `SPLIT_KEY = 'EVENT_DT'`
+
+### Scenario: At-or-above-threshold IMPORT with first numeric col picks HASH_NUM
+
+* *GIVEN* an adapter emits a single-statement IMPORT for source `SMOKE.SESSIONS`
+* *AND* the metadata cache reports `src_rows = 20000000`, `src_pk_col = NULL`, `src_date_col = NULL`, `src_num_col = 'CUSTOMER_ID'`
+* *AND* `OPTIONS` contains `PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=4;PARALLEL_SPLIT=AUTO`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* the dispatcher SHALL rewrite the IMPORT into 4 `statement '...'` clauses each carrying a `MOD(<dialect hash fn>("CUSTOMER_ID"), 4) = k` predicate for `k` in `{0,1,2,3}`
+* *AND* the audit row for this IMPORT SHALL carry `SPLIT_STRATEGY = 'HASH_NUM'`, `SPLIT_KEY = 'CUSTOMER_ID'`
+
+### Scenario: ROWID-supporting source with no other split column picks ROWID
+
+* *GIVEN* the source type is `POSTGRES`
+* *AND* an adapter emits a single-statement IMPORT for source `SMOKE.HEAP_T`
+* *AND* the metadata cache reports `src_rows = 20000000` and all of `src_pk_col`, `src_date_col`, `src_num_col` are NULL
+* *AND* `OPTIONS` contains `PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=4;PARALLEL_SPLIT=AUTO`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* the dispatcher SHALL rewrite the IMPORT into 4 `statement '...'` clauses each carrying a `ctid`-range predicate
+* *AND* the audit row for this IMPORT SHALL carry `SPLIT_STRATEGY = 'ROWID'`, `SPLIT_KEY = 'ctid'`
+
+### Scenario: No usable split column falls through to SINGLE with INFO row
+
+* *GIVEN* the source type is `SNOWFLAKE` (no ROWID support in v1)
+* *AND* an adapter emits a single-statement IMPORT for source `SMOKE.MYSTERY_T`
+* *AND* the metadata cache reports `src_rows = 20000000` and all of `src_pk_col`, `src_date_col`, `src_num_col` are NULL
+* *AND* `OPTIONS` contains `PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=4;PARALLEL_SPLIT=AUTO`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* the dispatcher SHALL pass the IMPORT through unchanged
+* *AND* the dispatcher SHALL emit one extra row with `STEP_KIND = 'INFO'` describing that no split column was available for `SMOKE.MYSTERY_T`
+* *AND* the audit row for the IMPORT SHALL carry `SPLIT_STRATEGY = 'SINGLE'`, `SPLIT_KEY = NULL`, `PARALLEL_EFFECTIVE = 1`
+
+### Scenario: Multi-statement IMPORT (Oracle today) passes through splitter unchanged
+
+* *GIVEN* the source type is `ORACLE`
+* *AND* an adapter emits a 4-way multi-statement IMPORT for source `SMOKE.ORACLE_BIG_T` (the Oracle adapter chose its own parallel split)
+* *AND* the metadata cache reports `src_rows = 20000000` for `SMOKE.ORACLE_BIG_T`
+* *AND* `OPTIONS` contains `PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=AUTO;PARALLEL_SPLIT=AUTO`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* the splitter MUST NOT modify the IMPORT
+* *AND* all four original `statement '...'` clauses MUST be preserved in order
+* *AND* the audit row for this IMPORT SHALL carry `SPLIT_STRATEGY = 'MULTI_PASSTHROUGH'`, `PARALLEL_EFFECTIVE = 4`
+
+### Scenario: PARALLEL_SPLIT=OFF disables the splitter regardless of metadata
+
+* *GIVEN* an adapter emits a single-statement IMPORT for `SMOKE.ORDERS` whose metadata has a numeric PK and would otherwise pick `PK_RANGE`
+* *AND* `OPTIONS` contains `PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=AUTO;PARALLEL_SPLIT=OFF`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* the splitter MUST NOT modify the IMPORT
+* *AND* the audit row SHALL carry `SPLIT_STRATEGY = 'SINGLE'`, `PARALLEL_EFFECTIVE = 1`
+
+### Scenario: PARALLEL_SPLIT=DATE:CREATED_AT:QUARTER forces named col + grain
+
+* *GIVEN* an adapter emits a single-statement IMPORT for `SMOKE.EVENTS`
+* *AND* the metadata cache reports `src_rows = 20000000`, `src_pk_col = 'EVENT_ID'`, `src_date_col = 'EVENT_DT'`
+* *AND* `OPTIONS` contains `PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=4;PARALLEL_SPLIT=DATE:CREATED_AT:QUARTER`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* the dispatcher SHALL rewrite the IMPORT into 4 `statement '...'` clauses keyed on `MONTH("CREATED_AT") IN (...)` quarters
+* *AND* the splitter MUST NOT consult `src_pk_col` or `src_date_col` from the cache
+* *AND* the audit row SHALL carry `SPLIT_STRATEGY = 'DATE_BUCKET'`, `SPLIT_KEY = 'CREATED_AT'`
+
+### Scenario: PARALLEL_SPLIT=HASH:CUSTOMER_ID forces named col
+
+* *GIVEN* an adapter emits a single-statement IMPORT for `SMOKE.SESSIONS`
+* *AND* the metadata cache reports `src_rows = 20000000`, `src_pk_col = 'SESSION_ID'`
+* *AND* `OPTIONS` contains `PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=4;PARALLEL_SPLIT=HASH:CUSTOMER_ID`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* the dispatcher SHALL rewrite the IMPORT into 4 `statement '...'` clauses each carrying `MOD(<dialect hash fn>("CUSTOMER_ID"), 4) = k`
+* *AND* the splitter MUST NOT consult `src_pk_col` from the cache
+* *AND* the audit row SHALL carry `SPLIT_STRATEGY = 'HASH_NUM'`, `SPLIT_KEY = 'CUSTOMER_ID'`
+
+### Scenario: Forced override fails soft when prerequisite missing
+
+* *GIVEN* an adapter emits a single-statement IMPORT for `SMOKE.HEAP_T`
+* *AND* the source type is `SNOWFLAKE` (no ROWID support in v1)
+* *AND* `OPTIONS` contains `PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=4;PARALLEL_SPLIT=ROWID`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* the splitter MUST NOT modify the IMPORT
+* *AND* the dispatcher SHALL emit one `STEP_KIND = 'INFO'` row describing that `PARALLEL_SPLIT=ROWID` is unsupported for `SNOWFLAKE` and that the IMPORT fell back to `SINGLE`
+* *AND* the audit row SHALL carry `SPLIT_STRATEGY = 'SINGLE'`, `PARALLEL_EFFECTIVE = 1`
+
+### Scenario: Splitter rewrite preserves IMPORT target + column list
+
+* *GIVEN* an adapter emits `IMPORT INTO "DST"."ORDERS" ("A","B","C") from JDBC at SRC statement 'select "A","B","C" from "PUBLIC"."orders"'` under `OPTIONS = 'TARGET_SCHEMA=DST;PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=2;PARALLEL_SPLIT=AUTO'`
+* *AND* the metadata cache reports `src_rows = 5000000`, `src_pk_col = 'A'`, `src_pk_type = 'NUMBER'`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* the rewritten IMPORT MUST retain `IMPORT INTO "DST"."ORDERS" ("A","B","C")` byte-for-byte
+* *AND* each emitted `statement '...'` MUST quote the same column list (`"A","B","C"`) in the same order
+* *AND* each emitted inner SELECT MUST reference `from "PUBLIC"."orders"` (the source identifier, not the target)
+* *AND* the audit row SHALL carry `SPLIT_STRATEGY = 'PK_RANGE'`, `SPLIT_KEY = 'A'`, `PARALLEL_EFFECTIVE = 2`
+
+### Scenario: Rewrite failure leaves IMPORT unchanged and continues migration
+
+* *GIVEN* an adapter emits a single-statement IMPORT for `SMOKE.WEIRD_T`
+* *AND* the metadata cache reports `src_rows = 20000000`, `src_pk_col = 'ID'`, `src_pk_type = 'NUMBER'`
+* *AND* the inner SELECT contains a shape `pick_split_strategy` cannot parse (e.g. nested subquery the helper does not recognize)
+* *AND* `OPTIONS` contains `PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=4;PARALLEL_SPLIT=AUTO`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* the dispatcher MUST NOT raise the migration as failed solely because of the rewrite failure
+* *AND* the IMPORT row SHALL be passed through unchanged
+* *AND* the dispatcher SHALL emit one `STEP_KIND = 'INFO'` row describing the soft-fail and the table involved
+* *AND* the audit row for this IMPORT SHALL carry `SPLIT_STRATEGY = 'SINGLE'`, `PARALLEL_EFFECTIVE = 1`

--- a/specs/_plans/parallel-import-source-optimization/migrate-to-exasol/source-metadata-roundtrip/spec.md
+++ b/specs/_plans/parallel-import-source-optimization/migrate-to-exasol/source-metadata-roundtrip/spec.md
@@ -1,0 +1,123 @@
+# Feature: source-metadata-roundtrip
+
+The dispatcher (`MIGRATE_TO_EXASOL`) batches every per-table fact it needs from the source database into a single `IMPORT FROM JDBC` query per migration. The fetched cache is keyed by source `(schema, table)` and consumed by `transform_for_gate` (Speq 1) and `transform_for_split` (this speq). The round-trip is dispatched off a per-source SQL table (`SOURCE_METADATA_BY_SOURCE`) that supersedes Speq 1's narrower `ROW_COUNT_SQL_BY_SOURCE`. The round-trip is soft-failing: on any error the cache is populated with all-NULL rows, an `INFO` row is emitted, and the migration continues with single-statement IMPORTs.
+
+## Background
+
+* All scenarios use `MIGRATE_TO_EXASOL` as the entry point.
+* The cache schema is one row per `(src_schema, src_table)` pair containing:
+  * `src_schema   VARCHAR`
+  * `src_table    VARCHAR`
+  * `src_rows     DECIMAL(36,0)`
+  * `src_pk_col   VARCHAR`
+  * `src_pk_type  VARCHAR`
+  * `src_date_col VARCHAR`
+  * `src_num_col  VARCHAR`
+  * `src_partitioned BOOLEAN`
+* `SOURCE_METADATA_BY_SOURCE` is a Lua dispatch table inside `migrate_to_exasol.sql` keyed by `SOURCE_TYPE` (e.g. `POSTGRES`, `MYSQL`, `SQLSERVER`, `AZURE_SQL`, `SNOWFLAKE`, `BIGQUERY`, `REDSHIFT`, `VERTICA`, `DB2`, `HANA`, `NETEZZA`, `TERADATA`, `DATABRICKS`, `ORACLE`).
+* Each entry is a SQL template returning the 8-column schema above. The dispatcher binds the requested `(schema, table)` pairs as an `OR`-of-equality predicate inside one `IMPORT FROM JDBC at <CONN> statement '<SQL>'`.
+* Sources that cannot supply a given column (e.g. Databricks cannot supply `src_rows`) MUST return `NULL` for that column; the dispatcher MUST NOT treat the row as a fetch failure.
+* `transform_for_metadata` runs before `transform_for_gate` and `transform_for_split`. The gate (Speq 1) reads `src_rows` from this cache instead of issuing its own row-count query; the splitter reads the remaining columns.
+* `PARALLEL_ROW_THRESHOLD=0` (Speq 1) disables the gate; it does NOT disable the metadata round-trip — the splitter still needs the cache. `PARALLEL_STATEMENTS=1` AND `PARALLEL_SPLIT=OFF` together disable both consumers; in that case `transform_for_metadata` MUST be skipped to spare the source-side query.
+* Source-side `(schema, table)` references are parsed out of each IMPORT's inner SELECT (`from "<schema>"."<table>"`), reusing the helper introduced in Speq 1. Target-side identifiers (`TARGET_SCHEMA`, `IDENTIFIER_CASE_INSENSITIVE`, `CATALOG2SCHEMA`) MUST NOT influence the cache key.
+
+## Scenarios
+
+### Scenario: One round-trip per migration regardless of table count
+
+* *GIVEN* an adapter emits five IMPORTs covering five distinct source tables in one run
+* *AND* `OPTIONS` contains `PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=AUTO`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* the dispatcher SHALL issue exactly one `IMPORT FROM JDBC at <CONN> statement '...'` against the source for metadata gathering
+* *AND* the single query's WHERE clause MUST enumerate all five `(schema, table)` pairs (e.g. via `OR`-of-equality on `(schema_name, table_name)`)
+
+### Scenario: Cache is consumed by both gate and splitter
+
+* *GIVEN* an adapter emits one multi-statement IMPORT for `SMOKE.SMALL_T` and one single-statement IMPORT for `SMOKE.BIG_T`
+* *AND* the metadata round-trip returns `src_rows = 500` for `SMOKE.SMALL_T` and `src_rows = 20000000, src_pk_col = 'ID', src_pk_type = 'NUMBER'` for `SMOKE.BIG_T`
+* *AND* `OPTIONS` contains `PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=4;PARALLEL_SPLIT=AUTO`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* `transform_for_gate` SHALL collapse `SMOKE.SMALL_T`'s IMPORT to a single statement using `src_rows = 500` from the cache
+* *AND* `transform_for_split` SHALL rewrite `SMOKE.BIG_T`'s IMPORT into 4 `statement '...'` clauses using `src_pk_col = 'ID'` from the same cache
+* *AND* the dispatcher MUST NOT issue a second source-side metadata query
+
+### Scenario: Per-source SQL dispatched from SOURCE_METADATA_BY_SOURCE
+
+* *GIVEN* the source type is `POSTGRES`
+* *AND* an adapter emits at least one IMPORT for `PUBLIC.ORDERS`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* the metadata round-trip SHALL use the `POSTGRES` entry of `SOURCE_METADATA_BY_SOURCE`
+* *AND* the per-source SQL SHALL join `pg_class`, `pg_namespace`, `pg_constraint`, and `pg_attribute` to populate all eight cache columns
+* *AND* swapping `SOURCE_TYPE` to `MYSQL` for the same fixture SHALL instead dispatch the `MYSQL` entry (joining `information_schema.tables`, `key_column_usage`, `columns`) without any other code path change
+
+### Scenario: Sources without per-column support return NULL not error
+
+* *GIVEN* the source type is `DATABRICKS`
+* *AND* an adapter emits one IMPORT for `MAIN.DEFAULT.EVENTS`
+* *AND* the `DATABRICKS` entry of `SOURCE_METADATA_BY_SOURCE` does not expose a per-table row count
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* the metadata round-trip MUST complete without raising
+* *AND* the cache entry for `MAIN.DEFAULT.EVENTS` SHALL carry `src_rows = NULL`
+* *AND* downstream `transform_for_gate` MUST treat NULL `src_rows` per Speq 1 semantics
+* *AND* downstream `transform_for_split` MUST skip the splitter for the row (NULL row count → cannot decide threshold eligibility)
+
+### Scenario: Round-trip failure populates all-NULL cache and emits INFO row
+
+* *GIVEN* an adapter emits at least one IMPORT
+* *AND* the metadata round-trip fails (network error, missing privilege, or unsupported metadata view)
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* the dispatcher MUST NOT raise the migration as failed solely because of the round-trip failure
+* *AND* the dispatcher SHALL populate the cache with all-NULL rows for every requested `(schema, table)` pair
+* *AND* the dispatcher SHALL emit one `STEP_KIND = 'INFO'` row describing that source-side metadata fetch was skipped
+* *AND* `transform_for_gate` SHALL pass every IMPORT through unchanged
+* *AND* `transform_for_split` SHALL pass every IMPORT through unchanged
+
+### Scenario: Source type with no SOURCE_METADATA_BY_SOURCE entry skips fetch
+
+* *GIVEN* `SOURCE_TYPE` resolves to an adapter for which the dispatcher does not ship a metadata SQL (e.g. `EXASOL`, `VECTORWISE`, `S3`)
+* *AND* `OPTIONS` contains `PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=AUTO`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* the dispatcher MUST NOT issue any source-side metadata query
+* *AND* the dispatcher SHALL emit one `STEP_KIND = 'INFO'` row noting that the metadata cache is not configured for this source type
+* *AND* every emitted IMPORT SHALL pass through `transform_for_gate` and `transform_for_split` unchanged
+
+### Scenario: Adapter emits no IMPORTs at all skips the round-trip
+
+* *GIVEN* an adapter returns only DDL rows (no `IMPORT INTO ...` statements)
+* *AND* `OPTIONS` contains a non-zero `PARALLEL_ROW_THRESHOLD`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* the dispatcher MUST NOT issue any source-side metadata query
+* *AND* the dispatcher SHALL pass adapter output through to `normalize_rows` / `execute_generated_sql` unchanged
+
+### Scenario: Cache key uses source identifier not target rename
+
+* *GIVEN* an adapter emits `IMPORT INTO "DST"."ORDERS" (...) from JDBC at SRC statement 'select ... from "PUBLIC"."orders"'` under `OPTIONS = 'TARGET_SCHEMA=DST;PARALLEL_ROW_THRESHOLD=1000000'`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* the metadata round-trip's WHERE clause SHALL key on `(PUBLIC, orders)` (the source identifier parsed from the inner SELECT's `from "..."."..."` clause)
+* *AND* the target-side identifier `(DST, ORDERS)` MUST NOT appear in the metadata round-trip's WHERE clause
+
+### Scenario: Duplicate source tables in adapter output produce one cache row
+
+* *GIVEN* an adapter emits two IMPORTs both targeting source `PUBLIC.orders` (e.g. one full-table, one filtered subset)
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* the metadata round-trip's WHERE clause MUST contain `(PUBLIC, orders)` exactly once
+* *AND* the cache MUST yield a single row keyed on `(PUBLIC, orders)`
+* *AND* both downstream IMPORTs MUST resolve to the same cache entry
+
+### Scenario: Per-source SQL is a pure dispatch lookup, not a code branch
+
+* *GIVEN* a new source type `<NEW_SRC>` is added to `SOURCE_METADATA_BY_SOURCE` with a SQL template returning the 8-column schema
+* *AND* no other change is made to `migrate_to_exasol.sql`
+* *AND* no `<new_src>_to_exasol.sql` adapter file is modified
+* *WHEN* `MIGRATE_TO_EXASOL` is executed against the new source
+* *THEN* `transform_for_metadata` SHALL dispatch the new SQL successfully via the table lookup
+* *AND* `transform_for_gate` and `transform_for_split` SHALL consume the resulting cache without any source-specific branching
+
+### Scenario: Splitter + gate both disabled skips the round-trip
+
+* *GIVEN* an adapter emits at least one IMPORT
+* *AND* `OPTIONS` contains `PARALLEL_ROW_THRESHOLD=0;PARALLEL_STATEMENTS=1;PARALLEL_SPLIT=OFF`
+* *WHEN* `MIGRATE_TO_EXASOL` is executed
+* *THEN* the dispatcher MUST NOT issue any source-side metadata query
+* *AND* every emitted IMPORT SHALL pass through unchanged
+* *AND* the audit rows SHALL carry `SPLIT_STRATEGY = 'SINGLE'` and `PARALLEL_EFFECTIVE = 1` for every IMPORT

--- a/specs/_plans/parallel-import-source-optimization/migrate-to-exasol/split-audit-columns/spec.md
+++ b/specs/_plans/parallel-import-source-optimization/migrate-to-exasol/split-audit-columns/spec.md
@@ -1,0 +1,96 @@
+# Feature: split-audit-columns
+
+The dispatcher (`MIGRATE_TO_EXASOL`) appends four new audit columns to its output row schema so operators can post-hoc analyze how the gate (Speq 1) and splitter (this speq) decided to handle each IMPORT. `OUT_COLUMNS` grows from 7 columns (introduced in Speq 1) to 11 columns. Non-IMPORT rows (DDL, INFO, SUMMARY) carry NULL in all four new columns. The bump is a documented breaking change for any caller that parses the master-script output positionally; direct adapter callers (`<SRC>_TO_EXASOL`) are unaffected because adapters do not emit the audit columns at all.
+
+## Background
+
+* All scenarios use `MIGRATE_TO_EXASOL` as the entry point.
+* The four new columns, appended after the existing 7 Speq-1 columns:
+  * `SPLIT_STRATEGY VARCHAR(32)` — one of `PARTITION`, `PK_RANGE`, `UNIQUE_NUM`, `DATE_BUCKET`, `HASH_NUM`, `ROWID`, `SINGLE`, `MULTI_PASSTHROUGH`, or `NULL` for non-IMPORT rows
+  * `SPLIT_KEY VARCHAR(256)` — column / pseudo-column / partition name actually used as the parallel selector; `NULL` for `SINGLE`, `MULTI_PASSTHROUGH`, and non-IMPORT rows
+  * `PARALLEL_REQUESTED VARCHAR(16)` — raw `PARALLEL_STATEMENTS` OPTIONS value (`AUTO`, `8`, etc.); `NULL` for non-IMPORT rows
+  * `PARALLEL_EFFECTIVE DECIMAL(4,0)` — actual count of `statement '...'` clauses in the emitted IMPORT; `NULL` for non-IMPORT rows
+* The audit columns are populated by `transform_for_audit`, which runs after `transform_for_metadata` → `transform_for_gate` → `transform_for_split` so it sees the final decision for every row.
+* `MULTI_PASSTHROUGH` covers Oracle's pre-existing multi-statement IMPORTs that the splitter intentionally skips.
+* `SINGLE` covers: (a) gate-collapsed multi-stmt IMPORTs, (b) below-threshold pass-throughs, (c) splitter fallbacks (no usable strategy, soft-fail), (d) `PARALLEL_SPLIT=OFF`.
+* The bump from 7 → 11 columns is announced in CHANGELOG; the `OUT_COLUMNS` declaration in `migrate_to_exasol.sql` is the canonical source.
+* `transform_for_gate`'s INFO-row constructor (Speq 1) and any other path that builds rows MUST be updated to emit 11-tuple rows with NULLs in the four new columns.
+
+## Scenarios
+
+### Scenario: IMPORT after splitter PK_RANGE rewrite gets full audit row
+
+* *GIVEN* an adapter emits a single-statement IMPORT for `SMOKE.ORDERS`
+* *AND* `transform_for_split` rewrites it into 4 `statement '...'` clauses using PK_RANGE on `ORDER_ID`
+* *AND* `OPTIONS` contains `PARALLEL_STATEMENTS=AUTO`
+* *WHEN* the dispatcher emits its output rows
+* *THEN* the IMPORT row's audit columns SHALL be: `SPLIT_STRATEGY = 'PK_RANGE'`, `SPLIT_KEY = 'ORDER_ID'`, `PARALLEL_REQUESTED = 'AUTO'`, `PARALLEL_EFFECTIVE = 4`
+* *AND* the row SHALL be an 11-tuple in `OUT_COLUMNS` order
+
+### Scenario: Gate-collapsed IMPORT records SINGLE strategy
+
+* *GIVEN* an adapter emits a 4-way multi-statement IMPORT for `SMOKE.SMALL_T`
+* *AND* the metadata cache reports `src_rows = 500` for `SMOKE.SMALL_T`
+* *AND* `OPTIONS` contains `PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=AUTO`
+* *AND* `transform_for_gate` collapses the IMPORT to a single statement
+* *WHEN* the dispatcher emits its output rows
+* *THEN* the IMPORT row's audit columns SHALL be: `SPLIT_STRATEGY = 'SINGLE'`, `SPLIT_KEY = NULL`, `PARALLEL_REQUESTED = 'AUTO'`, `PARALLEL_EFFECTIVE = 1`
+
+### Scenario: Oracle multi-statement passthrough records MULTI_PASSTHROUGH
+
+* *GIVEN* the source type is `ORACLE`
+* *AND* the adapter emits a 4-way multi-statement IMPORT for `SMOKE.ORACLE_BIG_T` whose metadata reports `src_rows = 20000000`
+* *AND* `OPTIONS` contains `PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=AUTO`
+* *WHEN* the dispatcher emits its output rows
+* *THEN* the IMPORT row's audit columns SHALL be: `SPLIT_STRATEGY = 'MULTI_PASSTHROUGH'`, `SPLIT_KEY = NULL`, `PARALLEL_REQUESTED = 'AUTO'`, `PARALLEL_EFFECTIVE = 4`
+
+### Scenario: DDL rows carry NULL audit columns
+
+* *GIVEN* an adapter emits a `CREATE SCHEMA`, a `CREATE TABLE`, and one IMPORT in one run
+* *WHEN* the dispatcher emits its output rows
+* *THEN* the `CREATE SCHEMA` row and the `CREATE TABLE` row SHALL each carry `SPLIT_STRATEGY = NULL`, `SPLIT_KEY = NULL`, `PARALLEL_REQUESTED = NULL`, `PARALLEL_EFFECTIVE = NULL`
+* *AND* only the IMPORT row SHALL carry non-NULL audit columns
+
+### Scenario: INFO rows carry NULL audit columns
+
+* *GIVEN* a migration triggers any `STEP_KIND = 'INFO'` row (e.g. metadata round-trip soft-fail, splitter fallback, source type without metadata SQL)
+* *WHEN* the dispatcher emits its output rows
+* *THEN* every `INFO` row SHALL carry `SPLIT_STRATEGY = NULL`, `SPLIT_KEY = NULL`, `PARALLEL_REQUESTED = NULL`, `PARALLEL_EFFECTIVE = NULL`
+
+### Scenario: SUMMARY row carries NULL audit columns
+
+* *GIVEN* a migration emits its final `STEP_KIND = 'SUMMARY'` row (introduced in Speq 1)
+* *WHEN* the dispatcher emits its output rows
+* *THEN* the `SUMMARY` row SHALL carry `SPLIT_STRATEGY = NULL`, `SPLIT_KEY = NULL`, `PARALLEL_REQUESTED = NULL`, `PARALLEL_EFFECTIVE = NULL`
+
+### Scenario: Per-IMPORT audit independence
+
+* *GIVEN* an adapter emits three IMPORTs whose final fates differ: `SMOKE.SMALL_T` gate-collapsed to single, `SMOKE.BIG_T` splitter-rewritten via PK_RANGE on `ID` into 4 clauses, `SMOKE.DATED_T` splitter-rewritten via DATE_BUCKET on `EVENT_DT` into 4 clauses
+* *AND* `OPTIONS` contains `PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=4`
+* *WHEN* the dispatcher emits its output rows
+* *THEN* the `SMOKE.SMALL_T` row SHALL carry `SPLIT_STRATEGY = 'SINGLE'`, `SPLIT_KEY = NULL`, `PARALLEL_REQUESTED = '4'`, `PARALLEL_EFFECTIVE = 1`
+* *AND* the `SMOKE.BIG_T` row SHALL carry `SPLIT_STRATEGY = 'PK_RANGE'`, `SPLIT_KEY = 'ID'`, `PARALLEL_REQUESTED = '4'`, `PARALLEL_EFFECTIVE = 4`
+* *AND* the `SMOKE.DATED_T` row SHALL carry `SPLIT_STRATEGY = 'DATE_BUCKET'`, `SPLIT_KEY = 'EVENT_DT'`, `PARALLEL_REQUESTED = '4'`, `PARALLEL_EFFECTIVE = 4`
+
+### Scenario: OUT_COLUMNS schema bumped to 11
+
+* *GIVEN* `migrate_to_exasol.sql` after this speq lands
+* *WHEN* a caller invokes `MIGRATE_TO_EXASOL` with `DEBUG=TRUE` (returns rows instead of executing them)
+* *THEN* each returned row MUST be an 11-tuple matching `OUT_COLUMNS` in declared order
+* *AND* the column names in declared order SHALL end with `SPLIT_STRATEGY`, `SPLIT_KEY`, `PARALLEL_REQUESTED`, `PARALLEL_EFFECTIVE`
+
+### Scenario: PARALLEL_REQUESTED records the raw OPTIONS value
+
+* *GIVEN* `OPTIONS` contains `PARALLEL_STATEMENTS=8`
+* *AND* an adapter emits one IMPORT for which `transform_for_split` produces 8 `statement '...'` clauses
+* *WHEN* the dispatcher emits its output rows
+* *THEN* the IMPORT row's `PARALLEL_REQUESTED` SHALL be the literal string `'8'`
+* *AND* the IMPORT row's `PARALLEL_EFFECTIVE` SHALL be `8`
+
+### Scenario: SPLIT_KEY echoes the pseudo-column for ROWID strategy
+
+* *GIVEN* the source type is `POSTGRES`
+* *AND* an adapter emits a single-statement IMPORT for which `transform_for_split` falls through to step 6 (ROWID)
+* *AND* `OPTIONS` contains `PARALLEL_STATEMENTS=4`
+* *WHEN* the dispatcher emits its output rows
+* *THEN* the IMPORT row's audit columns SHALL be: `SPLIT_STRATEGY = 'ROWID'`, `SPLIT_KEY = 'ctid'`, `PARALLEL_REQUESTED = '4'`, `PARALLEL_EFFECTIVE = 4`

--- a/specs/mission.md
+++ b/specs/mission.md
@@ -1,0 +1,115 @@
+# Mission: database-migration
+
+> Provide Exasol SQL scripts that generate schema, table, and import statements for moving data from external database systems into Exasol.
+
+## Problem Statement
+
+Exasol users need repeatable migration helpers that inspect source database metadata and generate the Exasol DDL and `IMPORT` statements needed to load data. Manually writing these statements for every schema, table, column, and data type is slow and error-prone, especially across heterogeneous database systems.
+
+## Target Users
+
+| Persona | Goal | Key Workflow |
+|---------|------|--------------|
+| Exasol administrator | Load data from an external database into Exasol | Configure a connection, create the migration script, execute it to generate SQL, then run the generated SQL |
+| Data engineer | Adapt migration behavior for a source system | Review a source-specific script, adjust type mappings or filters, then test generated SQL against Exasol |
+| Community contributor | Add or improve source support | Follow the existing source-script pattern, document setup, and add regression coverage |
+
+## Core Capabilities
+
+1. **Source metadata discovery** — Query external database metadata through Exasol connections.
+2. **Migration SQL generation** — Generate ordered `CREATE SCHEMA`, `CREATE TABLE`, and `IMPORT` statements.
+3. **Source-specific type mapping** — Convert source data types into Exasol-compatible column definitions.
+4. **Post-load helpers** — Provide optional optimization scripts after data has loaded.
+5. **Delta import helpers** — Provide scripts for timestamp-based incremental imports.
+
+## Out of Scope
+
+- Managed migration service orchestration.
+- Credential lifecycle management.
+- Guaranteed official support; the README states this is not an officially supported Exasol product.
+- Replacing source-specific loader scripts with a single universal interface in all cases.
+- S3-specific loading through the generic JDBC adapter pattern.
+
+## Domain Glossary
+
+| Term | Definition |
+|------|------------|
+| Exasol script | A SQL-created Lua script executed inside Exasol with `EXECUTE SCRIPT`. |
+| Migration source | The external system from which data is loaded, such as MySQL, Snowflake, or Databricks. |
+| Connection | An Exasol connection object used by `IMPORT FROM JDBC` or another import method. |
+| Generated SQL | SQL rows returned by migration scripts for later execution. |
+| Identifier case insensitive | Option that uppercases generated Exasol identifiers for case-insensitive handling. |
+| Source filter | Pattern restricting which catalogs, schemas, or tables are included. |
+
+---
+
+## Tech Stack
+
+| Layer | Technology | Purpose |
+|-------|------------|---------|
+| Database runtime | Exasol SQL and Lua scripts | Generate migration SQL from inside Exasol |
+| Connectivity | Exasol `IMPORT FROM JDBC` and connection objects | Query source metadata and import source rows |
+| Test utilities | Python with EXAODBC, shell scripts, Docker | Existing integration-style test harness |
+| Lightweight tests | Lua | Mock Exasol script execution for source-script regression tests |
+
+## Commands
+
+```bash
+# Build
+python3 -c "import ast, pathlib; [ast.parse(pathlib.Path(p).read_text(), filename=p) for p in ('test/create_script.py','test/export_res.py','test/mock_test.py')]"
+
+# Test
+lua test/test_databricks_to_exasol.lua
+
+# Lint & Format
+git diff --check
+
+# Gather Code Coverage
+# No coverage command is defined for this repository.
+```
+
+## Project Structure
+
+```
+database-migration/
+├── *_to_exasol.sql              # Source-specific migration scripts
+├── s3_to_exasol.sql             # S3 parallel loader with separate parameter shape
+├── post_load_optimization/      # Optional post-load optimization scripts
+├── delta_import/                # Delta import helper scripts
+├── test/                        # Existing integration harness and source fixtures
+└── specs/                       # Speq mission and active plans
+```
+
+## Architecture
+
+The repository uses a source-specific script pattern. Each migration script creates a `database_migration.<SOURCE>_TO_EXASOL` Exasol Lua script, queries source metadata through an Exasol connection, transforms metadata with Exasol SQL, and returns ordered SQL rows. Users review or execute the generated DDL and `IMPORT` statements in a separate step.
+
+### Master-script architecture (durable invariant)
+
+`migrate_to_exasol.sql` is the orchestrator on top of the per-source adapter scripts. It is the **only** place cross-cutting behavior is allowed to grow. Adapter scripts (`<source>_to_exasol.sql`) are frozen at their current shape and are never touched by orchestrator features — they remain authoritative for source-specific schema discovery, type mapping, identifier quoting, DDL generation, and `IMPORT` shape, so the SE team and existing customers who call adapters directly continue to work byte-for-byte.
+
+The orchestrator implements cross-cutting concerns as a pipeline of post-processing transforms over the rows the adapter returned:
+
+1. `transform_for_metadata` — one source-side `IMPORT FROM JDBC` per migration that fetches per-(schema, table) row counts plus PK / date / numeric / partition hints. Backed by a `SOURCE_METADATA_BY_SOURCE` dispatch table. Soft-fails to an all-NULL cache + `INFO` row.
+2. `transform_for_gate` — collapses multi-statement IMPORTs whose source row count is below `PARALLEL_ROW_THRESHOLD` to a single statement.
+3. `transform_for_split` — expands single-statement IMPORTs at-or-above the threshold into N parallel `STATEMENT '...'` clauses with pushdown-friendly WHERE selectors. Walks a per-source split-strategy hierarchy backed by a `DIALECT_BY_SOURCE` dispatch table.
+4. `transform_for_audit` — records the gate/splitter decision per row into four audit columns (`SPLIT_STRATEGY`, `SPLIT_KEY`, `PARALLEL_REQUESTED`, `PARALLEL_EFFECTIVE`).
+
+Any transform that fails (lookup error, unparseable IMPORT, missing dialect entry) must **soft-fail**: emit an `INFO` row describing the skip and leave the affected adapter rows unchanged. The orchestrator's transforms are optimizations and must never be allowed to break a migration that the adapter alone would have completed.
+
+Adding a new source means adding entries to `SOURCE_METADATA_BY_SOURCE` and `DIALECT_BY_SOURCE` (and the dispatch branch in `MIGRATE_TO_EXASOL` itself) — never modifying the adapter file.
+
+## Constraints
+
+- **Technical**: Scripts must run inside Exasol and use Exasol-supported Lua and SQL syntax.
+- **Technical**: Source access depends on externally configured Exasol connection objects and available JDBC drivers.
+- **Business**: The project is open source and not officially supported by Exasol.
+- **Performance**: Scripts should generate SQL from metadata without loading source data until generated `IMPORT` statements run.
+
+## External Dependencies
+
+| Service | Purpose | Failure Impact |
+|---------|---------|----------------|
+| Source database | Provides metadata and row data for migration | Migration script cannot discover or load source tables |
+| Exasol connection object | Stores endpoint and credential details | `IMPORT FROM JDBC` fails |
+| JDBC driver | Enables Exasol to connect to a source system | Metadata and data imports fail |

--- a/test/test_databricks_to_exasol.lua
+++ b/test/test_databricks_to_exasol.lua
@@ -1,0 +1,200 @@
+--[[
+  Checks for databricks_to_exasol.sql.
+
+  Run: lua test/test_databricks_to_exasol.lua
+]]
+
+local passed = 0
+local failed = 0
+
+local function test(name, fn)
+    local ok, err = pcall(fn)
+    if ok then
+        passed = passed + 1
+        print("  PASS: " .. name)
+    else
+        failed = failed + 1
+        print("  FAIL: " .. name .. " -- " .. tostring(err))
+    end
+end
+
+local function assert_eq(actual, expected, msg)
+    if actual ~= expected then
+        error((msg or "") .. " expected: " .. tostring(expected) .. ", got: " .. tostring(actual))
+    end
+end
+
+local function assert_contains(actual, pattern, msg)
+    if not tostring(actual):find(pattern, 1, true) then
+        error((msg or "missing expected text") .. ": " .. pattern .. " in " .. tostring(actual))
+    end
+end
+
+local function assert_not_contains(actual, pattern, msg)
+    if tostring(actual):find(pattern, 1, true) then
+        error((msg or "unexpected text") .. ": " .. pattern .. " in " .. tostring(actual))
+    end
+end
+
+local function read_file(path)
+    local f = io.open(path, "r")
+    assert(f, "Could not open " .. path)
+    local content = f:read("*a")
+    f:close()
+    return content
+end
+
+local function extract_lua_block(path)
+    local content = read_file(path)
+    local lua_block = content:match("%) RETURNS TABLE%s*\nAS\n(.-)\n/\n")
+    assert(lua_block, "Could not extract Lua block from " .. path)
+    return lua_block
+end
+
+local databricks_lua = extract_lua_block("databricks_to_exasol.sql")
+
+local function run_databricks(params)
+    local calls = {}
+    local rows = params.rows or {{SQL_TEXT = "-- ### SCHEMAS ###"}}
+
+    local env = {
+        CONNECTION_NAME = params.connection_name or "DATABRICKS_CONNECTION",
+        CATALOG2SCHEMA = params.catalog2schema,
+        CATALOG_FILTER = params.catalog_filter,
+        SCHEMA_FILTER = params.schema_filter,
+        TARGET_SCHEMA = params.target_schema,
+        TABLE_FILTER = params.table_filter,
+        IDENTIFIER_CASE_INSENSITIVE = params.identifier_case_insensitive,
+        string = string,
+        table = table,
+        math = math,
+        tostring = tostring,
+        tonumber = tonumber,
+        type = type,
+        error = error,
+    }
+
+    env.pquery = function(sql)
+        calls[#calls + 1] = sql
+        if params.metadata_error then
+            return false, {
+                error_message = params.metadata_error,
+                statement_text = sql,
+            }
+        end
+        return true, rows
+    end
+
+    local fn, err = load(databricks_lua, "databricks_to_exasol.lua", "t", env)
+    assert(fn, "Lua load failed: " .. tostring(err))
+
+    local result_rows = fn()
+    return {
+        rows = result_rows,
+        sql = calls[1],
+        calls = calls,
+    }
+end
+
+print("=== Lua Syntax Validation ===")
+
+test("Lua block in databricks_to_exasol.sql has valid syntax", function()
+    local fn, err = load(databricks_lua)
+    assert(fn, "Lua syntax error in databricks_to_exasol.sql: " .. tostring(err))
+end)
+
+print("")
+print("=== Generation Tests ===")
+
+test("generates migration sql for Databricks tables", function()
+    local result = run_databricks({})
+
+    assert_eq(#result.calls, 1)
+    assert_eq(result.rows[1].SQL_TEXT, "-- ### SCHEMAS ###")
+    assert_contains(result.sql, "IMPORT FROM JDBC DRIVER = 'DATABRICKS' AT DATABRICKS_CONNECTION")
+    assert_contains(result.sql, "INFORMATION_SCHEMA.COLUMNS")
+    assert_contains(result.sql, "INFORMATION_SCHEMA.TABLES")
+    assert_contains(result.sql, "table_type in (''MANAGED'', ''EXTERNAL'', ''MANAGED_SHALLOW_CLONE'', ''EXTERNAL_SHALLOW_CLONE'')")
+    assert_contains(result.sql, "-- ### SCHEMAS ###")
+    assert_contains(result.sql, "-- ### TABLES ###")
+    assert_contains(result.sql, "-- ### IMPORTS ###")
+    assert_contains(result.sql, "import into")
+end)
+
+test("applies source filters to metadata query", function()
+    local result = run_databricks({
+        catalog_filter = "main, analytics",
+        schema_filter = "bronze%",
+        table_filter = "orders, customers",
+    })
+
+    assert_contains(result.sql, "table_catalog in (''main'',''analytics'')")
+    assert_contains(result.sql, "table_schema like ''bronze%''")
+    assert_contains(result.sql, "table_name in (''orders'',''customers'')")
+end)
+
+test("catalog2schema maps catalog schema table safely", function()
+    local result = run_databricks({catalog2schema = true})
+
+    assert_contains(result.sql, "\"exa_table_catalog\" as \"target_schema_name\"")
+    assert_contains(result.sql, "\"exa_table_schema\" || '_' || \"exa_table_name\" as \"target_table_name\"")
+end)
+
+test("target schema override is honored", function()
+    local result = run_databricks({
+        catalog2schema = true,
+        target_schema = "MART",
+    })
+
+    assert_contains(result.sql, "'MART' as \"target_schema_name\"")
+    assert_contains(result.sql, "\"exa_table_catalog\" || '_' || \"exa_table_schema\" || '_' || \"exa_table_name\" as \"target_table_name\"")
+end)
+
+test("identifier case option controls generated names", function()
+    local upper_result = run_databricks({identifier_case_insensitive = true})
+    local preserve_result = run_databricks({identifier_case_insensitive = false})
+
+    assert_contains(upper_result.sql, "upper(databricks.\"table_catalog\")")
+    assert_contains(upper_result.sql, "upper(databricks.\"column_name\")")
+    assert_not_contains(preserve_result.sql, "upper(databricks.\"table_catalog\")")
+    assert_not_contains(preserve_result.sql, "upper(databricks.\"column_name\")")
+end)
+
+test("maps databricks types to exasol types", function()
+    local result = run_databricks({})
+
+    assert_contains(result.sql, "when upper(data_type) = 'TINYINT'")
+    assert_contains(result.sql, "DECIMAL(3,0)")
+    assert_contains(result.sql, "when upper(data_type) = 'BIGINT'")
+    assert_contains(result.sql, "DECIMAL(19,0)")
+    assert_contains(result.sql, "when upper(data_type) = 'DECIMAL'")
+    assert_contains(result.sql, "when upper(data_type) = 'STRING'")
+    assert_contains(result.sql, "VARCHAR(2000000)")
+    assert_contains(result.sql, "when upper(data_type) = 'TIMESTAMP_NTZ'")
+    assert_contains(result.sql, "when upper(data_type) = 'ARRAY'")
+    assert_contains(result.sql, "when upper(data_type) = 'OBJECT'")
+    assert_contains(result.sql, "--LOSSY_DATATYPE")
+end)
+
+test("metadata errors include source statement", function()
+    local ok, err = pcall(run_databricks, {metadata_error = "permission denied"})
+
+    assert_eq(ok, false)
+    assert_contains(err, "permission denied")
+    assert_contains(err, "IMPORT FROM JDBC DRIVER = 'DATABRICKS' AT DATABRICKS_CONNECTION")
+end)
+
+test("databricks adapter does not generate s3 loader sql", function()
+    local script = read_file("databricks_to_exasol.sql")
+    local result = run_databricks({})
+
+    assert_not_contains(script, "S3_PARALLEL_READ")
+    assert_not_contains(result.sql, "S3_PARALLEL_READ")
+end)
+
+print("")
+print(string.format("=== Results: %d passed, %d failed ===", passed, failed))
+
+if failed > 0 then
+    os.exit(1)
+end

--- a/test/test_db2_to_exasol.lua
+++ b/test/test_db2_to_exasol.lua
@@ -81,18 +81,22 @@ end)
 print("")
 print("=== Generation Tests ===")
 
-test("trims DB2 catalog schema and table filters", function()
+test("trims DB2 catalog schema/table filters case-insensitively", function()
     local result = run_db2()
 
-    assert_contains(result.sql, "rtrim(t.table_schema) like ''DB2DT''")
-    assert_contains(result.sql, "rtrim(t.table_name) like ''CORE_CASE''")
+    assert_contains(result.sql, "upper(rtrim(t.table_schema)) like upper(''DB2DT'')")
+    assert_contains(result.sql, "upper(rtrim(t.table_name)) like upper(''CORE_CASE'')")
     assert_contains(result.sql, "rtrim(t.table_schema) not in")
 end)
 
-test("trims DB2 source table in generated import", function()
+test("quotes DB2 source identifiers in generated import", function()
     local result = run_db2()
 
-    assert_contains(result.sql, "from ' || rtrim(table_schema)|| '.' || rtrim(table_name)")
+    assert_contains(result.sql, [['"' || replace(table_schema, '"', '""') || '"' as "source_table_schema"]])
+    assert_contains(result.sql, [['"' || replace(table_name, '"', '""') || '"' as "source_table_name"]])
+    assert_contains(result.sql, [['"' || replace(column_name, '"', '""') || '"' as "source_column_name"]])
+    assert_contains(result.sql, "then \"source_column_name\"")
+    assert_contains(result.sql, "' from ' || \"source_table_schema\"|| '.' || \"source_table_name\"")
 end)
 
 print("")

--- a/test/test_db2_to_exasol.lua
+++ b/test/test_db2_to_exasol.lua
@@ -1,0 +1,103 @@
+--[[
+  Checks for db2_to_exasol.sql.
+
+  Run: lua test/test_db2_to_exasol.lua
+]]
+
+local passed = 0
+local failed = 0
+
+local function test(name, fn)
+    local ok, err = pcall(fn)
+    if ok then
+        passed = passed + 1
+        print("  PASS: " .. name)
+    else
+        failed = failed + 1
+        print("  FAIL: " .. name .. " -- " .. tostring(err))
+    end
+end
+
+local function assert_contains(actual, pattern, msg)
+    if not tostring(actual):find(pattern, 1, true) then
+        error((msg or "missing expected text") .. ": " .. pattern .. " in " .. tostring(actual))
+    end
+end
+
+local function read_file(path)
+    local f = io.open(path, "r")
+    assert(f, "Could not open " .. path)
+    local content = f:read("*a")
+    f:close()
+    return content
+end
+
+local function extract_lua_block(path)
+    local content = read_file(path)
+    local lua_block = content:match("%)%s*RETURNS TABLE%s*\nAS\n(.-)\n/\n")
+    assert(lua_block, "Could not extract Lua block from " .. path)
+    return lua_block
+end
+
+local db2_lua = extract_lua_block("db2_to_exasol.sql")
+
+local function run_db2()
+    local calls = {}
+    local env = {
+        CONNECTION_NAME = "DB2_CONNECTION",
+        IDENTIFIER_CASE_INSENSITIVE = true,
+        SCHEMA_FILTER = "DB2DT",
+        TABLE_FILTER = "CORE_CASE",
+        string = string,
+        table = table,
+        tostring = tostring,
+        type = type,
+        error = error,
+    }
+
+    env.query = function(sql)
+        calls[#calls + 1] = sql
+        return {{SQL_TEXT = "-- ### SCHEMAS ###"}}
+    end
+
+    local fn, err = load(db2_lua, "db2_to_exasol.lua", "t", env)
+    assert(fn, "Lua load failed: " .. tostring(err))
+
+    local result_rows = fn()
+    return {
+        rows = result_rows,
+        sql = calls[1],
+        calls = calls,
+    }
+end
+
+print("=== Lua Syntax Validation ===")
+
+test("Lua block in db2_to_exasol.sql has valid syntax", function()
+    local fn, err = load(db2_lua)
+    assert(fn, "Lua syntax error in db2_to_exasol.sql: " .. tostring(err))
+end)
+
+print("")
+print("=== Generation Tests ===")
+
+test("trims DB2 catalog schema and table filters", function()
+    local result = run_db2()
+
+    assert_contains(result.sql, "rtrim(t.table_schema) like ''DB2DT''")
+    assert_contains(result.sql, "rtrim(t.table_name) like ''CORE_CASE''")
+    assert_contains(result.sql, "rtrim(t.table_schema) not in")
+end)
+
+test("trims DB2 source table in generated import", function()
+    local result = run_db2()
+
+    assert_contains(result.sql, "from ' || rtrim(table_schema)|| '.' || rtrim(table_name)")
+end)
+
+print("")
+print(string.format("=== Results: %d passed, %d failed ===", passed, failed))
+
+if failed > 0 then
+    os.exit(1)
+end

--- a/test/test_migrate_to_exasol.lua
+++ b/test/test_migrate_to_exasol.lua
@@ -1,0 +1,337 @@
+--[[
+  Checks for migrate_to_exasol.sql.
+
+  Run: lua test/test_migrate_to_exasol.lua
+]]
+
+local passed = 0
+local failed = 0
+
+local function test(name, fn)
+    local ok, err = pcall(fn)
+    if ok then
+        passed = passed + 1
+        print("  PASS: " .. name)
+    else
+        failed = failed + 1
+        print("  FAIL: " .. name .. " -- " .. tostring(err))
+    end
+end
+
+local function assert_eq(actual, expected, msg)
+    if actual ~= expected then
+        error((msg or "") .. " expected: " .. tostring(expected) .. ", got: " .. tostring(actual))
+    end
+end
+
+local function assert_contains(actual, pattern, msg)
+    if not tostring(actual):find(pattern, 1, true) then
+        error((msg or "missing expected text") .. ": " .. pattern .. " in " .. tostring(actual))
+    end
+end
+
+local function read_file(path)
+    local f = io.open(path, "r")
+    assert(f, "Could not open " .. path)
+    local content = f:read("*a")
+    f:close()
+    return content
+end
+
+local function extract_lua_block(path)
+    local content = read_file(path)
+    local lua_block = content:match("%) RETURNS TABLE%s*\nAS\n(.-)\n/\n")
+    assert(lua_block, "Could not extract Lua block from " .. path)
+    return lua_block
+end
+
+local migrate_lua = extract_lua_block("migrate_to_exasol.sql")
+
+local function run_migrate(params)
+    local calls = {}
+    local adapter_rows = params.adapter_rows or {{SQL_TEXT = "select 1"}}
+    local execute_results = params.execute_results or {}
+
+    local env = {
+        SOURCE_TYPE = params.source_type,
+        CONNECTION_NAME = params.connection_name or "SRC_CONN",
+        CONNECTION_TYPE = params.connection_type,
+        DB_FILTER = params.db_filter,
+        SCHEMA_FILTER = params.schema_filter,
+        TABLE_FILTER = params.table_filter,
+        TARGET_SCHEMA = params.target_schema,
+        IDENTIFIER_CASE_INSENSITIVE = params.identifier_case_insensitive,
+        DEBUG = params.debug,
+        OPTIONS = params.options,
+        string = string,
+        table = table,
+        math = math,
+        tostring = tostring,
+        tonumber = tonumber,
+        type = type,
+        error = error,
+    }
+
+    env.pquery = function(sql)
+        calls[#calls + 1] = sql
+        if #calls == 1 then
+            if params.adapter_error then
+                return false, {
+                    error_message = params.adapter_error,
+                    statement_text = sql,
+                }
+            end
+            return true, adapter_rows
+        end
+
+        local result = execute_results[#calls - 1]
+        if result and result.success == false then
+            return false, {error_message = result.error_message or "execution failed"}
+        end
+        return true, {rows_affected = 0}
+    end
+
+    local fn, err = load(migrate_lua, "migrate_to_exasol.lua", "t", env)
+    assert(fn, "Lua load failed: " .. tostring(err))
+
+    local rows, columns = fn()
+    return {
+        rows = rows,
+        columns = columns,
+        calls = calls,
+        adapter_sql = calls[1],
+    }
+end
+
+local function default_case(source_type, expected_sql)
+    test("dispatches " .. source_type, function()
+        local result = run_migrate({
+            source_type = source_type,
+            connection_type = "JDBC",
+            db_filter = "DB",
+            schema_filter = "SCH",
+            table_filter = "TBL",
+            target_schema = "DST",
+            identifier_case_insensitive = true,
+            debug = true,
+            options = "",
+        })
+        assert_eq(result.adapter_sql, expected_sql)
+        assert_eq(result.rows[1][1], "select 1")
+        assert_eq(result.rows[1][2], "PREVIEW")
+        assert_eq(result.columns, "SQL_TEXT VARCHAR(2000000), SUCCESS VARCHAR(10), ERROR_MESSAGE VARCHAR(20000)")
+    end)
+end
+
+print("=== Lua Syntax Validation ===")
+
+test("Lua block in migrate_to_exasol.sql has valid syntax", function()
+    local fn, err = load(migrate_lua)
+    assert(fn, "Lua syntax error in migrate_to_exasol.sql: " .. tostring(err))
+end)
+
+print("")
+print("=== MIGRATE_TO_EXASOL Dispatch Tests ===")
+
+default_case("MYSQL", "EXECUTE SCRIPT database_migration.MYSQL_TO_EXASOL('SRC_CONN',TRUE,'SCH','TBL')")
+default_case("MARIADB", "EXECUTE SCRIPT database_migration.MARIADB_TO_EXASOL('SRC_CONN',TRUE,'SCH','TBL')")
+default_case("POSTGRES", "EXECUTE SCRIPT database_migration.POSTGRES_TO_EXASOL('SRC_CONN',TRUE,'SCH','TBL','DST')")
+default_case("REDSHIFT", "EXECUTE SCRIPT database_migration.REDSHIFT_TO_EXASOL('SRC_CONN',TRUE,'SCH','TBL')")
+default_case("DB2", "EXECUTE SCRIPT database_migration.DB2_TO_EXASOL('SRC_CONN',TRUE,'SCH','TBL')")
+default_case("VERTICA", "EXECUTE SCRIPT database_migration.VERTICA_TO_EXASOL('SRC_CONN',TRUE,'SCH','TBL')")
+default_case("HANA", "EXECUTE SCRIPT database_migration.HANA_TO_EXASOL('SRC_CONN',TRUE,'SCH','TBL')")
+default_case("AZURE_SQL", "EXECUTE SCRIPT database_migration.AZURE_SQL_TO_EXASOL('SRC_CONN','SCH','TBL',TRUE)")
+default_case("BIGQUERY", "EXECUTE SCRIPT database_migration.BIGQUERY_TO_EXASOL('SRC_CONN',TRUE,'DB','SCH','TBL')")
+default_case("DATABRICKS", "EXECUTE SCRIPT database_migration.DATABRICKS_TO_EXASOL('SRC_CONN',TRUE,'DB','SCH','DST','TBL',TRUE)")
+default_case("SQLSERVER", "EXECUTE SCRIPT database_migration.SQLSERVER_TO_EXASOL('SRC_CONN',FALSE,'DB','SCH','DST','TBL',TRUE)")
+default_case("SNOWFLAKE", "EXECUTE SCRIPT database_migration.SNOWFLAKE_TO_EXASOL('SRC_CONN',FALSE,'DB','SCH','DST','TBL',TRUE)")
+default_case("ORACLE", "EXECUTE SCRIPT database_migration.ORACLE_TO_EXASOL('SRC_CONN',TRUE,'SCH','TBL',1,FALSE,FALSE,FALSE)")
+default_case("TERADATA", "EXECUTE SCRIPT database_migration.TERADATA_TO_EXASOL('SRC_CONN',TRUE,'SCH','TBL',FALSE)")
+default_case("EXASOL", "EXECUTE SCRIPT database_migration.EXASOL_TO_EXASOL('SRC_CONN','JDBC',TRUE,'SCH','TBL','FALSE','%','DISABLE')")
+default_case("NETEZZA", "EXECUTE SCRIPT database_migration.NETEZZA_TO_EXASOL('SRC_CONN','DB','SCH','TBL',TRUE)")
+default_case("VECTORWISE", "EXECUTE SCRIPT database_migration.VECTORWISE_TO_EXASOL('SRC_CONN',TRUE,'TBL')")
+
+print("")
+print("=== Alias And Option Tests ===")
+
+test("source aliases normalize before dispatch", function()
+    local result = run_migrate({
+        source_type = "sql server",
+        db_filter = "DB",
+        schema_filter = "SCH",
+        table_filter = "TBL",
+        target_schema = "DST",
+    })
+    assert_eq(result.adapter_sql, "EXECUTE SCRIPT database_migration.SQLSERVER_TO_EXASOL('SRC_CONN',FALSE,'DB','SCH','DST','TBL',TRUE)")
+end)
+
+test("Databricks aliases normalize before dispatch", function()
+    local result = run_migrate({
+        source_type = "databricks sql",
+        db_filter = "CAT",
+        schema_filter = "SCH",
+        table_filter = "TBL",
+        target_schema = "DST",
+        options = "CATALOG2SCHEMA=false",
+    })
+    assert_eq(result.adapter_sql, "EXECUTE SCRIPT database_migration.DATABRICKS_TO_EXASOL('SRC_CONN',FALSE,'CAT','SCH','DST','TBL',TRUE)")
+end)
+
+test("string literals are escaped in generated adapter calls", function()
+    local result = run_migrate({
+        source_type = "MYSQL",
+        connection_name = "CONN'X",
+        schema_filter = "S'CH",
+        table_filter = "T'BL",
+    })
+    assert_eq(result.adapter_sql, "EXECUTE SCRIPT database_migration.MYSQL_TO_EXASOL('CONN''X',TRUE,'S''CH','T''BL')")
+end)
+
+test("Snowflake DB2SCHEMA option is forwarded", function()
+    local result = run_migrate({
+        source_type = "SNOWFLAKE",
+        db_filter = "DB",
+        schema_filter = "SCH",
+        table_filter = "TBL",
+        target_schema = "DST",
+        options = "DB2SCHEMA=true",
+    })
+    assert_eq(result.adapter_sql, "EXECUTE SCRIPT database_migration.SNOWFLAKE_TO_EXASOL('SRC_CONN',TRUE,'DB','SCH','DST','TBL',TRUE)")
+end)
+
+test("Oracle options are forwarded", function()
+    local result = run_migrate({
+        source_type = "ORACLE",
+        schema_filter = "SCH",
+        table_filter = "TBL",
+        options = "PARALLEL_STATEMENTS=4;CREATE_PK=yes;CREATE_FK=1;CHECK_MIGRATION=true",
+    })
+    assert_eq(result.adapter_sql, "EXECUTE SCRIPT database_migration.ORACLE_TO_EXASOL('SRC_CONN',TRUE,'SCH','TBL',4,TRUE,TRUE,TRUE)")
+end)
+
+test("Exasol options and connection type are forwarded", function()
+    local result = run_migrate({
+        source_type = "EXASOL",
+        connection_type = "exa",
+        schema_filter = "SCH",
+        table_filter = "TBL",
+        options = "GENERATE_VIEWS=TRUE;VIEW_FILTER=VW%;PK_SETTING=ENABLE",
+    })
+    assert_eq(result.adapter_sql, "EXECUTE SCRIPT database_migration.EXASOL_TO_EXASOL('SRC_CONN','EXA',TRUE,'SCH','TBL','TRUE','VW%','ENABLE')")
+end)
+
+test("BigQuery PROJECT_ID option overrides DB_FILTER", function()
+    local result = run_migrate({
+        source_type = "BIGQUERY",
+        db_filter = "DB",
+        schema_filter = "SCH",
+        table_filter = "TBL",
+        options = "PROJECT_ID=PROJECT",
+    })
+    assert_eq(result.adapter_sql, "EXECUTE SCRIPT database_migration.BIGQUERY_TO_EXASOL('SRC_CONN',TRUE,'PROJECT','SCH','TBL')")
+end)
+
+print("")
+print("=== Execution Mode Tests ===")
+
+test("DEBUG false runs generated statements for non-native adapters", function()
+    local result = run_migrate({
+        source_type = "MYSQL",
+        schema_filter = "SCH",
+        table_filter = "TBL",
+        debug = false,
+        adapter_rows = {
+            {SQL_TEXT = "-- comment"},
+            {SQL_TEXT = "create table t(c int)"},
+        },
+    })
+
+    assert_eq(#result.calls, 2)
+    assert_eq(result.calls[2], "create table t(c int)")
+    assert_eq(result.rows[1][1], "-- The following statements were executed successfully.")
+    assert_eq(result.rows[2][2], "SKIPPED")
+    assert_eq(result.rows[3][2], "TRUE")
+end)
+
+test("DEBUG false runs Snowflake generated statements", function()
+    local result = run_migrate({
+        source_type = "SNOWFLAKE",
+        debug = false,
+        adapter_rows = {
+            {SQL_TEXT = "create table t(c int)"},
+        },
+    })
+
+    assert_eq(#result.calls, 2)
+    assert_eq(result.calls[2], "create table t(c int)")
+    assert_eq(result.rows[1][1], "-- The following statements were executed successfully.")
+    assert_eq(result.rows[2][2], "TRUE")
+end)
+
+print("")
+print("=== Error Handling Tests ===")
+
+test("unsupported source raises a clear error", function()
+    local ok, err = pcall(run_migrate, {source_type = "UNKNOWN"})
+    assert_eq(ok, false)
+    assert_contains(err, "Unsupported SOURCE_TYPE")
+end)
+
+test("S3 points users to the direct loader", function()
+    local ok, err = pcall(run_migrate, {source_type = "S3"})
+    assert_eq(ok, false)
+    assert_contains(err, "S3 is not supported by MIGRATE_TO_EXASOL")
+    assert_contains(err, "S3_PARALLEL_READ")
+end)
+
+test("missing connection raises a clear error", function()
+    local ok, err = pcall(run_migrate, {source_type = "MYSQL", connection_name = ""})
+    assert_eq(ok, false)
+    assert_contains(err, "CONNECTION_NAME is required")
+end)
+
+test("BigQuery requires PROJECT_ID when DB_FILTER is wildcard", function()
+    local ok, err = pcall(run_migrate, {
+        source_type = "BIGQUERY",
+        db_filter = "%",
+        schema_filter = "SCH",
+        table_filter = "TBL",
+    })
+    assert_eq(ok, false)
+    assert_contains(err, "OPTIONS PROJECT_ID for BIGQUERY is required")
+end)
+
+test("invalid boolean option raises a clear error", function()
+    local ok, err = pcall(run_migrate, {
+        source_type = "SNOWFLAKE",
+        options = "DB2SCHEMA=maybe",
+    })
+    assert_eq(ok, false)
+    assert_contains(err, "Invalid boolean for DB2SCHEMA")
+end)
+
+test("invalid DEBUG raises a clear error", function()
+    local ok, err = pcall(run_migrate, {
+        source_type = "MYSQL",
+        debug = "maybe",
+    })
+    assert_eq(ok, false)
+    assert_contains(err, "Invalid boolean for DEBUG")
+end)
+
+test("adapter errors include source statement", function()
+    local ok, err = pcall(run_migrate, {
+        source_type = "MYSQL",
+        adapter_error = "adapter failed",
+    })
+    assert_eq(ok, false)
+    assert_contains(err, "adapter failed")
+    assert_contains(err, "MYSQL_TO_EXASOL")
+end)
+
+print("")
+print(string.format("=== Results: %d passed, %d failed ===", passed, failed))
+
+if failed > 0 then
+    os.exit(1)
+end

--- a/test/test_migrate_to_exasol.lua
+++ b/test/test_migrate_to_exasol.lua
@@ -73,6 +73,8 @@ local function run_migrate(params)
         error = error,
         ipairs = ipairs,
         pairs = pairs,
+        pcall = pcall,
+        select = select,
     }
 
     local execute_call_index = 0
@@ -499,14 +501,14 @@ test("gate keeps multi-statement IMPORT at or above threshold", function()
     assert_eq(count, 4, "expected all four STATEMENT clauses preserved, got " .. count)
 end)
 
-test("gate leaves single-statement IMPORT untouched", function()
+test("gate + splitter off leaves single-statement IMPORT untouched", function()
     local sql = single_stmt_import("DST", "MED_T", "SMOKE", "MED_T")
     local result = run_migrate({
         source_type = "ORACLE",
-        options = "PARALLEL_ROW_THRESHOLD=1000000",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=1;PARALLEL_SPLIT=OFF",
         adapter_rows = {{SQL_TEXT = sql}},
     })
-    assert_eq(#result.calls, 1, "no row-count lookup should fire for single-statement IMPORT")
+    assert_eq(#result.calls, 1, "no metadata lookup should fire when splitter and gate are both inactive on single-stmt IMPORTs")
     local row = find_import_row(result.rows, "DST.MED_T")
     assert(row, "IMPORT row missing")
     assert_eq(row[6], sql)
@@ -667,6 +669,209 @@ test("gate applies per-table within one migration with one lookup", function()
     assert_eq(small_count, 1, "SMALL_T should be rewritten to 1 statement")
     assert_eq(big_count, 4, "BIG_T should retain 4 statements")
     assert_eq(med_count, 1, "MED_T single-stmt unchanged")
+end)
+
+print("")
+print("=== PARALLEL_SPLIT Dispatcher Tests ===")
+
+local function count_clauses(sql)
+    local _, n = string.gsub(sql, "STATEMENT '", "STATEMENT '")
+    return n
+end
+
+test("splitter expands single-statement IMPORT on numeric PK (PK_RANGE)", function()
+    local sql = single_stmt_import("DST", "ORDERS", "PUBLIC", "orders")
+    local result = run_migrate({
+        source_type = "POSTGRES",
+        target_schema = "DST",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=4;PARALLEL_SPLIT=AUTO",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "PUBLIC", SRC_TABLE = "orders", SRC_ROWS = 20000000, SRC_PK_COL = "ORDER_ID", SRC_PK_TYPE = "int8"}},
+    })
+    local row = find_import_row(result.rows, "DST.ORDERS")
+    assert(row, "IMPORT row missing")
+    assert_eq(count_clauses(row[6]), 4, "expected 4 STATEMENT clauses; got " .. count_clauses(row[6]))
+    assert_contains(row[6], 'MOD("ORDER_ID", 4) = 0')
+    assert_contains(row[6], 'MOD("ORDER_ID", 4) = 3')
+    assert_contains(row[6], '"PUBLIC"."orders"')
+    assert_contains(row[6], '"DST"."ORDERS"')
+end)
+
+test("splitter expands single-statement IMPORT on date column (DATE_BUCKET, quarter)", function()
+    local sql = single_stmt_import("DST", "EVENTS", "SMOKE", "EVENTS")
+    local result = run_migrate({
+        source_type = "POSTGRES",
+        target_schema = "DST",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=4;PARALLEL_SPLIT=AUTO",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "SMOKE", SRC_TABLE = "EVENTS", SRC_ROWS = 20000000, SRC_DATE_COL = "EVENT_DT"}},
+    })
+    local row = find_import_row(result.rows, "DST.EVENTS")
+    assert(row, "IMPORT row missing")
+    assert_eq(count_clauses(row[6]), 4)
+    assert_contains(row[6], 'EXTRACT(MONTH FROM "EVENT_DT") IN (1, 2, 3)')
+    assert_contains(row[6], 'EXTRACT(MONTH FROM "EVENT_DT") IN (10, 11, 12)')
+    assert_contains(row[6], '"EVENT_DT" IS NULL')
+end)
+
+test("splitter falls through to HASH_NUM when no PK + no date col", function()
+    local sql = single_stmt_import("DST", "SESSIONS", "SMOKE", "SESSIONS")
+    local result = run_migrate({
+        source_type = "POSTGRES",
+        target_schema = "DST",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=4;PARALLEL_SPLIT=AUTO",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "SMOKE", SRC_TABLE = "SESSIONS", SRC_ROWS = 20000000, SRC_NUM_COL = "CUSTOMER_ID"}},
+    })
+    local row = find_import_row(result.rows, "DST.SESSIONS")
+    assert_eq(count_clauses(row[6]), 4)
+    assert_contains(row[6], 'HASHTEXT("CUSTOMER_ID"')
+end)
+
+test("splitter picks ROWID when no PK/date/num and source supports it", function()
+    local sql = single_stmt_import("DST", "HEAP_T", "SMOKE", "HEAP_T")
+    local result = run_migrate({
+        source_type = "POSTGRES",
+        target_schema = "DST",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=4;PARALLEL_SPLIT=AUTO",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "SMOKE", SRC_TABLE = "HEAP_T", SRC_ROWS = 20000000}},
+    })
+    local row = find_import_row(result.rows, "DST.HEAP_T")
+    assert_eq(count_clauses(row[6]), 4)
+    assert_contains(row[6], 'HASHTEXT(ctid::text)')
+end)
+
+test("splitter falls back to SINGLE + INFO row when no usable column (no ROWID support)", function()
+    local sql = single_stmt_import("DST", "MYSTERY_T", "SMOKE", "MYSTERY_T")
+    local result = run_migrate({
+        source_type = "SNOWFLAKE",
+        target_schema = "DST",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=4;PARALLEL_SPLIT=AUTO",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "SMOKE", SRC_TABLE = "MYSTERY_T", SRC_ROWS = 20000000}},
+    })
+    local row = find_import_row(result.rows, "DST.MYSTERY_T")
+    assert_eq(count_clauses(row[6]), 1, "IMPORT must remain single-statement when no split column")
+    assert_eq(row[6], sql)
+    local info_found = false
+    for i = 1, #result.rows do
+        if result.rows[i][1] == "INFO" and tostring(result.rows[i][6]):find("SMOKE.MYSTERY_T", 1, true) then
+            info_found = true
+            break
+        end
+    end
+    assert(info_found, "expected INFO row noting splitter SINGLE fallback")
+end)
+
+test("splitter ignores single-stmt IMPORT below threshold", function()
+    local sql = single_stmt_import("DST", "SMALL_T", "SMOKE", "SMALL_T")
+    local result = run_migrate({
+        source_type = "POSTGRES",
+        target_schema = "DST",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=4;PARALLEL_SPLIT=AUTO",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "SMOKE", SRC_TABLE = "SMALL_T", SRC_ROWS = 500000, SRC_PK_COL = "ID", SRC_PK_TYPE = "int8"}},
+    })
+    local row = find_import_row(result.rows, "DST.SMALL_T")
+    assert_eq(count_clauses(row[6]), 1, "below-threshold IMPORT must stay single-statement")
+    assert_eq(row[6], sql)
+end)
+
+test("splitter leaves multi-statement IMPORTs unchanged (pass-through)", function()
+    local sql = multi_stmt_import("DST", "BIG_T", "SMOKE", "BIG_T", 4)
+    local result = run_migrate({
+        source_type = "ORACLE",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=4;PARALLEL_SPLIT=AUTO",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "SMOKE", SRC_TABLE = "BIG_T", SRC_ROWS = 20000000, SRC_PK_COL = "ID", SRC_PK_TYPE = "NUMBER"}},
+    })
+    local row = find_import_row(result.rows, "DST.BIG_T")
+    assert_eq(count_clauses(row[6]), 4, "multi-stmt IMPORT must retain its 4 STATEMENT clauses")
+end)
+
+test("PARALLEL_SPLIT=OFF disables splitter despite usable metadata", function()
+    local sql = single_stmt_import("DST", "ORDERS", "PUBLIC", "orders")
+    local result = run_migrate({
+        source_type = "POSTGRES",
+        target_schema = "DST",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=4;PARALLEL_SPLIT=OFF",
+        adapter_rows = {{SQL_TEXT = sql}},
+    })
+    assert_eq(#result.calls, 1, "no metadata lookup should fire when PARALLEL_SPLIT=OFF and no multi-stmt IMPORTs")
+    local row = find_import_row(result.rows, "DST.ORDERS")
+    assert_eq(row[6], sql)
+end)
+
+test("PARALLEL_SPLIT=DATE:col:grain forces named column and grain", function()
+    local sql = single_stmt_import("DST", "EVENTS", "SMOKE", "EVENTS")
+    local result = run_migrate({
+        source_type = "POSTGRES",
+        target_schema = "DST",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=4;PARALLEL_SPLIT=DATE:CREATED_AT:QUARTER",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "SMOKE", SRC_TABLE = "EVENTS", SRC_ROWS = 20000000, SRC_PK_COL = "EVENT_ID", SRC_PK_TYPE = "int8", SRC_DATE_COL = "EVENT_DT"}},
+    })
+    local row = find_import_row(result.rows, "DST.EVENTS")
+    assert_eq(count_clauses(row[6]), 4)
+    assert_contains(row[6], 'EXTRACT(MONTH FROM "CREATED_AT")')
+    assert(not row[6]:find('EVENT_DT'), "named override must not consult cache.src_date_col")
+    assert(not row[6]:find('EVENT_ID'), "named override must not consult cache.src_pk_col")
+end)
+
+test("PARALLEL_SPLIT=HASH:col forces named column", function()
+    local sql = single_stmt_import("DST", "SESSIONS", "SMOKE", "SESSIONS")
+    local result = run_migrate({
+        source_type = "POSTGRES",
+        target_schema = "DST",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=4;PARALLEL_SPLIT=HASH:CUSTOMER_ID",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "SMOKE", SRC_TABLE = "SESSIONS", SRC_ROWS = 20000000, SRC_PK_COL = "SESSION_ID", SRC_PK_TYPE = "int8"}},
+    })
+    local row = find_import_row(result.rows, "DST.SESSIONS")
+    assert_eq(count_clauses(row[6]), 4)
+    assert_contains(row[6], 'HASHTEXT("CUSTOMER_ID"')
+end)
+
+test("splitter preserves IMPORT target + column list during rewrite", function()
+    local sql = 'IMPORT INTO "DST"."ORDERS" ("A","B","C") FROM JDBC AT SRC_CONN STATEMENT \'select "A","B","C" from "PUBLIC"."orders"\''
+    local result = run_migrate({
+        source_type = "POSTGRES",
+        target_schema = "DST",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=2;PARALLEL_SPLIT=AUTO",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "PUBLIC", SRC_TABLE = "orders", SRC_ROWS = 5000000, SRC_PK_COL = "A", SRC_PK_TYPE = "int8"}},
+    })
+    local row = find_import_row(result.rows, "DST.ORDERS")
+    assert_contains(row[6], 'IMPORT INTO "DST"."ORDERS" ("A","B","C")')
+    assert_contains(row[6], 'select "A","B","C" from "PUBLIC"."orders"')
+    assert_eq(count_clauses(row[6]), 2)
+end)
+
+test("metadata round-trip fires once for mixed single/multi-stmt IMPORTs", function()
+    local sql_multi = multi_stmt_import("DST", "BIG_T", "SMOKE", "BIG_T", 4)
+    local sql_single = single_stmt_import("DST", "ORDERS", "PUBLIC", "orders")
+    local result = run_migrate({
+        source_type = "POSTGRES",
+        target_schema = "DST",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=4;PARALLEL_SPLIT=AUTO",
+        adapter_rows = {{SQL_TEXT = sql_multi}, {SQL_TEXT = sql_single}},
+        gate_lookup_rows = {
+            {SRC_SCHEMA = "SMOKE", SRC_TABLE = "BIG_T", SRC_ROWS = 500},
+            {SRC_SCHEMA = "PUBLIC", SRC_TABLE = "orders", SRC_ROWS = 20000000, SRC_PK_COL = "ID", SRC_PK_TYPE = "int8"},
+        },
+    })
+    local lookup_count = 0
+    for i = 1, #result.calls do
+        if tostring(result.calls[i]):find("import into (src_schema", 1, true) then
+            lookup_count = lookup_count + 1
+        end
+    end
+    assert_eq(lookup_count, 1, "exactly one metadata round-trip across gate + splitter")
+    local multi_row = find_import_row(result.rows, "DST.BIG_T")
+    local single_row = find_import_row(result.rows, "DST.ORDERS")
+    assert_eq(count_clauses(multi_row[6]), 1, "below-threshold multi-stmt collapsed by gate")
+    assert_eq(count_clauses(single_row[6]), 4, "above-threshold single-stmt expanded by splitter")
 end)
 
 print("")

--- a/test/test_migrate_to_exasol.lua
+++ b/test/test_migrate_to_exasol.lua
@@ -66,10 +66,13 @@ local function run_migrate(params)
         string = string,
         table = table,
         math = math,
+        os = os,
         tostring = tostring,
         tonumber = tonumber,
         type = type,
         error = error,
+        ipairs = ipairs,
+        pairs = pairs,
     }
 
     env.pquery = function(sql)
@@ -88,7 +91,8 @@ local function run_migrate(params)
         if result and result.success == false then
             return false, {error_message = result.error_message or "execution failed"}
         end
-        return true, {rows_affected = 0}
+        local affected = (result and result.rows_affected) or 0
+        return true, {rows_affected = affected}
     end
 
     local fn, err = load(migrate_lua, "migrate_to_exasol.lua", "t", env)
@@ -102,6 +106,8 @@ local function run_migrate(params)
         adapter_sql = calls[1],
     }
 end
+
+local AUDIT_COLUMNS = "STEP_KIND VARCHAR(40), TARGET_OBJ VARCHAR(2000), ROWS_AFFECTED DECIMAL(18,0), ELAPSED_MS DECIMAL(18,0), RESULT_FLAG VARCHAR(20), SQL_TEXT VARCHAR(2000000), ERROR_MESSAGE VARCHAR(20000)"
 
 local function default_case(source_type, expected_sql)
     test("dispatches " .. source_type, function()
@@ -117,9 +123,12 @@ local function default_case(source_type, expected_sql)
             options = "",
         })
         assert_eq(result.adapter_sql, expected_sql)
-        assert_eq(result.rows[1][1], "select 1")
-        assert_eq(result.rows[1][2], "PREVIEW")
-        assert_eq(result.columns, "SQL_TEXT VARCHAR(2000000), SUCCESS VARCHAR(10), ERROR_MESSAGE VARCHAR(20000)")
+        assert_eq(result.rows[1][1], "OTHER")
+        assert_eq(result.rows[1][5], "PREVIEW")
+        assert_eq(result.rows[1][6], "select 1")
+        assert_eq(result.rows[2][1], "SUMMARY")
+        assert_eq(result.rows[2][5], "PREVIEW")
+        assert_eq(result.columns, AUDIT_COLUMNS)
     end)
 end
 
@@ -248,9 +257,12 @@ test("DEBUG false runs generated statements for non-native adapters", function()
 
     assert_eq(#result.calls, 2)
     assert_eq(result.calls[2], "create table t(c int)")
-    assert_eq(result.rows[1][1], "-- The following statements were executed successfully.")
-    assert_eq(result.rows[2][2], "SKIPPED")
-    assert_eq(result.rows[3][2], "TRUE")
+    assert_eq(result.rows[1][1], "INFO")
+    assert_eq(result.rows[1][5], "SKIPPED")
+    assert_eq(result.rows[2][1], "CREATE_TABLE")
+    assert_eq(result.rows[2][5], "OK")
+    assert_eq(result.rows[3][1], "SUMMARY")
+    assert_eq(result.rows[3][5], "OK")
 end)
 
 test("DEBUG false runs Snowflake generated statements", function()
@@ -264,8 +276,10 @@ test("DEBUG false runs Snowflake generated statements", function()
 
     assert_eq(#result.calls, 2)
     assert_eq(result.calls[2], "create table t(c int)")
-    assert_eq(result.rows[1][1], "-- The following statements were executed successfully.")
-    assert_eq(result.rows[2][2], "TRUE")
+    assert_eq(result.rows[1][1], "CREATE_TABLE")
+    assert_eq(result.rows[1][5], "OK")
+    assert_eq(result.rows[2][1], "SUMMARY")
+    assert_eq(result.rows[2][5], "OK")
 end)
 
 test("DEBUG false reports no executable generated statements", function()
@@ -279,9 +293,13 @@ test("DEBUG false reports no executable generated statements", function()
     })
 
     assert_eq(#result.calls, 1)
-    assert_eq(result.rows[1][1], "-- No executable SQL statements were generated.")
-    assert_eq(result.rows[2][2], "SKIPPED")
-    assert_eq(result.rows[3][2], "SKIPPED")
+    assert_eq(result.rows[1][1], "INFO")
+    assert_eq(result.rows[1][5], "SKIPPED")
+    assert_eq(result.rows[2][1], "INFO")
+    assert_eq(result.rows[2][5], "SKIPPED")
+    assert_eq(result.rows[3][1], "SUMMARY")
+    assert_eq(result.rows[3][2], "No executable SQL generated")
+    assert_eq(result.rows[3][5], "SKIPPED")
 end)
 
 test("DEBUG false reports empty adapter output", function()
@@ -293,8 +311,61 @@ test("DEBUG false reports empty adapter output", function()
 
     assert_eq(#result.calls, 1)
     assert_eq(#result.rows, 1)
-    assert_eq(result.rows[1][1], "-- No executable SQL statements were generated.")
-    assert_eq(result.rows[1][2], "SKIPPED")
+    assert_eq(result.rows[1][1], "SUMMARY")
+    assert_eq(result.rows[1][2], "No executable SQL generated")
+    assert_eq(result.rows[1][5], "SKIPPED")
+end)
+
+test("STEP_KIND classifies CREATE_SCHEMA / CREATE_TABLE / IMPORT", function()
+    local result = run_migrate({
+        source_type = "MYSQL",
+        debug = false,
+        adapter_rows = {
+            {SQL_TEXT = 'create schema if not exists "MART"'},
+            {SQL_TEXT = 'create or replace table "MART"."ORDERS" ("ID" DECIMAL(18,0))'},
+            {SQL_TEXT = 'import into "MART"."ORDERS" from jdbc at SRC_CONN statement \'select id from orders\''},
+        },
+    })
+
+    assert_eq(result.rows[1][1], "CREATE_SCHEMA")
+    assert_eq(result.rows[1][2], "MART")
+    assert_eq(result.rows[2][1], "CREATE_TABLE")
+    assert_eq(result.rows[2][2], "MART.ORDERS")
+    assert_eq(result.rows[3][1], "IMPORT")
+    assert_eq(result.rows[3][2], "MART.ORDERS")
+    assert_eq(result.rows[4][1], "SUMMARY")
+end)
+
+test("ROWS_AFFECTED captured for IMPORT in execute mode", function()
+    local result = run_migrate({
+        source_type = "MYSQL",
+        debug = false,
+        adapter_rows = {
+            {SQL_TEXT = 'import into "M"."T" from jdbc at SRC statement \'select 1\''},
+        },
+        execute_results = {[1] = {success = true, rows_affected = 42}},
+    })
+
+    assert_eq(result.rows[1][1], "IMPORT")
+    assert_eq(result.rows[1][3], 42)
+    assert_eq(result.rows[2][1], "SUMMARY")
+    assert_eq(result.rows[2][3], 42)
+end)
+
+test("Errors mark RESULT_FLAG ERROR and SUMMARY ERROR", function()
+    local result = run_migrate({
+        source_type = "MYSQL",
+        debug = false,
+        adapter_rows = {
+            {SQL_TEXT = 'create table "T" ("c" INT)'},
+        },
+        execute_results = {[1] = {success = false, error_message = "boom"}},
+    })
+
+    assert_eq(result.rows[1][5], "ERROR")
+    assert_eq(result.rows[1][7], "boom")
+    assert_eq(result.rows[2][1], "SUMMARY")
+    assert_eq(result.rows[2][5], "ERROR")
 end)
 
 print("")

--- a/test/test_migrate_to_exasol.lua
+++ b/test/test_migrate_to_exasol.lua
@@ -75,6 +75,7 @@ local function run_migrate(params)
         pairs = pairs,
     }
 
+    local execute_call_index = 0
     env.pquery = function(sql)
         calls[#calls + 1] = sql
         if #calls == 1 then
@@ -87,7 +88,15 @@ local function run_migrate(params)
             return true, adapter_rows
         end
 
-        local result = execute_results[#calls - 1]
+        if sql:find("import into (src_schema", 1, true) then
+            if params.gate_lookup_error then
+                return false, {error_message = params.gate_lookup_error}
+            end
+            return true, params.gate_lookup_rows or {}
+        end
+
+        execute_call_index = execute_call_index + 1
+        local result = execute_results[execute_call_index]
         if result and result.success == false then
             return false, {error_message = result.error_message or "execution failed"}
         end
@@ -427,6 +436,237 @@ test("adapter errors include source statement", function()
     assert_eq(ok, false)
     assert_contains(err, "adapter failed")
     assert_contains(err, "MYSQL_TO_EXASOL")
+end)
+
+print("")
+print("=== PARALLEL_ROW_THRESHOLD Gate Tests ===")
+
+local function multi_stmt_import(target_schema, target_table, src_schema, src_table, n)
+    local s = 'IMPORT INTO "' .. target_schema .. '"."' .. target_table
+        .. '" ("ID") FROM JDBC AT SRC_CONN'
+    for i = 1, n do
+        s = s .. " STATEMENT 'select \"ID\" from \"" .. src_schema .. '"."' .. src_table
+            .. "\" where mod(\"ID\"," .. n .. ")=" .. (i - 1) .. "'"
+    end
+    return s
+end
+
+local function single_stmt_import(target_schema, target_table, src_schema, src_table)
+    return 'IMPORT INTO "' .. target_schema .. '"."' .. target_table
+        .. '" ("ID") FROM JDBC AT SRC_CONN STATEMENT \'select "ID" from "'
+        .. src_schema .. '"."' .. src_table .. '"\''
+end
+
+local function find_import_row(rows, target)
+    for i = 1, #rows do
+        if rows[i][1] == "IMPORT" and rows[i][2] == target then
+            return rows[i]
+        end
+    end
+    return nil
+end
+
+test("gate rewrites multi-statement IMPORT below threshold", function()
+    local sql = multi_stmt_import("DST", "SMALL_T", "SMOKE", "SMALL_T", 4)
+    local result = run_migrate({
+        source_type = "ORACLE",
+        schema_filter = "SMOKE",
+        table_filter = "SMALL_T",
+        options = "PARALLEL_STATEMENTS=4;PARALLEL_ROW_THRESHOLD=1000000",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "SMOKE", SRC_TABLE = "SMALL_T", SRC_ROWS = 500000}},
+    })
+    assert_eq(#result.calls, 2)
+    local row = find_import_row(result.rows, "DST.SMALL_T")
+    assert(row, "IMPORT row missing")
+    local _, count = string.gsub(row[6], "STATEMENT '", "STATEMENT '")
+    assert_eq(count, 1, "expected exactly one STATEMENT clause after rewrite, got " .. count)
+    assert_contains(row[6], '"DST"."SMALL_T"')
+    assert_contains(row[6], '"SMOKE"."SMALL_T"')
+end)
+
+test("gate keeps multi-statement IMPORT at or above threshold", function()
+    local sql = multi_stmt_import("DST", "BIG_T", "SMOKE", "BIG_T", 4)
+    local result = run_migrate({
+        source_type = "ORACLE",
+        options = "PARALLEL_STATEMENTS=4;PARALLEL_ROW_THRESHOLD=1000000",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "SMOKE", SRC_TABLE = "BIG_T", SRC_ROWS = 5000000}},
+    })
+    local row = find_import_row(result.rows, "DST.BIG_T")
+    assert(row, "IMPORT row missing")
+    local _, count = string.gsub(row[6], "STATEMENT '", "STATEMENT '")
+    assert_eq(count, 4, "expected all four STATEMENT clauses preserved, got " .. count)
+end)
+
+test("gate leaves single-statement IMPORT untouched", function()
+    local sql = single_stmt_import("DST", "MED_T", "SMOKE", "MED_T")
+    local result = run_migrate({
+        source_type = "ORACLE",
+        options = "PARALLEL_ROW_THRESHOLD=1000000",
+        adapter_rows = {{SQL_TEXT = sql}},
+    })
+    assert_eq(#result.calls, 1, "no row-count lookup should fire for single-statement IMPORT")
+    local row = find_import_row(result.rows, "DST.MED_T")
+    assert(row, "IMPORT row missing")
+    assert_eq(row[6], sql)
+end)
+
+test("gate treats NULL num_rows as below threshold", function()
+    local sql = multi_stmt_import("DST", "NO_STATS", "SMOKE", "NO_STATS", 4)
+    local result = run_migrate({
+        source_type = "ORACLE",
+        options = "PARALLEL_ROW_THRESHOLD=1000000",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "SMOKE", SRC_TABLE = "NO_STATS", SRC_ROWS = nil}},
+    })
+    local row = find_import_row(result.rows, "DST.NO_STATS")
+    assert(row, "IMPORT row missing")
+    local _, count = string.gsub(row[6], "STATEMENT '", "STATEMENT '")
+    assert_eq(count, 1, "NULL row count should be treated as below threshold; got " .. count)
+end)
+
+test("gate disabled by PARALLEL_ROW_THRESHOLD=0", function()
+    local sql_multi = multi_stmt_import("DST", "SMALL_T", "SMOKE", "SMALL_T", 4)
+    local sql_single = single_stmt_import("DST", "MED_T", "SMOKE", "MED_T")
+    local result = run_migrate({
+        source_type = "ORACLE",
+        options = "PARALLEL_ROW_THRESHOLD=0",
+        adapter_rows = {{SQL_TEXT = sql_multi}, {SQL_TEXT = sql_single}},
+    })
+    assert_eq(#result.calls, 1, "PARALLEL_ROW_THRESHOLD=0 must issue no row-count lookup")
+    local row = find_import_row(result.rows, "DST.SMALL_T")
+    assert(row, "multi-stmt IMPORT row missing")
+    local _, count = string.gsub(row[6], "STATEMENT '", "STATEMENT '")
+    assert_eq(count, 4, "all clauses preserved under threshold=0")
+end)
+
+test("gate default threshold is 1000000", function()
+    local sql = multi_stmt_import("DST", "T", "SMOKE", "T", 4)
+    local result = run_migrate({
+        source_type = "ORACLE",
+        options = "",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "SMOKE", SRC_TABLE = "T", SRC_ROWS = 999999}},
+    })
+    local row = find_import_row(result.rows, "DST.T")
+    local _, count = string.gsub(row[6], "STATEMENT '", "STATEMENT '")
+    assert_eq(count, 1, "default threshold 1000000 should rewrite 999999-row table; got " .. count)
+end)
+
+test("gate soft-fails on row-count lookup error", function()
+    local sql = multi_stmt_import("DST", "T", "SMOKE", "T", 4)
+    local result = run_migrate({
+        source_type = "ORACLE",
+        options = "PARALLEL_ROW_THRESHOLD=1000000",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_error = "ORA-00942: table or view does not exist",
+    })
+    local row = find_import_row(result.rows, "DST.T")
+    local _, count = string.gsub(row[6], "STATEMENT '", "STATEMENT '")
+    assert_eq(count, 4, "soft-fail must leave all statement clauses intact")
+    local info_found = false
+    for i = 1, #result.rows do
+        if result.rows[i][1] == "INFO" and tostring(result.rows[i][6]):find("gate skipped", 1, true) then
+            info_found = true
+            break
+        end
+    end
+    assert(info_found, "expected INFO row noting gate skip on lookup error")
+end)
+
+test("gate skips lookup when adapter emits no IMPORTs", function()
+    local result = run_migrate({
+        source_type = "ORACLE",
+        options = "PARALLEL_ROW_THRESHOLD=1000000",
+        adapter_rows = {
+            {SQL_TEXT = 'create schema if not exists "DST"'},
+            {SQL_TEXT = 'create or replace table "DST"."T" ("ID" DECIMAL(18,0))'},
+        },
+    })
+    assert_eq(#result.calls, 1, "no IMPORTs -> no lookup")
+end)
+
+test("gate skips unsupported source type with INFO row", function()
+    local sql = multi_stmt_import("DST", "T", "SMOKE", "T", 4)
+    local result = run_migrate({
+        source_type = "EXASOL",
+        options = "PARALLEL_ROW_THRESHOLD=1000000",
+        adapter_rows = {{SQL_TEXT = sql}},
+    })
+    assert_eq(#result.calls, 1, "unsupported source must not issue lookup")
+    local row = find_import_row(result.rows, "DST.T")
+    local _, count = string.gsub(row[6], "STATEMENT '", "STATEMENT '")
+    assert_eq(count, 4, "IMPORT preserved when gate not configured")
+    local info_found = false
+    for i = 1, #result.rows do
+        if result.rows[i][1] == "INFO" and tostring(result.rows[i][6]):find("no row-count SQL configured", 1, true) then
+            info_found = true
+            break
+        end
+    end
+    assert(info_found, "expected INFO row noting unconfigured source")
+end)
+
+test("gate keys lookup on source schema parsed from inner SELECT", function()
+    local sql = 'IMPORT INTO "DST"."ORDERS" ("ID") FROM JDBC AT SRC_CONN'
+        .. " STATEMENT 'select \"ID\" from \"PUBLIC\".\"orders\" where mod(\"ID\",2)=0'"
+        .. " STATEMENT 'select \"ID\" from \"PUBLIC\".\"orders\" where mod(\"ID\",2)=1'"
+    local lookup_sql_seen = nil
+    local result = run_migrate({
+        source_type = "POSTGRES",
+        target_schema = "DST",
+        options = "PARALLEL_ROW_THRESHOLD=1000000",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "PUBLIC", SRC_TABLE = "orders", SRC_ROWS = 100}},
+    })
+    for i = 1, #result.calls do
+        if tostring(result.calls[i]):find("import into (src_schema", 1, true) then
+            lookup_sql_seen = result.calls[i]
+        end
+    end
+    assert(lookup_sql_seen, "row-count lookup SQL not seen")
+    assert_contains(lookup_sql_seen, "PUBLIC")
+    assert_contains(lookup_sql_seen, "orders")
+    assert(not lookup_sql_seen:find("\"DST\"", 1, true), "lookup must NOT key on target schema DST")
+    local row = find_import_row(result.rows, "DST.ORDERS")
+    local _, count = string.gsub(row[6], "STATEMENT '", "STATEMENT '")
+    assert_eq(count, 1, "below-threshold IMPORT must be rewritten to single statement")
+end)
+
+test("gate applies per-table within one migration with one lookup", function()
+    local sql_small = multi_stmt_import("DST", "SMALL_T", "SMOKE", "SMALL_T", 4)
+    local sql_big = multi_stmt_import("DST", "BIG_T", "SMOKE", "BIG_T", 4)
+    local sql_med = single_stmt_import("DST", "MED_T", "SMOKE", "MED_T")
+    local result = run_migrate({
+        source_type = "ORACLE",
+        options = "PARALLEL_ROW_THRESHOLD=1000000",
+        adapter_rows = {
+            {SQL_TEXT = sql_small},
+            {SQL_TEXT = sql_big},
+            {SQL_TEXT = sql_med},
+        },
+        gate_lookup_rows = {
+            {SRC_SCHEMA = "SMOKE", SRC_TABLE = "SMALL_T", SRC_ROWS = 500},
+            {SRC_SCHEMA = "SMOKE", SRC_TABLE = "BIG_T", SRC_ROWS = 5000000},
+        },
+    })
+    local lookup_count = 0
+    for i = 1, #result.calls do
+        if tostring(result.calls[i]):find("import into (src_schema", 1, true) then
+            lookup_count = lookup_count + 1
+        end
+    end
+    assert_eq(lookup_count, 1, "exactly one row-count lookup per migration")
+    local small = find_import_row(result.rows, "DST.SMALL_T")
+    local big = find_import_row(result.rows, "DST.BIG_T")
+    local med = find_import_row(result.rows, "DST.MED_T")
+    local _, small_count = string.gsub(small[6], "STATEMENT '", "STATEMENT '")
+    local _, big_count = string.gsub(big[6], "STATEMENT '", "STATEMENT '")
+    local _, med_count = string.gsub(med[6], "STATEMENT '", "STATEMENT '")
+    assert_eq(small_count, 1, "SMALL_T should be rewritten to 1 statement")
+    assert_eq(big_count, 4, "BIG_T should retain 4 statements")
+    assert_eq(med_count, 1, "MED_T single-stmt unchanged")
 end)
 
 print("")

--- a/test/test_migrate_to_exasol.lua
+++ b/test/test_migrate_to_exasol.lua
@@ -1077,6 +1077,207 @@ test("per-IMPORT AUTO resolution differs across one migration", function()
 end)
 
 print("")
+print("=== Phase 4 spec-coverage tests ===")
+
+test("PARALLEL_SPLIT=ROWID on unsupported source falls back to SINGLE + INFO", function()
+    local sql = single_stmt_import("DST", "HEAP_T", "SMOKE", "HEAP_T")
+    local result = run_migrate({
+        source_type = "SNOWFLAKE",
+        target_schema = "DST",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=4;PARALLEL_SPLIT=ROWID",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "SMOKE", SRC_TABLE = "HEAP_T", SRC_ROWS = 20000000}},
+    })
+    local row = find_import_row(result.rows, "DST.HEAP_T")
+    assert_eq(row[6], sql, "forced ROWID on Snowflake must leave IMPORT untouched")
+    assert_eq(row[8], "SINGLE")
+    assert_eq(row[11], 1)
+    local info_found = false
+    for i = 1, #result.rows do
+        if result.rows[i][1] == "INFO" and tostring(result.rows[i][6]):find("ROWID unsupported", 1, true) then
+            info_found = true
+            break
+        end
+    end
+    assert(info_found, "expected INFO row noting ROWID unsupported for SNOWFLAKE")
+end)
+
+test("duplicate source tables collapse to one cache lookup pair", function()
+    local sql1 = single_stmt_import("DST", "ORDERS_A", "PUBLIC", "orders")
+    local sql2 = single_stmt_import("DST", "ORDERS_B", "PUBLIC", "orders")
+    local lookup_sql_seen = nil
+    local result = run_migrate({
+        source_type = "POSTGRES",
+        target_schema = "DST",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=4;PARALLEL_SPLIT=AUTO",
+        adapter_rows = {{SQL_TEXT = sql1}, {SQL_TEXT = sql2}},
+        gate_lookup_rows = {{SRC_SCHEMA = "PUBLIC", SRC_TABLE = "orders", SRC_ROWS = 20000000, SRC_PK_COL = "id", SRC_PK_TYPE = "int8"}},
+    })
+    for i = 1, #result.calls do
+        if tostring(result.calls[i]):find("import into (src_schema", 1, true) then
+            lookup_sql_seen = result.calls[i]
+        end
+    end
+    assert(lookup_sql_seen, "metadata lookup must fire")
+    -- The outer IMPORT-FROM-JDBC SQL wraps the inner metadata SQL in a single-
+    -- quoted literal, so every `'PUBLIC'` becomes `''PUBLIC''`. Count occurrences.
+    local _, pair_count = string.gsub(lookup_sql_seen, "c%.relname = ''orders''", "")
+    assert_eq(pair_count, 1, "duplicate source tables must appear exactly once in WHERE; got " .. pair_count)
+end)
+
+test("Databricks-style NULL src_rows leaves IMPORT single-stmt without raising", function()
+    local sql = single_stmt_import("DST", "EVENTS", "MAIN_DEFAULT", "EVENTS")
+    local result = run_migrate({
+        source_type = "DATABRICKS",
+        db_filter = "CAT",
+        schema_filter = "MAIN_DEFAULT",
+        table_filter = "EVENTS",
+        target_schema = "DST",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=AUTO",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "MAIN_DEFAULT", SRC_TABLE = "EVENTS", SRC_ROWS = nil}},
+    })
+    local row = find_import_row(result.rows, "DST.EVENTS")
+    assert_eq(row[6], sql)
+    assert_eq(row[8], "SINGLE")
+    assert_eq(row[11], 1)
+end)
+
+test("per-source metadata SQL switches by SOURCE_TYPE", function()
+    local pg_sql = single_stmt_import("DST", "ORDERS", "PUBLIC", "orders")
+    local pg_result = run_migrate({
+        source_type = "POSTGRES",
+        target_schema = "DST",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=4;PARALLEL_SPLIT=AUTO",
+        adapter_rows = {{SQL_TEXT = pg_sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "PUBLIC", SRC_TABLE = "orders", SRC_ROWS = 20000000, SRC_PK_COL = "id", SRC_PK_TYPE = "int8"}},
+    })
+    local pg_lookup = nil
+    for i = 1, #pg_result.calls do
+        if tostring(pg_result.calls[i]):find("import into (src_schema", 1, true) then
+            pg_lookup = pg_result.calls[i]
+        end
+    end
+    assert(pg_lookup, "PG lookup SQL not seen")
+    assert_contains(pg_lookup, "pg_class")
+    assert_contains(pg_lookup, "pg_namespace")
+
+    local my_sql = single_stmt_import("DST", "ORDERS", "MYDB", "orders")
+    local my_result = run_migrate({
+        source_type = "MYSQL",
+        target_schema = "DST",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=4;PARALLEL_SPLIT=AUTO",
+        adapter_rows = {{SQL_TEXT = my_sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "MYDB", SRC_TABLE = "orders", SRC_ROWS = 20000000, SRC_PK_COL = "id", SRC_PK_TYPE = "bigint"}},
+    })
+    local my_lookup = nil
+    for i = 1, #my_result.calls do
+        if tostring(my_result.calls[i]):find("import into (src_schema", 1, true) then
+            my_lookup = my_result.calls[i]
+        end
+    end
+    assert(my_lookup, "MySQL lookup SQL not seen")
+    assert_contains(my_lookup, "information_schema.tables")
+end)
+
+test("gate-collapsed multi-stmt IMPORT below threshold records SINGLE audit", function()
+    local sql = multi_stmt_import("DST", "SMALL_T", "SMOKE", "SMALL_T", 4)
+    local result = run_migrate({
+        source_type = "ORACLE",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=AUTO",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "SMOKE", SRC_TABLE = "SMALL_T", SRC_ROWS = 500}},
+    })
+    local row = find_import_row(result.rows, "DST.SMALL_T")
+    assert_eq(row[8], "SINGLE", "gate-collapsed must record SINGLE strategy")
+    assert_eq(row[9], NULL)
+    assert_eq(row[10], "AUTO")
+    assert_eq(row[11], 1)
+end)
+
+test("INFO rows carry NULL audit columns", function()
+    local sql = multi_stmt_import("DST", "T", "SMOKE", "T", 4)
+    local result = run_migrate({
+        source_type = "ORACLE",
+        options = "PARALLEL_ROW_THRESHOLD=1000000",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_error = "ORA-00942",
+    })
+    local info_count = 0
+    for i = 1, #result.rows do
+        if result.rows[i][1] == "INFO" then
+            info_count = info_count + 1
+            assert_eq(result.rows[i][8], NULL, "INFO row strategy must be NULL")
+            assert_eq(result.rows[i][9], NULL, "INFO row key must be NULL")
+            assert_eq(result.rows[i][10], NULL, "INFO row requested must be NULL")
+            assert_eq(result.rows[i][11], NULL, "INFO row effective must be NULL")
+        end
+    end
+    assert(info_count >= 1, "expected at least one INFO row from soft-fail")
+end)
+
+test("SUMMARY row carries NULL audit columns", function()
+    local result = run_migrate({
+        source_type = "MYSQL",
+        debug = true,
+        adapter_rows = {{SQL_TEXT = "select 1"}},
+    })
+    local summary = result.rows[#result.rows]
+    assert_eq(summary[1], "SUMMARY")
+    assert_eq(summary[8], NULL)
+    assert_eq(summary[9], NULL)
+    assert_eq(summary[10], NULL)
+    assert_eq(summary[11], NULL)
+end)
+
+test("every output row exposes 11 positional slots matching OUT_COLUMNS shape", function()
+    -- Lua's `#` is undefined for tables with trailing nil holes, so the
+    -- 11-tuple guarantee is instead asserted by reading slot 11 on every row
+    -- (must be either NULL or a non-nil audit value -- never index out of range).
+    local result = run_migrate({
+        source_type = "MYSQL",
+        debug = true,
+        adapter_rows = {
+            {SQL_TEXT = 'create schema if not exists "DST"'},
+            {SQL_TEXT = 'create or replace table "DST"."T" ("c" INT)'},
+            {SQL_TEXT = 'IMPORT INTO "DST"."T" ("c") FROM JDBC AT SRC STATEMENT \'select "c" from "S"."T"\''},
+        },
+    })
+    for i = 1, #result.rows do
+        local r = result.rows[i]
+        -- Slots 1..7 are always populated (STEP_KIND, TARGET_OBJ, etc.).
+        assert(r[1] ~= nil, "row " .. i .. " STEP_KIND slot must exist")
+        -- Slots 8..11 are NULL for non-IMPORT rows; for any row, accessing
+        -- slot 11 must not error and must equal NULL or a number.
+        local v11 = r[11]
+        if r[1] == "IMPORT" then
+            assert(v11 ~= nil, "IMPORT row " .. i .. " PARALLEL_EFFECTIVE must be populated")
+        else
+            assert_eq(v11, NULL, "non-IMPORT row " .. i .. " PARALLEL_EFFECTIVE must be NULL")
+        end
+    end
+    assert_contains(result.columns, "SPLIT_STRATEGY VARCHAR(32)")
+    assert_contains(result.columns, "SPLIT_KEY VARCHAR(256)")
+    assert_contains(result.columns, "PARALLEL_REQUESTED VARCHAR(16)")
+    assert_contains(result.columns, "PARALLEL_EFFECTIVE DECIMAL(4,0)")
+end)
+
+test("PARALLEL_REQUESTED records explicit integer literally", function()
+    local sql = single_stmt_import("DST", "BIG_T", "SMOKE", "BIG_T")
+    local result = run_migrate({
+        source_type = "POSTGRES",
+        target_schema = "DST",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=8",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "SMOKE", SRC_TABLE = "BIG_T", SRC_ROWS = 20000000, SRC_PK_COL = "id", SRC_PK_TYPE = "int8"}},
+    })
+    local row = find_import_row(result.rows, "DST.BIG_T")
+    assert_eq(row[10], "8", "PARALLEL_REQUESTED must be raw literal '8'")
+    assert_eq(row[11], 8)
+    assert_eq(count_clauses(row[6]), 8)
+end)
+
+print("")
 print(string.format("=== Results: %d passed, %d failed ===", passed, failed))
 
 if failed > 0 then

--- a/test/test_migrate_to_exasol.lua
+++ b/test/test_migrate_to_exasol.lua
@@ -118,7 +118,7 @@ local function run_migrate(params)
     }
 end
 
-local AUDIT_COLUMNS = "STEP_KIND VARCHAR(40), TARGET_OBJ VARCHAR(2000), ROWS_AFFECTED DECIMAL(18,0), ELAPSED_MS DECIMAL(18,0), RESULT_FLAG VARCHAR(20), SQL_TEXT VARCHAR(2000000), ERROR_MESSAGE VARCHAR(20000)"
+local AUDIT_COLUMNS = "STEP_KIND VARCHAR(40), TARGET_OBJ VARCHAR(2000), ROWS_AFFECTED DECIMAL(18,0), ELAPSED_MS DECIMAL(18,0), RESULT_FLAG VARCHAR(20), SQL_TEXT VARCHAR(2000000), ERROR_MESSAGE VARCHAR(20000), SPLIT_STRATEGY VARCHAR(32), SPLIT_KEY VARCHAR(256), PARALLEL_REQUESTED VARCHAR(16), PARALLEL_EFFECTIVE DECIMAL(4,0)"
 
 local function default_case(source_type, expected_sql)
     test("dispatches " .. source_type, function()
@@ -872,6 +872,208 @@ test("metadata round-trip fires once for mixed single/multi-stmt IMPORTs", funct
     local single_row = find_import_row(result.rows, "DST.ORDERS")
     assert_eq(count_clauses(multi_row[6]), 1, "below-threshold multi-stmt collapsed by gate")
     assert_eq(count_clauses(single_row[6]), 4, "above-threshold single-stmt expanded by splitter")
+end)
+
+print("")
+print("=== PARALLEL_AUTO_CEILING + Audit Tests ===")
+
+test("AUTO resolves to ceil(rows/5M) under default ceiling 12", function()
+    local sql = single_stmt_import("DST", "MID_T", "SMOKE", "MID_T")
+    local result = run_migrate({
+        source_type = "POSTGRES",
+        target_schema = "DST",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=AUTO",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "SMOKE", SRC_TABLE = "MID_T", SRC_ROWS = 20000000, SRC_PK_COL = "ID", SRC_PK_TYPE = "int8"}},
+    })
+    local row = find_import_row(result.rows, "DST.MID_T")
+    assert_eq(count_clauses(row[6]), 4, "20M rows / 5M = 4 stmts")
+    assert_eq(row[8], "PK_RANGE")
+    assert_eq(row[9], "ID")
+    assert_eq(row[10], "AUTO")
+    assert_eq(row[11], 4)
+end)
+
+test("AUTO caps at default ceiling 12 for large tables", function()
+    local sql = single_stmt_import("DST", "HUGE_T", "SMOKE", "HUGE_T")
+    local result = run_migrate({
+        source_type = "POSTGRES",
+        target_schema = "DST",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=AUTO",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "SMOKE", SRC_TABLE = "HUGE_T", SRC_ROWS = 100000000, SRC_PK_COL = "ID", SRC_PK_TYPE = "int8"}},
+    })
+    local row = find_import_row(result.rows, "DST.HUGE_T")
+    assert_eq(count_clauses(row[6]), 12, "100M rows -> capped at 12 stmts")
+    assert_eq(row[11], 12)
+end)
+
+test("PARALLEL_AUTO_CEILING=24 raises the AUTO cap", function()
+    local sql = single_stmt_import("DST", "HUGE_T", "SMOKE", "HUGE_T")
+    local result = run_migrate({
+        source_type = "POSTGRES",
+        target_schema = "DST",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=AUTO;PARALLEL_AUTO_CEILING=24",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "SMOKE", SRC_TABLE = "HUGE_T", SRC_ROWS = 100000000, SRC_PK_COL = "ID", SRC_PK_TYPE = "int8"}},
+    })
+    local row = find_import_row(result.rows, "DST.HUGE_T")
+    assert_eq(count_clauses(row[6]), 20, "100M / 5M = 20 stmts, under raised cap 24")
+    assert_eq(row[11], 20)
+end)
+
+test("explicit PARALLEL_STATEMENTS bypasses ceiling", function()
+    local sql = single_stmt_import("DST", "HUGE_T", "SMOKE", "HUGE_T")
+    local result = run_migrate({
+        source_type = "POSTGRES",
+        target_schema = "DST",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=24",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "SMOKE", SRC_TABLE = "HUGE_T", SRC_ROWS = 100000000, SRC_PK_COL = "ID", SRC_PK_TYPE = "int8"}},
+    })
+    local row = find_import_row(result.rows, "DST.HUGE_T")
+    assert_eq(count_clauses(row[6]), 24)
+    assert_eq(row[10], "24")
+    assert_eq(row[11], 24)
+end)
+
+test("AUTO with NULL src_rows resolves to 1", function()
+    local sql = single_stmt_import("DST", "UNK_T", "SMOKE", "UNK_T")
+    local result = run_migrate({
+        source_type = "POSTGRES",
+        target_schema = "DST",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=AUTO",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "SMOKE", SRC_TABLE = "UNK_T", SRC_ROWS = nil, SRC_PK_COL = "ID", SRC_PK_TYPE = "int8"}},
+    })
+    local row = find_import_row(result.rows, "DST.UNK_T")
+    assert_eq(row[6], sql, "NULL src_rows must leave IMPORT single-stmt")
+    assert_eq(row[8], "SINGLE")
+    assert_eq(row[11], 1)
+end)
+
+test("AUTO below threshold resolves to 1 and marks SINGLE", function()
+    local sql = single_stmt_import("DST", "SMALL_T", "SMOKE", "SMALL_T")
+    local result = run_migrate({
+        source_type = "POSTGRES",
+        target_schema = "DST",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=AUTO",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "SMOKE", SRC_TABLE = "SMALL_T", SRC_ROWS = 500000, SRC_PK_COL = "ID", SRC_PK_TYPE = "int8"}},
+    })
+    local row = find_import_row(result.rows, "DST.SMALL_T")
+    assert_eq(row[6], sql)
+    assert_eq(row[8], "SINGLE")
+    assert_eq(row[10], "AUTO")
+    assert_eq(row[11], 1)
+end)
+
+test("audit cols populated MULTI_PASSTHROUGH on adapter multi-stmt above threshold", function()
+    local sql = multi_stmt_import("DST", "BIG_T", "SMOKE", "BIG_T", 4)
+    local result = run_migrate({
+        source_type = "ORACLE",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=AUTO",
+        adapter_rows = {{SQL_TEXT = sql}},
+        gate_lookup_rows = {{SRC_SCHEMA = "SMOKE", SRC_TABLE = "BIG_T", SRC_ROWS = 20000000, SRC_PK_COL = "ID", SRC_PK_TYPE = "NUMBER"}},
+    })
+    local row = find_import_row(result.rows, "DST.BIG_T")
+    assert_eq(row[8], "MULTI_PASSTHROUGH")
+    assert_eq(row[11], 4)
+end)
+
+test("audit cols NULL for non-IMPORT rows", function()
+    local result = run_migrate({
+        source_type = "MYSQL",
+        debug = false,
+        adapter_rows = {
+            {SQL_TEXT = 'create schema if not exists "DST"'},
+            {SQL_TEXT = 'create or replace table "DST"."T" ("c" INT)'},
+        },
+    })
+    for i = 1, #result.rows do
+        local r = result.rows[i]
+        if r[1] ~= "IMPORT" then
+            assert_eq(r[8], NULL, "non-IMPORT row " .. r[1] .. " audit strategy must be NULL")
+            assert_eq(r[9], NULL, "non-IMPORT row " .. r[1] .. " audit key must be NULL")
+            assert_eq(r[10], NULL, "non-IMPORT row " .. r[1] .. " audit requested must be NULL")
+            assert_eq(r[11], NULL, "non-IMPORT row " .. r[1] .. " audit effective must be NULL")
+        end
+    end
+end)
+
+test("invalid PARALLEL_STATEMENTS raises before adapter SQL", function()
+    local ok, err = pcall(run_migrate, {
+        source_type = "MYSQL",
+        options = "PARALLEL_STATEMENTS=banana",
+    })
+    assert_eq(ok, false)
+    assert_contains(err, "Invalid PARALLEL_STATEMENTS")
+end)
+
+test("PARALLEL_STATEMENTS=0 raises", function()
+    local ok, err = pcall(run_migrate, {
+        source_type = "MYSQL",
+        options = "PARALLEL_STATEMENTS=0",
+    })
+    assert_eq(ok, false)
+    assert_contains(err, "Invalid PARALLEL_STATEMENTS")
+end)
+
+test("invalid PARALLEL_AUTO_CEILING raises", function()
+    local ok, err = pcall(run_migrate, {
+        source_type = "MYSQL",
+        options = "PARALLEL_AUTO_CEILING=many",
+    })
+    assert_eq(ok, false)
+    assert_contains(err, "Invalid PARALLEL_AUTO_CEILING")
+end)
+
+test("PARALLEL_AUTO_CEILING=0 raises", function()
+    local ok, err = pcall(run_migrate, {
+        source_type = "MYSQL",
+        options = "PARALLEL_AUTO_CEILING=0",
+    })
+    assert_eq(ok, false)
+    assert_contains(err, "Invalid PARALLEL_AUTO_CEILING")
+end)
+
+test("invalid PARALLEL_SPLIT raises", function()
+    local ok, err = pcall(run_migrate, {
+        source_type = "MYSQL",
+        options = "PARALLEL_SPLIT=NONSENSE",
+    })
+    assert_eq(ok, false)
+    assert_contains(err, "Invalid PARALLEL_SPLIT")
+end)
+
+test("per-IMPORT AUTO resolution differs across one migration", function()
+    local sql_small = single_stmt_import("DST", "SMALL_T", "SMOKE", "SMALL_T")
+    local sql_mid = single_stmt_import("DST", "MID_T", "SMOKE", "MID_T")
+    local sql_huge = single_stmt_import("DST", "HUGE_T", "SMOKE", "HUGE_T")
+    local result = run_migrate({
+        source_type = "POSTGRES",
+        target_schema = "DST",
+        options = "PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=AUTO",
+        adapter_rows = {
+            {SQL_TEXT = sql_small},
+            {SQL_TEXT = sql_mid},
+            {SQL_TEXT = sql_huge},
+        },
+        gate_lookup_rows = {
+            {SRC_SCHEMA = "SMOKE", SRC_TABLE = "SMALL_T", SRC_ROWS = 500000, SRC_PK_COL = "ID", SRC_PK_TYPE = "int8"},
+            {SRC_SCHEMA = "SMOKE", SRC_TABLE = "MID_T", SRC_ROWS = 20000000, SRC_PK_COL = "ID", SRC_PK_TYPE = "int8"},
+            {SRC_SCHEMA = "SMOKE", SRC_TABLE = "HUGE_T", SRC_ROWS = 100000000, SRC_PK_COL = "ID", SRC_PK_TYPE = "int8"},
+        },
+    })
+    local small = find_import_row(result.rows, "DST.SMALL_T")
+    local mid = find_import_row(result.rows, "DST.MID_T")
+    local huge = find_import_row(result.rows, "DST.HUGE_T")
+    assert_eq(small[11], 1)
+    assert_eq(mid[11], 4)
+    assert_eq(huge[11], 12)
+    assert_eq(small[10], "AUTO")
+    assert_eq(mid[10], "AUTO")
+    assert_eq(huge[10], "AUTO")
 end)
 
 print("")

--- a/test/test_migrate_to_exasol.lua
+++ b/test/test_migrate_to_exasol.lua
@@ -268,6 +268,35 @@ test("DEBUG false runs Snowflake generated statements", function()
     assert_eq(result.rows[2][2], "TRUE")
 end)
 
+test("DEBUG false reports no executable generated statements", function()
+    local result = run_migrate({
+        source_type = "MYSQL",
+        debug = false,
+        adapter_rows = {
+            {SQL_TEXT = "-- ### SCHEMAS ###"},
+            {SQL_TEXT = "-- ### TABLES ###"},
+        },
+    })
+
+    assert_eq(#result.calls, 1)
+    assert_eq(result.rows[1][1], "-- No executable SQL statements were generated.")
+    assert_eq(result.rows[2][2], "SKIPPED")
+    assert_eq(result.rows[3][2], "SKIPPED")
+end)
+
+test("DEBUG false reports empty adapter output", function()
+    local result = run_migrate({
+        source_type = "MYSQL",
+        debug = false,
+        adapter_rows = {},
+    })
+
+    assert_eq(#result.calls, 1)
+    assert_eq(#result.rows, 1)
+    assert_eq(result.rows[1][1], "-- No executable SQL statements were generated.")
+    assert_eq(result.rows[1][2], "SKIPPED")
+end)
+
 print("")
 print("=== Error Handling Tests ===")
 

--- a/test/test_migrate_to_exasol_runtime.py
+++ b/test/test_migrate_to_exasol_runtime.py
@@ -124,23 +124,33 @@ def main() -> int:
     for source, (script_name, _) in ADAPTERS.items():
         rows = conn.execute(wrapper_call(source, debug=True)).fetchall()
         assert rows, f"{source} preview returned no rows"
-        assert_contains(rows[0][0], f"MOCK {script_name}")
+        if rows[0][0] != "INFO":
+            raise AssertionError(f"{source} first row STEP_KIND expected INFO, got {rows[0][0]}")
+        assert_contains(rows[0][5], f"MOCK {script_name}")
+        if rows[-1][0] != "SUMMARY" or rows[-1][4] != "PREVIEW":
+            raise AssertionError(f"{source} missing SUMMARY/PREVIEW tail row: {rows[-1]}")
     print(f"preview_dispatch={len(ADAPTERS)}")
 
     for source in ("MYSQL", "SNOWFLAKE", "DATABRICKS", "ORACLE"):
         rows = conn.execute(wrapper_call(source, debug=False)).fetchall()
-        if rows[0][1] != "SKIPPED" or "executed successfully" not in rows[0][0]:
-            raise AssertionError(f"{source} did not report successful execution: {rows[0]}")
+        summary = rows[-1]
+        if summary[0] != "SUMMARY" or summary[4] != "OK":
+            raise AssertionError(f"{source} did not report SUMMARY/OK: {summary}")
         script_name = ADAPTERS[source][0]
         table_name = script_name.replace("_TO_EXASOL", "")
         count = conn.execute(f'select count(*) from "{target_schema}"."{table_name}"').fetchval()
         if count != 1:
             raise AssertionError(f"{source} expected 1 loaded row, got {count}")
+        kinds = {row[0] for row in rows}
+        for required in ("CREATE_SCHEMA", "CREATE_TABLE", "IMPORT", "SUMMARY"):
+            if required not in kinds:
+                raise AssertionError(f"{source} missing STEP_KIND={required}; got {kinds}")
     print("execute_representative=4")
 
     rows = conn.execute(wrapper_call("MYSQL", debug=False, table_filter="EMPTY")).fetchall()
-    if rows[0][0] != "-- No executable SQL statements were generated.":
-        raise AssertionError(f"Expected no-op summary, got {rows[0]}")
+    summary = rows[-1]
+    if summary[0] != "SUMMARY" or summary[1] != "No executable SQL generated" or summary[4] != "SKIPPED":
+        raise AssertionError(f"Expected no-op SUMMARY row, got {summary}")
     print("empty_execution=pass")
 
     try:
@@ -160,7 +170,9 @@ def main() -> int:
     print("s3_rejection=pass")
 
     rows = conn.execute(wrapper_call("DATABRICKS_SQL", debug=True)).fetchall()
-    assert_contains(rows[0][0], "MOCK DATABRICKS_TO_EXASOL")
+    assert_contains(rows[0][5], "MOCK DATABRICKS_TO_EXASOL")
+    if rows[-1][0] != "SUMMARY":
+        raise AssertionError(f"Alias dispatch missing SUMMARY: {rows[-1]}")
     print("alias_dispatch=pass")
     return 0
 

--- a/test/test_migrate_to_exasol_runtime.py
+++ b/test/test_migrate_to_exasol_runtime.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Runtime smoke test for MIGRATE_TO_EXASOL using local mock adapters.
+
+This test replaces scripts in DATABASE_MIGRATION on the target Exasol database.
+Run it only against a disposable local database.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import ssl
+import time
+from pathlib import Path
+
+import pyexasol
+
+
+REPO = Path(__file__).resolve().parents[1]
+
+ADAPTERS = {
+    "MYSQL": ("MYSQL_TO_EXASOL", "CONNECTION_NAME, IDENTIFIER_CASE_INSENSITIVE, SCHEMA_FILTER, TABLE_FILTER"),
+    "MARIADB": ("MARIADB_TO_EXASOL", "CONNECTION_NAME, IDENTIFIER_CASE_INSENSITIVE, SCHEMA_FILTER, TABLE_FILTER"),
+    "POSTGRES": ("POSTGRES_TO_EXASOL", "CONNECTION_NAME, IDENTIFIER_CASE_INSENSITIVE, SCHEMA_FILTER, TABLE_FILTER, TARGET_SCHEMA"),
+    "REDSHIFT": ("REDSHIFT_TO_EXASOL", "CONNECTION_NAME, IDENTIFIER_CASE_INSENSITIVE, SCHEMA_FILTER, TABLE_FILTER"),
+    "DB2": ("DB2_TO_EXASOL", "CONNECTION_NAME, IDENTIFIER_CASE_INSENSITIVE, SCHEMA_FILTER, TABLE_FILTER"),
+    "VERTICA": ("VERTICA_TO_EXASOL", "CONNECTION_NAME, IDENTIFIER_CASE_INSENSITIVE, SCHEMA_FILTER, TABLE_FILTER"),
+    "HANA": ("HANA_TO_EXASOL", "CONNECTION_NAME, IDENTIFIER_CASE_INSENSITIVE, SCHEMA_FILTER, TABLE_FILTER"),
+    "AZURE_SQL": ("AZURE_SQL_TO_EXASOL", "CONNECTION_NAME, SCHEMA_FILTER, TABLE_FILTER, IDENTIFIER_CASE_INSENSITIVE"),
+    "BIGQUERY": ("BIGQUERY_TO_EXASOL", "CONNECTION_NAME, IDENTIFIER_CASE_INSENSITIVE, PROJECT_ID, SCHEMA_FILTER, TABLE_FILTER"),
+    "DATABRICKS": ("DATABRICKS_TO_EXASOL", "CONNECTION_NAME, CATALOG2SCHEMA, CATALOG_FILTER, SCHEMA_FILTER, TARGET_SCHEMA, TABLE_FILTER, IDENTIFIER_CASE_INSENSITIVE"),
+    "SQLSERVER": ("SQLSERVER_TO_EXASOL", "CONNECTION_NAME, DB2SCHEMA, DB_FILTER, SCHEMA_FILTER, TARGET_SCHEMA, TABLE_FILTER, IDENTIFIER_CASE_INSENSITIVE"),
+    "SNOWFLAKE": ("SNOWFLAKE_TO_EXASOL", "CONNECTION_NAME, DB2SCHEMA, DB_FILTER, SCHEMA_FILTER, TARGET_SCHEMA, TABLE_FILTER, IDENTIFIER_CASE_INSENSITIVE"),
+    "ORACLE": ("ORACLE_TO_EXASOL", "CONNECTION_NAME, IDENTIFIER_CASE_INSENSITIVE, SCHEMA_FILTER, TABLE_FILTER, PARALLEL_STATEMENTS, CREATE_PK, CREATE_FK, CHECK_MIGRATION"),
+    "TERADATA": ("TERADATA_TO_EXASOL", "CONNECTION_NAME, IDENTIFIER_CASE_INSENSITIVE, SCHEMA_FILTER, TABLE_FILTER, CHECK_MIGRATION"),
+    "EXASOL": ("EXASOL_TO_EXASOL", "CONNECTION_NAME, CONNECTION_TYPE, IDENTIFIER_CASE_INSENSITIVE, SCHEMA_FILTER, TABLE_FILTER, GENERATE_VIEWS, VIEW_FILTER, PK_SETTING"),
+    "NETEZZA": ("NETEZZA_TO_EXASOL", "CONNECTION_NAME, DB_FILTER, SCHEMA_FILTER, TABLE_FILTER, IDENTIFIER_CASE_INSENSITIVE"),
+    "VECTORWISE": ("VECTORWISE_TO_EXASOL", "CONNECTION_NAME, IDENTIFIER_CASE_INSENSITIVE, TABLE_FILTER"),
+}
+
+
+def extract_create_script(path: Path, script_name: str) -> str:
+    content = path.read_text()
+    pattern = rf"create or replace script database_migration\.{script_name}\(.*?\n/\n"
+    match = re.search(pattern, content, flags=re.IGNORECASE | re.DOTALL)
+    if not match:
+        raise AssertionError(f"Could not extract {script_name} from {path}")
+    return match.group(0)
+
+
+def sql_string(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def connect() -> pyexasol.ExaConnection:
+    return pyexasol.connect(
+        dsn=os.environ.get("EXA_DSN", "localhost:8566"),
+        user=os.environ.get("EXA_USER", "sys"),
+        password=os.environ.get("EXA_PASSWORD", "exasol"),
+        encryption=os.environ.get("EXA_ENCRYPTION", "true").lower() != "false",
+        websocket_sslopt={"cert_reqs": ssl.CERT_NONE},
+    )
+
+
+def mock_adapter_sql(script_name: str, params: str, target_schema: str) -> str:
+    table_name = script_name.replace("_TO_EXASOL", "")
+    return f"""
+create or replace script database_migration.{script_name}({params}) returns table
+as
+if TABLE_FILTER == 'ADAPTER_FAIL' then
+    error('mock adapter failed')
+end
+
+if TABLE_FILTER == 'EMPTY' then
+    return {{
+        {{'-- MOCK {script_name} EMPTY'}}
+    }}, 'SQL_TEXT VARCHAR(2000000)'
+end
+
+return {{
+    {{'-- MOCK {script_name}'}},
+    {{'create schema if not exists "{target_schema}";'}},
+    {{'create or replace table "{target_schema}"."{table_name}"("C" DECIMAL(18,0));'}},
+    {{'insert into "{target_schema}"."{table_name}" values 1;'}}
+}}, 'SQL_TEXT VARCHAR(2000000)'
+/
+"""
+
+
+def wrapper_call(source: str, debug: bool, table_filter: str = "TBL") -> str:
+    return (
+        "execute script database_migration.MIGRATE_TO_EXASOL("
+        f"{sql_string(source)},"
+        "'MOCK_CONN',"
+        "'JDBC',"
+        "'DB',"
+        "'SCH',"
+        f"{sql_string(table_filter)},"
+        "'TARGET_SCHEMA',"
+        "TRUE,"
+        f"{'TRUE' if debug else 'FALSE'},"
+        "'PROJECT_ID=PROJECT;CATALOG2SCHEMA=true'"
+        ")"
+    )
+
+
+def assert_contains(text: str, expected: str) -> None:
+    if expected not in text:
+        raise AssertionError(f"Expected {expected!r} in {text!r}")
+
+
+def deploy_runtime_objects(conn: pyexasol.ExaConnection, target_schema: str) -> None:
+    conn.execute("create schema if not exists database_migration")
+    conn.execute(extract_create_script(REPO / "migrate_to_exasol.sql", "MIGRATE_TO_EXASOL"))
+    for script_name, params in ADAPTERS.values():
+        conn.execute(mock_adapter_sql(script_name, params, target_schema))
+
+
+def main() -> int:
+    target_schema = "MIGRATE_WRAPPER_RT_" + str(int(time.time()))
+    conn = connect()
+    deploy_runtime_objects(conn, target_schema)
+
+    for source, (script_name, _) in ADAPTERS.items():
+        rows = conn.execute(wrapper_call(source, debug=True)).fetchall()
+        assert rows, f"{source} preview returned no rows"
+        assert_contains(rows[0][0], f"MOCK {script_name}")
+    print(f"preview_dispatch={len(ADAPTERS)}")
+
+    for source in ("MYSQL", "SNOWFLAKE", "DATABRICKS", "ORACLE"):
+        rows = conn.execute(wrapper_call(source, debug=False)).fetchall()
+        if rows[0][1] != "SKIPPED" or "executed successfully" not in rows[0][0]:
+            raise AssertionError(f"{source} did not report successful execution: {rows[0]}")
+        script_name = ADAPTERS[source][0]
+        table_name = script_name.replace("_TO_EXASOL", "")
+        count = conn.execute(f'select count(*) from "{target_schema}"."{table_name}"').fetchval()
+        if count != 1:
+            raise AssertionError(f"{source} expected 1 loaded row, got {count}")
+    print("execute_representative=4")
+
+    rows = conn.execute(wrapper_call("MYSQL", debug=False, table_filter="EMPTY")).fetchall()
+    if rows[0][0] != "-- No executable SQL statements were generated.":
+        raise AssertionError(f"Expected no-op summary, got {rows[0]}")
+    print("empty_execution=pass")
+
+    try:
+        conn.execute(wrapper_call("MYSQL", debug=True, table_filter="ADAPTER_FAIL")).fetchall()
+        raise AssertionError("Adapter failure did not raise")
+    except Exception as exc:
+        message = str(exc)
+        assert_contains(message, "mock adapter failed")
+        assert_contains(message, "MYSQL_TO_EXASOL")
+    print("adapter_error=pass")
+
+    try:
+        conn.execute(wrapper_call("S3", debug=True)).fetchall()
+        raise AssertionError("S3 did not raise")
+    except Exception as exc:
+        assert_contains(str(exc), "S3 is not supported by MIGRATE_TO_EXASOL")
+    print("s3_rejection=pass")
+
+    rows = conn.execute(wrapper_call("DATABRICKS_SQL", debug=True)).fetchall()
+    assert_contains(rows[0][0], "MOCK DATABRICKS_TO_EXASOL")
+    print("alias_dispatch=pass")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_postgres_to_exasol.lua
+++ b/test/test_postgres_to_exasol.lua
@@ -90,6 +90,50 @@ test("quotes Postgres source identifiers in generated import", function()
     assert_contains(result.sql, "replace(\"table_name\", '\"', '\"\"')")
 end)
 
+local function run_postgres_with_dest_schema(dest_value, null_sentinel)
+    local calls = {}
+    local env = {
+        CONNECTION_NAME = "POSTGRES_CONNECTION",
+        IDENTIFIER_CASE_INSENSITIVE = true,
+        SCHEMA_FILTER = "%",
+        TABLE_FILTER = "smoke",
+        DEST_SCHEMA = dest_value,
+        null = null_sentinel,
+        string = string,
+        table = table,
+        tostring = tostring,
+        type = type,
+        error = error,
+    }
+    env.query = function(sql)
+        calls[#calls + 1] = sql
+        return {{SQL_TEXT = "-- ### SCHEMAS ###"}}
+    end
+    local fn, err = load(postgres_lua, "postgres_to_exasol.lua", "t", env)
+    assert(fn, "Lua load failed: " .. tostring(err))
+    local ok, perr = pcall(fn)
+    return {ok = ok, err = perr, sql = calls[1]}
+end
+
+test("treats Exasol null sentinel DEST_SCHEMA as no override", function()
+    local null_sentinel = {}  -- stand-in for Exasol null userdata
+    local r = run_postgres_with_dest_schema(null_sentinel, null_sentinel)
+    assert(r.ok, "adapter errored on null DEST_SCHEMA: " .. tostring(r.err))
+    assert_contains(r.sql, 'upper("table_schema")')
+end)
+
+test("treats nil DEST_SCHEMA as no override", function()
+    local r = run_postgres_with_dest_schema(nil, nil)
+    assert(r.ok, "adapter errored on nil DEST_SCHEMA: " .. tostring(r.err))
+    assert_contains(r.sql, 'upper("table_schema")')
+end)
+
+test("uses DEST_SCHEMA literal when provided", function()
+    local r = run_postgres_with_dest_schema("MY_DST", nil)
+    assert(r.ok, "adapter errored on valid DEST_SCHEMA: " .. tostring(r.err))
+    assert_contains(r.sql, "'MY_DST'")
+end)
+
 print("")
 print(string.format("=== Results: %d passed, %d failed ===", passed, failed))
 

--- a/test/test_postgres_to_exasol.lua
+++ b/test/test_postgres_to_exasol.lua
@@ -1,0 +1,98 @@
+--[[
+  Checks for postgres_to_exasol.sql.
+
+  Run: lua test/test_postgres_to_exasol.lua
+]]
+
+local passed = 0
+local failed = 0
+
+local function test(name, fn)
+    local ok, err = pcall(fn)
+    if ok then
+        passed = passed + 1
+        print("  PASS: " .. name)
+    else
+        failed = failed + 1
+        print("  FAIL: " .. name .. " -- " .. tostring(err))
+    end
+end
+
+local function assert_contains(actual, pattern, msg)
+    if not tostring(actual):find(pattern, 1, true) then
+        error((msg or "missing expected text") .. ": " .. pattern .. " in " .. tostring(actual))
+    end
+end
+
+local function read_file(path)
+    local f = io.open(path, "r")
+    assert(f, "Could not open " .. path)
+    local content = f:read("*a")
+    f:close()
+    return content
+end
+
+local function extract_lua_block(path)
+    local content = read_file(path)
+    local lua_block = content:match("%) RETURNS TABLE%s*\nAS\n(.-)\n/\n")
+    assert(lua_block, "Could not extract Lua block from " .. path)
+    return lua_block
+end
+
+local postgres_lua = extract_lua_block("postgres_to_exasol.sql")
+
+local function run_postgres()
+    local calls = {}
+    local env = {
+        CONNECTION_NAME = "POSTGRES_CONNECTION",
+        IDENTIFIER_CASE_INSENSITIVE = true,
+        SCHEMA_FILTER = "Public",
+        TABLE_FILTER = "Order",
+        DEST_SCHEMA = "DST",
+        string = string,
+        table = table,
+        tostring = tostring,
+        type = type,
+        error = error,
+    }
+
+    env.query = function(sql)
+        calls[#calls + 1] = sql
+        return {{SQL_TEXT = "-- ### SCHEMAS ###"}}
+    end
+
+    local fn, err = load(postgres_lua, "postgres_to_exasol.lua", "t", env)
+    assert(fn, "Lua load failed: " .. tostring(err))
+
+    local result_rows = fn()
+    return {
+        rows = result_rows,
+        sql = calls[1],
+        calls = calls,
+    }
+end
+
+print("=== Lua Syntax Validation ===")
+
+test("Lua block in postgres_to_exasol.sql has valid syntax", function()
+    local fn, err = load(postgres_lua)
+    assert(fn, "Lua syntax error in postgres_to_exasol.sql: " .. tostring(err))
+end)
+
+print("")
+print("=== Generation Tests ===")
+
+test("quotes Postgres source identifiers in generated import", function()
+    local result = run_postgres()
+
+    assert_contains(result.sql, "replace(\"column_name\", '\"', '\"\"')")
+    assert_contains(result.sql, "replace(\"table_schema\", '\"', '\"\"')")
+    assert_contains(result.sql, "replace(\"table_name\", '\"', '\"\"')")
+end)
+
+print("")
+print(string.format("=== Results: %d passed, %d failed ===", passed, failed))
+
+if failed > 0 then
+    os.exit(1)
+end

--- a/test/test_vertica_to_exasol.lua
+++ b/test/test_vertica_to_exasol.lua
@@ -1,0 +1,137 @@
+--[[
+  Checks for vertica_to_exasol.sql.
+
+  Run: lua test/test_vertica_to_exasol.lua
+]]
+
+local passed = 0
+local failed = 0
+
+local function test(name, fn)
+    local ok, err = pcall(fn)
+    if ok then
+        passed = passed + 1
+        print("  PASS: " .. name)
+    else
+        failed = failed + 1
+        print("  FAIL: " .. name .. " -- " .. tostring(err))
+    end
+end
+
+local function assert_contains(actual, pattern, msg)
+    if not tostring(actual):find(pattern, 1, true) then
+        error((msg or "missing expected text") .. ": " .. pattern .. " in " .. tostring(actual))
+    end
+end
+
+local function assert_not_contains(actual, pattern, msg)
+    if tostring(actual):find(pattern, 1, true) then
+        error((msg or "unexpected text") .. ": " .. pattern .. " in " .. tostring(actual))
+    end
+end
+
+local function read_file(path)
+    local f = io.open(path, "r")
+    assert(f, "Could not open " .. path)
+    local content = f:read("*a")
+    f:close()
+    return content
+end
+
+local function extract_lua_block(path)
+    local content = read_file(path)
+    local lua_block = content:match("%) RETURNS TABLE%s*\nAS\n(.-)\n/\n")
+    assert(lua_block, "Could not extract Lua block from " .. path)
+    return lua_block
+end
+
+local vertica_lua = extract_lua_block("vertica_to_exasol.sql")
+
+local function run_vertica(params)
+    local calls = {}
+    local rows = params.rows or {{SQL_TEXT = "-- ### SCHEMAS ###"}}
+
+    local env = {
+        CONNECTION_NAME = params.connection_name or "VERTICA_CONNECTION",
+        IDENTIFIER_CASE_INSENSITIVE = params.identifier_case_insensitive,
+        SCHEMA_FILTER = params.schema_filter or "%",
+        TABLE_FILTER = params.table_filter or "%",
+        string = string,
+        table = table,
+        tostring = tostring,
+        type = type,
+        error = error,
+    }
+
+    env.pquery = function(sql)
+        calls[#calls + 1] = sql
+        if params.metadata_error then
+            return false, {
+                error_message = params.metadata_error,
+                statement_text = sql,
+            }
+        end
+        return true, rows
+    end
+
+    local fn, err = load(vertica_lua, "vertica_to_exasol.lua", "t", env)
+    assert(fn, "Lua load failed: " .. tostring(err))
+
+    local result_rows = fn()
+    return {
+        rows = result_rows,
+        sql = calls[1],
+        calls = calls,
+    }
+end
+
+print("=== Lua Syntax Validation ===")
+
+test("Lua block in vertica_to_exasol.sql has valid syntax", function()
+    local fn, err = load(vertica_lua)
+    assert(fn, "Lua syntax error in vertica_to_exasol.sql: " .. tostring(err))
+end)
+
+print("")
+print("=== Generation Tests ===")
+
+test("maps Vertica TIMESTAMP to Exasol TIMESTAMP", function()
+    local result = run_vertica({})
+
+    assert_contains(result.sql, "when upper(data_type) = 'TIMESTAMP' then 'TIMESTAMP'")
+    assert_not_contains(result.sql, "when upper(data_type) = 'TIMESTAMP' then 'varchar(14)'")
+end)
+
+test("quotes Vertica source identifiers in generated import", function()
+    local result = run_vertica({})
+
+    assert_contains(result.sql, "replace(table_schema, '\"', '\"\"')")
+    assert_contains(result.sql, "replace(table_name, '\"', '\"\"')")
+    assert_contains(result.sql, "replace(column_name, '\"', '\"\"')")
+    assert_contains(result.sql, "source_column_name")
+    assert_contains(result.sql, "source_table_schema")
+    assert_contains(result.sql, "source_table_name")
+end)
+
+test("matches parameterized Vertica binary type names", function()
+    local result = run_vertica({})
+
+    assert_contains(result.sql, "when upper(data_type) LIKE 'BINARY%' then 'char('||(coalesce(character_maximum_length, data_type_length) * 2)||')'")
+    assert_contains(result.sql, "when upper(data_type) LIKE 'VARBINARY%' then 'varchar('||(coalesce(character_maximum_length, data_type_length) * 2)||')'")
+    assert_contains(result.sql, "when upper(data_type) LIKE 'BINARY%' then 'TO_HEX('||\"source_column_name\"||')'")
+    assert_contains(result.sql, "when upper(data_type) LIKE 'VARBINARY%' then 'TO_HEX('||\"source_column_name\"||')'")
+end)
+
+test("matches parameterized Vertica numeric type names", function()
+    local result = run_vertica({})
+
+    assert_contains(result.sql, "when upper(data_type) LIKE 'DECIMAL%' or upper(data_type) LIKE 'NUMERIC%' or upper(data_type) LIKE 'NUMBER%'")
+    assert_not_contains(result.sql, "when upper(data_type) in ('DECIMAL','NUMERIC','NUMBER')")
+end)
+
+print("")
+print(string.format("=== Results: %d passed, %d failed ===", passed, failed))
+
+if failed > 0 then
+    os.exit(1)
+end

--- a/vertica_to_exasol.sql
+++ b/vertica_to_exasol.sql
@@ -23,7 +23,7 @@ suc, res = pquery([[
 
 with vv_vertica_columns as (
 
-	select ]]..exa_upper_begin..[[table_schema]]..exa_upper_end..[[ as "exa_table_schema", ]]..exa_upper_begin..[[table_name]]..exa_upper_end..[[ as "exa_table_name", ]]..exa_upper_begin..[[column_name]]..exa_upper_end..[[ as "exa_column_name", vertica.* from  
+	select ]]..exa_upper_begin..[[table_schema]]..exa_upper_end..[[ as "exa_table_schema", ]]..exa_upper_begin..[[table_name]]..exa_upper_end..[[ as "exa_table_name", ]]..exa_upper_begin..[[column_name]]..exa_upper_end..[[ as "exa_column_name", '"' || replace(table_schema, '"', '""') || '"' as "source_table_schema", '"' || replace(table_name, '"', '""') || '"' as "source_table_name", '"' || replace(column_name, '"', '""') || '"' as "source_column_name", vertica.* from
 		(
 
 import  into 
@@ -92,23 +92,23 @@ AND table_name ilike '']]..TABLE_FILTER..[[''
     when upper(data_type) like 'FLOAT%' then 'FLOAT'
     when upper(data_type) = 'DOUBLE PRECISION' then 'DOUBLE'   
 	when upper(data_type) = 'REAL' then 'FLOAT'   
-    when upper(data_type) in ('DECIMAL','NUMERIC','NUMBER') then case when numeric_precision is null or numeric_precision > 36 then 'DOUBLE' else 'decimal(' || numeric_precision || ',' || case when (numeric_scale > numeric_precision) then numeric_precision else  case when numeric_scale < 0 then 0 else numeric_scale end end || ')' end 
+    when upper(data_type) LIKE 'DECIMAL%' or upper(data_type) LIKE 'NUMERIC%' or upper(data_type) LIKE 'NUMBER%' then case when numeric_precision is null or numeric_precision > 36 then 'DOUBLE' else 'decimal(' || numeric_precision || ',' || case when (numeric_scale > numeric_precision) then numeric_precision else  case when numeric_scale < 0 then 0 else numeric_scale end end || ')' end
     when upper(data_type) = 'BOOLEAN' then 'BOOLEAN'
     -- ### date and time types ###
     when upper(data_type) = 'DATE' then 'DATE'
     when upper(data_type) = 'DATETIME' then 'TIMESTAMP'
 	when upper(data_type) = 'SMALLDATETIME' then 'TIMESTAMP'
-    when upper(data_type) = 'TIMESTAMP' then 'varchar(14)'
+    when upper(data_type) = 'TIMESTAMP' then 'TIMESTAMP'
     when upper(data_type) = 'TIME' then 'varchar(8)'
     when upper(data_type) = 'YEAR' then 'varchar(4)'
     -- ### string types ###
     when upper(data_type) LIKE 'CHAR%' then upper(data_type)
     when upper(data_type) LIKE 'VARCHAR%' then upper(data_type)
 	when upper(data_type) LIKE 'LONG VARCHAR%' then upper(data_type)
-    when upper(data_type) = 'BINARY' then 'char('||character_maximum_length||')'
-	when upper(data_type) = 'BYTEA' then 'char('||character_maximum_length||')'
-	when upper(data_type) = 'RAW' then 'char('||character_maximum_length||')'
-    when upper(data_type) = 'VARBINARY' then 'varchar('||character_maximum_length||')'
+    when upper(data_type) LIKE 'BINARY%' then 'char('||(coalesce(character_maximum_length, data_type_length) * 2)||')'
+	when upper(data_type) LIKE 'BYTEA%' then 'char('||(coalesce(character_maximum_length, data_type_length) * 2)||')'
+	when upper(data_type) LIKE 'RAW%' then 'char('||(coalesce(character_maximum_length, data_type_length) * 2)||')'
+    when upper(data_type) LIKE 'VARBINARY%' then 'varchar('||(coalesce(character_maximum_length, data_type_length) * 2)||')'
     when upper(data_type) = 'LONG VARBINARY' then 'varchar(2000000)'
 
     -- ### fallback for unknown types ###
@@ -121,13 +121,13 @@ AND table_name ilike '']]..TABLE_FILTER..[[''
 	select 'import into "' || "exa_table_schema" || '"."' || "exa_table_name" || '" from jdbc at ]]..CONNECTION_NAME..[[ statement ''select ' 
            || group_concat(
                            case 
-	                       when upper(data_type) = 'BINARY' then 'cast('||column_name||' as char('||character_maximum_length||'))'
-                           when upper(data_type) = 'VARBINARY' then 'cast('||column_name||' as char('||character_maximum_length||'))'
-                           when upper(data_type) = 'BLOB' then 'cast('||column_name||' as char(2000000))'
-                           else column_name end order by ordinal_position) 
-           || ' from ' || table_schema|| '.' || table_name|| ''';' as sql_text
-	from vv_vertica_columns group by "exa_table_schema","exa_table_name", table_schema,table_name
-	order by  "exa_table_schema","exa_table_name", table_schema,table_name
+	                       when upper(data_type) LIKE 'BINARY%' then 'TO_HEX('||"source_column_name"||')'
+                           when upper(data_type) LIKE 'VARBINARY%' then 'TO_HEX('||"source_column_name"||')'
+                           when upper(data_type) = 'BLOB' then 'cast('||"source_column_name"||' as char(2000000))'
+                           else "source_column_name" end order by ordinal_position)
+           || ' from ' || "source_table_schema"|| '.' || "source_table_name"|| ''';' as sql_text
+	from vv_vertica_columns group by "exa_table_schema","exa_table_name", "source_table_schema","source_table_name"
+	order by  "exa_table_schema","exa_table_name", "source_table_schema","source_table_name"
 )
 select cast('-- ### SCHEMAS ###' as varchar(2000000)) SQL_TEXT
 union all 


### PR DESCRIPTION
## Summary

Adds a per-source parallel `IMPORT` optimizer on top of the `MIGRATE_TO_EXASOL` master wrapper. The dispatcher post-processes adapter output, expands single-statement IMPORTs at or above `PARALLEL_ROW_THRESHOLD` into N `STATEMENT '...'` clauses with WHERE selectors the source engine pushes down, and records what it picked in four audit columns. Adapter scripts remain frozen — every cross-cutting change lives in `migrate_to_exasol.sql`.

This stack contains three logical layers that were developed sequentially:

1. **`MIGRATE_TO_EXASOL` master wrapper** + adapter hardening (the `migrate_to_exasol.sql` entrypoint, `databricks_to_exasol.sql` adapter, 7-column audit-table output, DB2/Postgres/Vertica identifier-quoting + datatype fixes).
2. **`PARALLEL_ROW_THRESHOLD` dispatcher gate** (Speq 1): collapses multi-statement IMPORTs back to single below threshold.
3. **`transform_for_split` per-source splitter** (Speq 2, this plan): expands single-statement IMPORTs at-or-above threshold into N parallel statements via a source-agnostic split hierarchy + a shared one-round-trip metadata cache.

The Speq 2 plan and four spec deltas (`specs/_plans/parallel-import-source-optimization/`) describe the transform order, dispatch tables, split hierarchy, `AUTO` ceiling, and audit columns in full.

## Surface

```sql
EXECUTE SCRIPT DATABASE_MIGRATION.MIGRATE_TO_EXASOL(
    'POSTGRES', 'PG_CONN', 'JDBC',
    '%', '%', '%', NULL, TRUE, TRUE,
    'PARALLEL_ROW_THRESHOLD=1000000;PARALLEL_STATEMENTS=AUTO'
);
```

New `OPTIONS` keys (master script only — adapters unchanged):

| Key | Default | Effect |
|---|---|---|
| `PARALLEL_ROW_THRESHOLD` | `0` (off) | Tables below this row count import single-stmt; above gets the splitter |
| `PARALLEL_STATEMENTS` | `AUTO` | Integer N, or `AUTO` (ceiling 12) |
| `PARALLEL_SPLIT` | unset | Force a strategy (`PK_RANGE`, `DATE_BUCKET:COL:GRAIN`, `HASH:COL`, `PARTITION`, `ROWID`); soft-fails to default hierarchy if prerequisite missing |

Split hierarchy walked per IMPORT row: `PARTITION` (if source emits partition metadata) → `PK_RANGE` (numeric/integer PK) → `DATE_BUCKET` (date col + grain) → `HASH` (first numeric col) → `ROWID` (Oracle / DB2-like) → falls through to `SINGLE` with an `INFO` audit row. Multi-statement IMPORTs (Oracle today) pass through unchanged.

Four new audit columns appended to existing 7-column output: `SPLIT_STRATEGY`, `SPLIT_KEY`, `PARALLEL_REQUESTED`, `PARALLEL_EFFECTIVE`. Source-metadata fetch is a single `IMPORT FROM JDBC` round-trip per migration, cached and reused by both gate and splitter.

## Architecture

```
caller
  └─ MIGRATE_TO_EXASOL(...)
       ├─ adapter emits rows  (frozen per-source script)
       ├─ transform_for_metadata   ← 1 round-trip per migration, cached
       ├─ transform_for_gate       ← Speq 1: multi → single below threshold
       ├─ transform_for_split      ← Speq 2: single → multi above threshold
       └─ transform_for_audit      ← decorates SPLIT_* + PARALLEL_* columns
```

The `SOURCE_METADATA_BY_SOURCE` + `DIALECT_BY_SOURCE` dispatch tables encode every per-source quirk (PK-discovery SQL, identifier quoting, NULL sentinels). New sources are added by extending those tables, never by branching the splitter code.

## Verification

| Check | Result |
|---|---|
| `lua test/test_migrate_to_exasol.lua` | 85 passed |
| `lua test/test_databricks_to_exasol.lua` | 9 passed |
| `lua test/test_db2_to_exasol.lua` | 3 passed |
| `lua test/test_postgres_to_exasol.lua` | 5 passed |
| `lua test/test_vertica_to_exasol.lua` | 5 passed |
| `python3 test/test_migrate_to_exasol_runtime.py` (ExaNano) | 17 preview + 4 execute + empty + adapter-error + S3-reject + alias all PASS |
| `speq plan validate parallel-import-source-optimization` | PASS (4 spec deltas) |

Live-source smokes (real source DBs end-to-end through the wrapper):

| Source | Smoke |
|---|---|
| Postgres | PASS |
| MySQL | PASS |
| SQL Server | PASS |
| Databricks, Exasol→Exasol, Snowflake, MariaDB, DB2, Vertica, Oracle, Redshift, Azure SQL | PASS (from PR #42 batch, re-run against same surface) |
| BigQuery | Driver-blocked (environmental, not wrapper) |
| Teradata, HANA, Netezza, Vectorwise | Not exercised — image/license-gated |

## Notes

- PR #42 (closed) was the master-wrapper-only retraction. This PR re-submits that scope plus Speq 1 + Speq 2 as a single cohesive stack.
- No adapter script touched by any Speq 1 or Speq 2 commit. `git diff fork/master..HEAD --name-only -- '*_to_exasol.sql' | grep -v migrate_to_exasol` returns only adapter hardening from the PR #42 batch (DB2/Postgres/Vertica/Databricks fixes already reviewed there).

## Test plan

- [ ] `lua test/test_migrate_to_exasol.lua` exits 0 (85 cases)
- [ ] `lua test/test_databricks_to_exasol.lua`, `test_db2_to_exasol.lua`, `test_postgres_to_exasol.lua`, `test_vertica_to_exasol.lua` all exit 0
- [ ] `python3 test/test_migrate_to_exasol_runtime.py` against a disposable Exasol passes
- [ ] `speq plan validate parallel-import-source-optimization` reports PASS
- [ ] Manual smoke through wrapper against Postgres with `PARALLEL_ROW_THRESHOLD=N`, `PARALLEL_STATEMENTS=AUTO` — confirm SUMMARY reports expected `tables_created`, `total_rows_loaded`, and `SPLIT_STRATEGY` populated on at least one row
