### PR TITLE
Fix bugs, add lossless DOUBLE→DECIMAL(p,s) & per-type switches in convert_datatypes.sql

### DIFF
--- a/post_load_optimization/README.md
+++ b/post_load_optimization/README.md
@@ -12,110 +12,136 @@ What they do:
 
 
 ## Optimize datatypes
-See script [convert_datatypes.sql](convert_datatypes.sql)
-This script helps you to get optimal datatypes for your tables.
-It performs multiple optimizations:
-
-#### DOUBLE --> DECIMAL
-Convert columns of type `DOUBLE` to `DECIMAL` if the column only contains integers
-
-###### Example:
-
-| Current datatype | Example value | New datatype  |
-|------------------|---------------|---------------|
-| DOUBLE           | 1234567890.0  | DECIMAL(18,0) |
-
-#### DECIMAL --> smaller DECIMAL
-Convert columns of type `DECIMAL` to a smaller `DECIMAL` if the column only contains values, that would also fit into a smaller type. The script won't pick the smallest DECIMAL possible but will either choose DECIMAL(18,0) or DECIMAL(9,0) as this corresponds to int32 / int64.
-So far, it will only consider columns without scale.
-
-###### Example:
-
-| Current datatype | Length of maximum value (abs) | New datatype  |
-|------------------|-------------------------------|---------------|
-| DECIMAL(20,0)    | 17                            | DECIMAL(18,0) |
-| DECIMAL(18,0)    | 2                             | DECIMAL(9,0)  |
 
 
-#### TIMESTAMP --> DATE
-If a column is of type `TIMESTAMP` but only contains values where the time of the day is set to 0, it will be converted to `DATE`.
+The `convert_datatypes.sql` script optimizes table column datatypes to reduce disk
+storage and improve join performance. You typically run it once after importing your
+data. It first reports (or applies) the changes it would make, so you stay in control.
 
-###### Example:
+> 📖 **Background:** see Exasol's [Performance Best Practices](https://docs.exasol.com/db/latest/performance/best_practices.htm).
+> Choosing the smallest sufficient data type improves compression and join/query performance —
+> that is exactly what this script helps you do.
 
-| Current datatype | Example value           | New datatype |
-|------------------|-------------------------|--------------|
-| TIMESTAMP        | 2018-02-09 00:00:00.000 | DATE         |
+Only **real, local base TABLE** columns are inspected:
+- views and synonyms are excluded (`COLUMN_OBJECT_TYPE = 'TABLE'`)
+- **virtual schema** columns are excluded (`COLUMN_IS_VIRTUAL = FALSE`)
 
+> #### ⚠️⚠️ ATTENTION — `apply_conversion = true` IS IRREVERSIBLE ⚠️⚠️
+>
+> **`apply_conversion = true` runs `ALTER TABLE ... MODIFY` against your real tables.
+> There is NO undo and NO automatic backup.**
+>
+> - **ALWAYS** run with `apply_conversion = false` first and carefully **REVIEW every proposed statement**.
+> - Only set `true` when you are **100% sure** that every single proposed conversion must be performed.
+> - **✅ Safer way:** keep `apply_conversion = false`, copy the statements from the `query_text`
+>   column, and execute them **yourself, one statement at a time**, checking each result.
+> - Make sure you have a **backup** / can recreate the affected tables before applying.
 
+### Conversion types
 
-#### VARCHAR --> smaller VARCHAR
-Convert columns of type `VARCHAR` to a smaller `VARCHAR` if the column only contains values, that would also fit into a smaller type. The script won't take the smallest possible length but will add 20% (and then take the next bigger round decimal) buffer to make sure, inserts with slightly larger values will still work.
+| From | To | When |
+|------|----|------|
+| `DOUBLE` | smallest fitting `DECIMAL(p,0)` or `DECIMAL(p,s)` | the values are **exactly** representable as a DECIMAL: pure integers → `DECIMAL(9,0)`/`DECIMAL(18,0)`, or values with a small constant number of decimals (e.g. prices `19.99`) → `DECIMAL(p,s)`. Only proposed when a **round-trip cast proves it is lossless for every value** (`cast(cast(v as decimal(36,s)) as double) = v`); genuine floating-point values (e.g. `1/3`) stay `DOUBLE`. The detected scale is capped at 9 and the result never exceeds 64-bit. Chosen directly in a **single** `ALTER`. |
+| `DECIMAL(p,0)` | `DECIMAL(9,0)` / `DECIMAL(18,0)` | the values fit into a smaller integer type. `9` maps to the 32-bit and `18` to the 64-bit internal representation. Example: `DECIMAL(20,0)` with max length 17 → `DECIMAL(18,0)`. |
+| `DECIMAL(p,s)` | `DECIMAL(9,s)` / `DECIMAL(18,s)` | the required precision (integer digits + scale) fits into a smaller type; the **scale is preserved**. |
+| `TIMESTAMP` / `TIMESTAMP WITH LOCAL TIME ZONE` | `DATE` | every value has a midnight time component (no hours/minutes/seconds/fraction), for any fractional precision `p` (0–9). For `TIMESTAMP WITH LOCAL TIME ZONE` the check and the conversion both run in the current `SESSIONTIMEZONE`. |
+| `VARCHAR(n)` | smaller `VARCHAR` (same charset) | the actual maximum length plus a ~20% buffer (rounded up to the next round number) is smaller than `n`. Columns with `n <= 3` are left untouched. The original **character set (`ASCII` / `UTF8`) is preserved** — e.g. `VARCHAR(2000000) ASCII` becomes `VARCHAR(500) ASCII`, never `UTF8`. |
 
-###### Example:
-| Current datatype | Length of maximum value (abs) | New datatype  |
-|------------------|-------------------------------|---------------|
-| VARCHAR(2000000) | 1543                          | VARCHAR(2000) |
-| VARCHAR(1000)    | 7                             | VARCHAR(10)   |
+> The script does not change a column when the table/column is empty (all NULL), when
+> the value is a real `DOUBLE`/`TIMESTAMP`, or when no smaller type fits.
 
+### Parameters
 
-#### Parameters to be aware of:
-``` SQL
+```sql
 execute script DATABASE_MIGRATION.CONVERT_DATATYPES(
-'DATATYPES',		-- schema_name: 	 SCHEMA name or SCHEMA_FILTER (can be %)
-'%', 		   	-- table_name: 	  TABLE name or TABLE_FILTER  (can be %)
-false   		    -- apply_conversion: If false, only output of what would be changed is generated, if true conversions are applied
+    'MY_SCHEMA',   -- schema_name:       schema name or filter, wildcards (%) allowed
+    '%',           -- table_name:        table name or filter, wildcards (%) allowed
+    true,          -- convert_double:    DOUBLE       -> smallest fitting DECIMAL(p,0) / DECIMAL(p,s)
+    true,          -- convert_integer:   DECIMAL(p,0) -> DECIMAL(9,0) / DECIMAL(18,0)
+    true,          -- convert_decimal:   DECIMAL(p,s) -> DECIMAL(9,s) / DECIMAL(18,s)
+    true,          -- convert_timestamp: TIMESTAMP / TIMESTAMP WITH LOCAL TIME ZONE -> DATE
+    true,          -- convert_varchar:   VARCHAR(n)   -> smaller VARCHAR (same charset)
+    false,         -- log_for_all_columns: false = only report changed columns, true = report every inspected column
+    false          -- apply_conversion:  false = only report (recommended), true = IRREVERSIBLY apply
 );
-
 ```
 
-* `SCHEMA_NAME`: The schema you want to modify, wildcards are allowed.
+| Parameter | Description |
+|-----------|-------------|
+| `SCHEMA_NAME` | The schema you want to modify. Wildcards (`%`) are allowed. The filter is a value comparison against the case-exact catalog name — see *Case sensitivity* below. |
+| `TABLE_NAME` | The table you want to modify. Wildcards (`%`) are allowed. |
+| `CONVERT_DOUBLE` | `true`/`false` — check & convert `DOUBLE` → `DECIMAL(p,0)` / `DECIMAL(p,s)`. |
+| `CONVERT_INTEGER` | `true`/`false` — check & convert `DECIMAL(p,0)` → `DECIMAL(9,0)` / `DECIMAL(18,0)`. |
+| `CONVERT_DECIMAL` | `true`/`false` — check & convert `DECIMAL(p,s)` → `DECIMAL(9,s)` / `DECIMAL(18,s)`. |
+| `CONVERT_TIMESTAMP` | `true`/`false` — check & convert `TIMESTAMP` / `TIMESTAMP WITH LOCAL TIME ZONE` → `DATE`. |
+| `CONVERT_VARCHAR` | `true`/`false` — check & convert `VARCHAR(n)` → smaller `VARCHAR` (same charset). |
+| `LOG_FOR_ALL_COLUMNS` | `true`/`false`. `false` = report only columns that **will change**. `true` = report **every inspected column**, including `Keep ...` rows (useful to see *why* a column is left unchanged). |
+| `APPLY_CONVERSION` | 🛑 **`false` = only report the proposed changes — STRONGLY RECOMMENDED.** `true` = **IRREVERSIBLY** execute the `ALTER TABLE` statements against your tables — **no undo**. Only use `true` after reviewing the dry-run; see the ⚠️ warning box above. |
 
-* `TABLE_NAME`: The table you want to modify, wildcards are allowed. To execute the script on a whole schema, put `'%'`.
+Each of the five `convert_*` switches enables one conversion type independently; a type set to
+`false` is neither inspected nor applied. They apply to both the dry-run and the apply run.
 
-* `APPLY_CONVERSION`: This parameter specifies if you directly want to the script to modify the tables. If set to `true`, it will apply the conversions. For `false`, you will get the SQL statements that would be executed as an output and can still modify them manually.
+### Output
 
-#### Example for convert_datatypes:
+What is reported depends on the `log_for_all_columns` parameter:
+- `log_for_all_columns = false` → **one row per column that will change**.
+- `log_for_all_columns = true`  → **one row per inspected column**, including `Keep ...` rows
+  that explain why a column is left unchanged.
 
-``` SQL
-create schema if not exists DATATYPES;
-CREATE OR REPLACE TABLE DATATYPES.NUMBER_TEST (
-    "DOUBLE" DOUBLE,
-    DOUBLE_TO_CONVERT DOUBLE,
-	DOUBLE_TO_CONVERT2 DOUBLE,
-	DOUBLE_NULL DOUBLE,
-    TIMESTAMP_REAL TIMESTAMP,
-	TIMESTAMP_TO_CONVERT TIMESTAMP,
-	TIMESTAMP_TO_KEEP_WITH_NULL TIMESTAMP,
-	"TIMESTAMP" TIMESTAMP,
-	"WEIRDCOL'NAME1" DOUBLE,
-	"WEIRDCOL'NAME2" DECIMAL(18),
-	"WEIRDCOL'NAME3" TIMESTAMP
-);
+The output is **sorted by `schema_name`, `table_name`, `column_name`**.
 
-INSERT INTO DATATYPES.NUMBER_TEST VALUES
-(1.2,1,1.000000000001,null,'1000-01-01 00:00:00.000', '1000-01-01 00:00:00.000', '1999-01-01 00:00:00.001', '1000-01-01 00:00:01.000',1,2, '1000-01-01 00:00:00.000')
-,(2.1,2,2.000000000001,null,'2012-01-01 01:23:31.000', '1999-01-01 00:00:00.000', null, '1999-01-01 23:59:59.999',1,2, '1000-01-01 00:00:00.000' )
-;
+| Column | Meaning |
+|--------|---------|
+| `schema_name`, `table_name`, `column_name` | the inspected column |
+| `conversion` | what happens, e.g. `DOUBLE --> DECIMAL(9, 0), max length: 1`, `VARCHAR(1000) UTF8  --> VARCHAR(20) UTF8, max length: 10`, or `Keep VARCHAR(100) UTF8, max length: 12` |
+| `query_text` | the generated `ALTER TABLE ... MODIFY ...` statement |
+| `success` | only present when `apply_conversion = true`: `true` or the error message |
 
-CREATE OR REPLACE TABLE DATATYPES.VARCHAR_TEST (
-	"SMALL_VARCHAR" VARCHAR(2000),
-	"BIG_VARCHAR" VARCHAR(2000000),
-	"VARCHAR_TO_KEEP" VARCHAR(10),
-	"VARCHAR_EMPTY" VARCHAR(1000)
-);
+If the result would be empty, the script returns a single informative row in the `conversion`
+column instead:
+- `log_for_all_columns = false` → `No columns found that need optimization.`
+- `log_for_all_columns = true`  → `No matching columns found (check the filters and the convert_* switches).`
+  — i.e. no column matched the schema/table filter and the enabled `convert_*` switches at all.
 
-INSERT INTO DATATYPES.VARCHAR_TEST VALUES
-('a', 'onehundred_chars_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', 'ten_bbbbbb', null)
-;
+### How it works
+
+- **Single scan per column.** Each column is measured with one aggregate query (not-null
+  count plus the relevant length/flag information), so a table is scanned once per column.
+- **DOUBLE in one step, only when lossless.** A convertible `DOUBLE` is changed directly
+  to its optimal `DECIMAL(p,0)` (integers) or `DECIMAL(p,s)` (constant-scale decimals) in a
+  single statement. The decision uses a **round-trip cast** — `cast(cast(v as decimal(36,s))
+  as double) = v` must hold for every row — which guarantees the conversion does not alter
+  any value. Genuine floating-point values stay `DOUBLE`.
+- **Parameter-independent timestamp check.** The `TIMESTAMP -> DATE` detection uses
+  `TRUNC()` and therefore does not depend on the `TIMESTAMP_ARITHMETIC_BEHAVIOR`
+  database parameter. It covers both `TIMESTAMP` and `TIMESTAMP WITH LOCAL TIME ZONE`
+  of any precision `p` (0–9); for the time-zone variant the check and conversion are
+  evaluated in the current `SESSIONTIMEZONE`.
+
+### Case sensitivity
+
+Exasol folds **unquoted** identifiers to UPPER CASE, while **delimited** (double-quoted)
+identifiers are case-sensitive (default `SQL_IDENTIFIER_COMPARISON = CASE SENSITIVE`).
+The script processes every schema/table/column name as a delimited identifier (via
+`quote()` and the `::identifier` placeholder), so `MixedCase` and `lowercase` names are
+handled correctly.
+
+The `schema_name` / `table_name` **filter**, however, is a value comparison against the
+names as stored in the catalog. Pass the name exactly as it was created (e.g.
+`'MixedCase'`, not `'MIXEDCASE'`), or use `%`.
+
+### Recommended workflow
+
+1. Run with `apply_conversion = false` and **carefully review every proposed `ALTER` statement**.
+2. Then choose one:
+   - **✅ Safest (recommended):** keep `apply_conversion = false`, copy the statements from the
+     `query_text` column, and run them **yourself, one statement at a time**, checking each result.
+   - 🛑 Or set `apply_conversion = true` — **only if you are 100% sure**; this applies *all* changes
+     irreversibly in one go, with no undo.
 
 
--- If executed with 'false' --> Script only displays what changes would be made
-execute script DATABASE_MIGRATION.CONVERT_DATATYPES(
-'DATATYPES',		-- schema_name: 	 SCHEMA name or SCHEMA_FILTER (can be %)
-'%', 		   	-- table_name: 	  TABLE name or TABLE_FILTER  (can be %)
-false   		    -- apply_conversion: If false, only output of what would be changed is generated, if true conversions are applied
-);
-```
+
 
 ## Migrate primary keys
+
 See script [set_primary_keys.sql](set_primary_keys.sql)

--- a/post_load_optimization/convert_datatypes.sql
+++ b/post_load_optimization/convert_datatypes.sql
@@ -1,30 +1,132 @@
 create schema if not exists database_migration;
-/* 
-	This script creates datatype optimizations for you. You can run this after
+/*
+    This script creates datatype optimizations for you. You can run this after
     importing your data. Selecting smaller datatypes might improve performance.
 
-	This script:
-  - looks at all columns of type 'DOUBLE' and converts them to numbers
-	if only integer values are contained in the columns.
-  - looks at all columns of type 'DECIMAL' and converts them to a smaller type
-	of decimal if a smaller datatype is also sufficient.
-  - looks at all columns of type 'TIMESTAMP' and converts them to date
-	if only date values are contained in the columns.
-  - looks at all columns of type 'VARCHAR' and converts them to a smaller type
-    of varchar if a smaller VARCHAR can still hold the information in the column
+    This script:
+  - looks at all columns of type 'DOUBLE' and converts them directly to the
+    smallest fitting DECIMAL if the values are exactly representable: integer values
+    -> DECIMAL(p,0), or values with a small constant number of decimals (e.g. prices)
+    -> DECIMAL(p,s). The conversion is only proposed when a round-trip cast proves it
+    is lossless for every value; genuine floating-point values stay DOUBLE.
+  - looks at all columns of type 'DECIMAL' (scale = 0) and converts them to a
+    smaller integer type (32-bit / 64-bit) if a smaller datatype is sufficient.
+  - looks at all columns of type 'DECIMAL' (scale <> 0) and converts them to a
+    smaller decimal if a smaller datatype is sufficient (scale is preserved).
+  - looks at all columns of type 'TIMESTAMP' and 'TIMESTAMP WITH LOCAL TIME ZONE'
+    and converts them to DATE if only date values (no time component) are contained
+    in the column. For TIMESTAMP WITH LOCAL TIME ZONE the check and the conversion are
+    evaluated in the current SESSIONTIMEZONE (both in the same session, so consistent).
+  - looks at all columns of type 'VARCHAR' and converts them to a smaller
+    VARCHAR if a smaller VARCHAR can still hold the information in the column.
+    The original character set (ASCII / UTF8) is always preserved.
+
+    Each of the five conversion types above can be switched on/off individually via the
+    convert_double / convert_integer / convert_decimal / convert_timestamp / convert_varchar
+    parameters (true = check & possibly convert this type, false = skip it entirely).
+
+    Only real, local base TABLE columns are inspected:
+      * views and synonyms are excluded (COLUMN_OBJECT_TYPE = 'TABLE')
+      * VIRTUAL SCHEMA columns are excluded (COLUMN_IS_VIRTUAL = FALSE)
+
+    ====================================================================================
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!  A T T E N T I O N  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    ====================================================================================
+    The parameter apply_conversion = TRUE will IRREVERSIBLY change your table
+    definitions with ALTER TABLE ... MODIFY statements.
+
+      -> ONLY use apply_conversion = TRUE when you have reviewed the dry-run output
+         (apply_conversion = FALSE) and are 100% sure that EVERY proposed conversion
+         must really be performed.
+      -> The SAFER way is to run with apply_conversion = FALSE first, then copy the
+         generated statements from the "query_text" column and execute them YOURSELF,
+         one statement at a time, checking each result.
+      -> A conversion that does not fit the data will fail at execution time; with
+         apply_conversion = TRUE the error only shows up in the "success" column.
+
+    Always have a backup / be able to recreate the affected tables before applying.
+    ====================================================================================
+
+    Case sensitivity:
+      All schema/table/column names are processed as DELIMITED (double-quoted)
+      identifiers via quote() and the ::identifier placeholder, so MixedCase and
+      lowercase names work correctly. The schema_name / table_name FILTER is a VALUE
+      comparison against the (case-exact) catalog names, so pass the name exactly as
+      it is stored, or use '%'.
 */
 
 --parameter	schema_name: 	  SCHEMA name or SCHEMA_FILTER (can be %)
---parameter	table_name: 	  TABLE name or TABLE_FILTER  (can be %)	
---parameter	apply_conversion: Can be true or false, if true, columns are automatically converted to matching datatype. If false, only output of what would be changed is generated
+--parameter	table_name: 	  TABLE name or TABLE_FILTER  (can be %)
+--parameter	convert_double:    true/false - check/convert DOUBLE      -> smallest fitting DECIMAL(p,0) / DECIMAL(p,s)
+--parameter	convert_integer:   true/false - check/convert DECIMAL(p,0) -> DECIMAL(9,0) / DECIMAL(18,0)
+--parameter	convert_decimal:   true/false - check/convert DECIMAL(p,s) -> DECIMAL(9,s) / DECIMAL(18,s)
+--parameter	convert_timestamp: true/false - check/convert TIMESTAMP / TIMESTAMP WITH LOCAL TIME ZONE -> DATE
+--parameter	convert_varchar:   true/false - check/convert VARCHAR(n)   -> smaller VARCHAR (same charset)
+--parameter	log_for_all_columns: true/false - false = report only columns that change; true = report every inspected column (incl. 'Keep ...' rows)
+--parameter	apply_conversion: !!! ATTENTION !!! true or false. TRUE irreversibly alters your tables - only use it when you are 100% sure after reviewing the dry-run (false). The safer way is to review the output of a false-run and execute the statements manually, one by one.
 --/
-create or replace script database_migration.convert_datatypes(schema_name, table_name, apply_conversion) RETURNS TABLE
+create or replace script database_migration.convert_datatypes(schema_name, table_name, convert_double, convert_integer, convert_decimal, convert_timestamp, convert_varchar, log_for_all_columns, apply_conversion) RETURNS TABLE
  as
 
+------------------------------------------------------------------------------------------------------
+-- Returns the smaller integer precision (9 = 32-bit, 18 = 64-bit) that still fits
+-- "needed" digits, or nil if no smaller type than current_precision is possible.
+------------------------------------------------------------------------------------------------------
+function smaller_integer_precision(needed, current_precision)
+	if needed <= 9 and current_precision > 9 then
+		return 9     -- fits into 32-bit
+	elseif needed <= 18 and current_precision > 18 then
+		return 18    -- fits into 64-bit
+	else
+		return nil   -- no smaller type fits
+	end
+end
+
+------------------------------------------------------------------------------------------------------
+-- For a DOUBLE column that also contains fractional values, find the smallest scale s
+-- (1..MAX_DOUBLE_SCALE) at which EVERY non-null value is exactly representable as a
+-- DECIMAL of that scale, proven per row by a round-trip cast:
+--    cast(cast(value as decimal(36,s)) as double) = value
+-- i.e. the DECIMAL reproduces the original DOUBLE bit-for-bit (lossless). It also requires
+-- the resulting precision (integer digits + s) to fit into 18 (64-bit), so the DECIMAL is
+-- never larger than the 8-byte DOUBLE. Returns scale, max_int_digits -- or nil if none.
+------------------------------------------------------------------------------------------------------
+function detect_lossless_double_scale(scm, tbl, col)
+	local MAX_DOUBLE_SCALE = 9    -- conservative cap (prices, rates, ...); higher-scale data stays DOUBLE
+	local viol = ''
+	for s = 0, MAX_DOUBLE_SCALE do
+		viol = viol .. ", count(case when cast(cast(::col_name as decimal(36,"..s..")) as double) <> ::col_name then 1 end)"
+	end
+	local ok, r = pquery([[
+		select coalesce(max(length(cast(floor(abs(::col_name)) as decimal(36,0)))), 0) ]] .. viol .. [[
+		from ::curr_schema.::curr_table
+	]], {curr_schema=scm, curr_table=tbl, col_name=col})
+	if not ok then
+		return nil   -- e.g. a value too large to cast -> keep DOUBLE
+	end
+
+	local max_int_digits = r[1][1]
+	-- r[1][2] = round-trip violations at scale 0 ; r[1][2+s] = violations at scale s
+	if r[1][2] == 0 then
+		return nil   -- all values are integer-valued: handled by the integer path, don't invent a scale
+	end
+	for s = 1, MAX_DOUBLE_SCALE do
+		if r[1][2 + s] == 0 and (max_int_digits + s) <= 18 then
+			return s, max_int_digits
+		end
+	end
+	return nil
+end
+
+------------------------------------------------------------------------------------------------------
+-- DOUBLE --> DECIMAL : convert DOUBLE columns that contain only integer values, or only
+-- values that are exactly representable as a small-scale DECIMAL, directly to the smallest
+-- fitting DECIMAL (one single, lossless ALTER statement).
+------------------------------------------------------------------------------------------------------
 function convert_double_to_decimal(schema_name, table_name, log_for_all_columns)
 
 	local result_table = {}
-	res = query([[
+	local res = query([[
 			select
 				column_schema,
 				column_table,
@@ -32,464 +134,535 @@ function convert_double_to_decimal(schema_name, table_name, log_for_all_columns)
 			from
 				exa_all_columns
 			where
-				column_type_id = 8 and --type_id of DOUBLE
-				column_schema like :schema_filter and -- e.g. '%' to convert all schema
-				COLUMN_TABLE like :table_filter	--e.g. '%' to convert all tables
-	]],{schema_filter=schema_name, table_filter=table_name})
-	
+				column_type_id = 8 and             -- type_id of DOUBLE
+				column_schema like :schema_filter and
+				column_table  like :table_filter and
+				column_object_type = 'TABLE' and   -- only base tables, never views/synonyms
+				column_is_virtual  = FALSE         -- never virtual schema columns
+		]], {schema_filter=schema_name, table_filter=table_name})
+
 	for i=1,#res do
-			local modify_column = false
-			local message_action = ''
-			local query_to_execute = ''
-			--select overall rowcount (not null cols and rowcount with scale information (e.g. .0000000001)
-			tsSuc, tsColumns = pquery([[select
-					count(::col_name) "count", 'values_in_column' "title", 1 "order_column"
-				from
-					::curr_schema.::curr_table				
-			union all
-				select
-					count(*) , 'cols_with_plain_decimals' , 2
-				from
-					::curr_schema.::curr_table
-				where --select only columns with plain decimal (no scale)
-					(
-						not(
-							abs(::col_name - cast(::col_name as decimal)) < 0.00000000001
-								and
-							 (
-	--							::col_name is null
-	--								or
-								to_char(::col_name) ='0'
-									or
-								abs(::col_name) >= 1
-							)
-								and
-							abs(::col_name) < 1E14
+		local modify_column    = false
+		local message_action   = ''
+		local query_to_execute = ''
+
+		local scm = quote(res[i][1])
+		local tbl = quote(res[i][2])
+		local col = quote(res[i][3])
+
+		-- Single table scan: not-null count, number of rows that are NOT a plain
+		-- integer, and the max number of integer digits (only meaningful when all
+		-- values are integers). pquery: if a value cannot be cast to DECIMAL at all
+		-- (overflow) we keep the column instead of aborting the whole script.
+		local tsSuc, tsColumns = pquery([[
+			select
+				count(::col_name) as values_in_column,
+				count(case when
+					not(
+						abs(::col_name - cast(::col_name as decimal)) < 0.00000000001
+							and
+						(
+							to_char(::col_name) = '0'
+								or
+							abs(::col_name) >= 1
 						)
-					) order by 3 asc]]
-				, {curr_schema=quote(res[i][1]), curr_table=quote(res[i][2]),col_name=quote(res[i][3])});
+							and
+						abs(::col_name) < 1E14
+					)
+				then 1 end) as non_integer_rows,
+				coalesce(max(length(cast(abs(::col_name) as decimal(18,0)))), 0) as max_int_length
+			from
+				::curr_schema.::curr_table
+		]], {curr_schema=scm, curr_table=tbl, col_name=col})
 
-			-- tsColumns[1][1] is the number of not_null values in this double column
-			-- tsColumns[2][1] is the number of rows with plain decimals in this double column
+		-- tsColumns[1][1] = number of not-null values
+		-- tsColumns[1][2] = number of rows that are NOT plain integers
+		-- tsColumns[1][3] = max number of integer digits
+		if not tsSuc then
+			message_action = 'Keep DOUBLE (too big for DECIMAL)'
 
-			if not tsSuc then
-				-- Datatype doesn't fit into decimal --> do nothing
-				message_action = 'Keep DOUBLE (too big for DECIMAL)'
+		elseif tsColumns[1][1] == 0 then
+			message_action = 'Keep DOUBLE (IS EMPTY)'
 
-			elseif tsColumns[1][1]==0 then
-				--no rows in table -> do nothing
-				message_action = 'Keep DOUBLE (IS EMPTY)'
-
-			elseif tsColumns[2][1]==0 then
-				--rows in table but content seems to be decimal only (without scale information)
-				query_to_execute = "ALTER TABLE "..quote(res[i][1]).. "."..quote(res[i][2]).." MODIFY ("..quote(res[i][3]).." DECIMAL);"
-				modify_column = true
-				message_action = 'DOUBLE --> DECIMAL'
-
-			else --real double
-				message_action = 'Keep DOUBLE'
-				
+		elseif tsColumns[1][2] == 0 then
+			-- integer only -> convert directly to the smallest fitting DECIMAL.
+			-- (values are < 1E14, so they always fit into DECIMAL(18,0))
+			local max_int_length = tsColumns[1][3]
+			local target
+			if max_int_length <= 9 then
+				target = 9    -- fits into 32-bit
+			else
+				target = 18   -- fits into 64-bit
 			end
-		
+			query_to_execute = "ALTER TABLE "..scm.."."..tbl.." MODIFY ("..col.." DECIMAL("..target..",0));"
+			modify_column    = true
+			message_action   = 'DOUBLE --> DECIMAL('..target..', 0), max length: '..max_int_length
 
-		if modify_column == true or log_for_all_columns then
-			result_table[#result_table+1] = {res[i][1], res[i][2], res[i][3],message_action, query_to_execute}
+		else
+			-- contains fractional values -> only convert if a DECIMAL(p,s) can represent
+			-- EVERY value losslessly (proven by a round-trip cast). Otherwise keep DOUBLE.
+			local s, max_int_digits = detect_lossless_double_scale(scm, tbl, col)
+			if s ~= nil then
+				local p = max_int_digits + s
+				local target
+				if p <= 9 then
+					target = 9    -- fits into 32-bit
+				else
+					target = 18   -- fits into 64-bit
+				end
+				query_to_execute = "ALTER TABLE "..scm.."."..tbl.." MODIFY ("..col.." DECIMAL("..target..","..s.."));"
+				modify_column    = true
+				message_action   = 'DOUBLE --> DECIMAL('..target..', '..s..') (lossless)'
+			else
+				message_action = 'Keep DOUBLE'
+			end
 		end
 
+		if modify_column or log_for_all_columns then
+			result_table[#result_table+1] = {res[i][1], res[i][2], res[i][3], message_action, query_to_execute}
+		end
 	end
 	return result_table
-	end -- end of function convert_double_to_decimal
+end -- convert_double_to_decimal
+
+------------------------------------------------------------------------------------------------------
+-- DECIMAL(p,0) --> smaller integer DECIMAL
 ------------------------------------------------------------------------------------------------------
 function convert_integer_to_smaller_integer(schema_name, table_name, log_for_all_columns)
 
 	local result_table = {}
-	res = query([[select
+	local res = query([[
+			select
 				column_schema,
 				column_table,
 				column_name,
-				COLUMN_NUM_PREC,COLUMN_NUM_SCALE
+				column_num_prec
 			from
 				exa_all_columns
 			where
-				column_type_id = 3 and --type_id of DECIMAL
-				column_schema like :schema_filter and -- e.g. '%' to convert all schema
-				COLUMN_TABLE like :table_filter	--e.g. '%' to convert all tables
-				and column_OBJECT_TYPE='TABLE'
-				and COLUMN_NUM_SCALE = 0 -- uncomment to only handle values without scale
-				and COLUMN_NUM_PREC >9
-	]],{schema_filter=schema_name, table_filter=table_name})
+				column_type_id = 3 and             -- type_id of DECIMAL
+				column_schema like :schema_filter and
+				column_table  like :table_filter and
+				column_object_type = 'TABLE' and
+				column_is_virtual  = FALSE and
+				column_num_scale = 0 and           -- only columns without scale
+				column_num_prec  > 9
+		]], {schema_filter=schema_name, table_filter=table_name})
+
 	for i=1,#res do
-			local modify_column = false
-			local message_action = ''
-			local query_to_execute = ''
+		local modify_column    = false
+		local message_action   = ''
+		local query_to_execute = ''
 
-			scm = quote(res[i][1])
-			tbl = quote(res[i][2])
-			col = quote(res[i][3])
-			dColumns = query([[select
-					count(::col_name) "count", 'values_in_column' "title", 1 "order_column"
-				from
-					::curr_schema.::curr_table				
-			union all
-				select
-					max(length(abs(::col_name))) , 'max_length' , 2
-				from
-					::curr_schema.::curr_table
-			 order by 3 asc]], {curr_schema=scm, curr_table=tbl,col_name=col});
-			
-			-- dColumns[1][1] is the number of not_null values in this decimal column
-			-- dColumns[2][1] is the max length in this decimal column
-			if dColumns[1][1]==0 then
+		local scm       = quote(res[i][1])
+		local tbl       = quote(res[i][2])
+		local col       = quote(res[i][3])
+		local precision = res[i][4]
 
-				--no rows in table -> do nothing
-				message_action = 'Keep DECIMAL (IS EMPTY)'
+		-- Single table scan: not-null count + max number of digits.
+		local dColumns = query([[
+			select
+				count(::col_name) as values_in_column,
+				coalesce(max(length(abs(::col_name))), 0) as max_length
+			from
+				::curr_schema.::curr_table
+		]], {curr_schema=scm, curr_table=tbl, col_name=col})
 
-			elseif (dColumns[2][1]<=9 and res[i][4] > 9) or (dColumns[2][1]<=18 and res[i][4] > 18) then
-				-- can find smaller datatype, either 32Bit or 64Bit
-				change_from = res[i][4];
-				if (dColumns[2][1]<=9 and res[i][4] > 9) then
-				--fits into 32Bit
-				change_to = 9;
-				else
-				--fits into 64Bit
-				change_to=18;
-				end
+		local not_null_count = dColumns[1][1]
+		local max_length     = dColumns[1][2]
 
-				query_to_execute = "ALTER TABLE "..quote(res[i][1]).. "."..quote(res[i][2]).." MODIFY ("..quote(res[i][3]).." DECIMAL("..change_to..","..res[i][5].."));"
-				modify_column = true
-				message_action = 'DECIMAL('..change_from..', '..res[i][5]..')  --> DECIMAL('..change_to..', '..res[i][5]..'), max length: '..dColumns[2][1]
-				
+		if not_null_count == 0 then
+			message_action = 'Keep DECIMAL (IS EMPTY)'
+		else
+			local target = smaller_integer_precision(max_length, precision)
+			if target ~= nil then
+				query_to_execute = "ALTER TABLE "..scm.."."..tbl.." MODIFY ("..col.." DECIMAL("..target..",0));"
+				modify_column    = true
+				message_action   = 'DECIMAL('..precision..', 0)  --> DECIMAL('..target..', 0), max length: '..max_length
 			else
-				message_action = 'Keep DECIMAL('..res[i][4]..'), max length: '..dColumns[2][1]
+				message_action = 'Keep DECIMAL('..precision..', 0), max length: '..max_length
 			end
+		end
 
-		if modify_column == true or log_for_all_columns then
-			result_table[#result_table+1] = {res[i][1], res[i][2], res[i][3],message_action, query_to_execute}
+		if modify_column or log_for_all_columns then
+			result_table[#result_table+1] = {res[i][1], res[i][2], res[i][3], message_action, query_to_execute}
 		end
-		end
+	end
 	return result_table
-	end -- end of function convert_integer_to_smaller_integer
-	
+end -- convert_integer_to_smaller_integer
+
+------------------------------------------------------------------------------------------------------
+-- DECIMAL(p,s) --> smaller DECIMAL (scale preserved)
 ------------------------------------------------------------------------------------------------------
 function convert_decimal_with_scale_to_smaller_decimal(schema_name, table_name, log_for_all_columns)
 
 	local result_table = {}
-	res = query([[select
+	local res = query([[
+			select
 				column_schema,
 				column_table,
 				column_name,
-				COLUMN_NUM_PREC,
-				COLUMN_NUM_SCALE
+				column_num_prec,
+				column_num_scale
 			from
 				exa_all_columns
 			where
-				column_type_id = 3 and --type_id of DECIMAL
-				column_schema like :schema_filter and -- e.g. '%' to convert all schema
-				COLUMN_TABLE like :table_filter	--e.g. '%' to convert all tables
-				and column_OBJECT_TYPE='TABLE'
-				and COLUMN_NUM_SCALE <> 0  -- take only columns into account that have a scale
-				and COLUMN_NUM_PREC >9
-	]],{schema_filter=schema_name, table_filter=table_name})
+				column_type_id = 3 and             -- type_id of DECIMAL
+				column_schema like :schema_filter and
+				column_table  like :table_filter and
+				column_object_type = 'TABLE' and
+				column_is_virtual  = FALSE and
+				column_num_scale <> 0 and          -- only columns that have a scale
+				column_num_prec   > 9
+		]], {schema_filter=schema_name, table_filter=table_name})
 
 	for i=1,#res do
-			local modify_column = false
-			local message_action = ''
-			local query_to_execute = ''
-
-			scm = quote(res[i].COLUMN_SCHEMA)
-			tbl = quote(res[i].COLUMN_TABLE)
-			col = quote(res[i].COLUMN_NAME)
-			col_scale = res[i].COLUMN_NUM_SCALE
-			dColumns = query([[select
-					count(::col_name) "count", 'values_in_column' "title", 1 "order_column"
-				from
-					::curr_schema.::curr_table				
-			union all
-				select
-					 coalesce(max(length(round(abs(::col_name)))),0) , 'max_length' , 2
-				from
-					::curr_schema.::curr_table
-			 order by 3 asc]], {curr_schema=scm, curr_table=tbl,col_name=col});
-			
-			-- dColumns[1][1] is the number of not_null values in this decimal column
-			-- dColumns[2][1] is the max length in this decimal column
-			max_length_incl_scale = dColumns[2][1] + col_scale
-			if dColumns[1][1]==0 then
-
-				--no rows in table -> do nothing
-				message_action = 'Keep DECIMAL (IS EMPTY)'
-
-			elseif (max_length_incl_scale<=9 and res[i][4] > 9) or (max_length_incl_scale<=18 and res[i][4] > 18) then
-				-- can find smaller datatype, either 32Bit or 64Bit
-				change_from = res[i][4];
-				if (max_length_incl_scale<=9 and res[i][4] > 9) then
-					--fits into 32Bit
-					change_to = 9;
-				else
-					--fits into 64Bit
-					change_to=18;
-				end
-
-				query_to_execute = "ALTER TABLE "..quote(res[i][1]).. "."..quote(res[i][2]).." MODIFY ("..quote(res[i][3]).." DECIMAL("..change_to..","..res[i][5].."));"
-				modify_column = true
-				message_action = 'DECIMAL('..change_from..', '..res[i][5]..')  --> DECIMAL('..change_to..', '..res[i][5]..'), max length: '..max_length_incl_scale
-				
-			else
-				message_action = 'Keep DECIMAL('..res[i][4]..'), max length: '..max_length_incl_scale
-			end
-
-		if modify_column == true or log_for_all_columns then
-			result_table[#result_table+1] = {res[i][1], res[i][2], res[i][3],message_action, query_to_execute}
-		end
-		end
-	return result_table
-	end -- end of function convert_decimal_with_scale_to_smaller_decimal
-------------------------------------------------------------------------------------------------------
-function convert_timestamp_to_date(schema_name, table_name, log_for_all_columns)
-result_table = {};
-res = query([[
-		select
-			column_schema,
-			column_table,
-			column_name
-		from
-			exa_all_columns
-		where
-			column_type_id = 93 and --type_id of TIMESTAMP
-			column_schema like :schema_filter and -- e.g. '%' to convert all schema
-			COLUMN_TABLE like :table_filter	--e.g. '%' to convert all tables
-]],{schema_filter=schema_name, table_filter=table_name})
-
-for i=1,#res do
-		local modify_column = false
-		local message_action = ''
+		local modify_column    = false
+		local message_action   = ''
 		local query_to_execute = ''
 
-		--select overall rowcount (not null cols and rowcount with time information (e.g. one millisecond)
-		tsColumns = query([[select
-				count(::col_name) "count", 'values_in_column' "title", 1 "order_column"
-			from
-				::curr_schema.::curr_table				
-			where
-				::col_name is not null
-		union all
+		local scm       = quote(res[i][1])
+		local tbl       = quote(res[i][2])
+		local col       = quote(res[i][3])
+		local precision = res[i][4]
+		local col_scale = res[i][5]
+
+		-- Single table scan: not-null count + max length of the integer part.
+		-- floor() (not round()) so a value like 999.99 counts as 3 integer digits,
+		-- not 4 -- otherwise an otherwise-possible shrink would be missed.
+		local dColumns = query([[
 			select
-				count(*) , 'cols_with_plain_dates' , 2
+				count(::col_name) as values_in_column,
+				coalesce(max(length(floor(abs(::col_name)))), 0) as max_int_length
 			from
 				::curr_schema.::curr_table
-			where --select only columns with plain dates (no hours, minutes, seconds, fraction)
-				(
-						::col_name - to_date(::col_name) != INTERVAL '00:00:00.000000' HOUR
-					TO
-						SECOND
-				) order by 3 asc]]
-			, {curr_schema=quote(res[i][1]), curr_table=quote(res[i][2]),col_name=quote(res[i][3])});
+		]], {curr_schema=scm, curr_table=tbl, col_name=col})
 
+		local not_null_count   = dColumns[1][1]
+		local max_int_length   = dColumns[1][2]
+		local needed_precision = max_int_length + col_scale
 
-		-- tsColumns[1][1] is the number of not_null values in this timestamp column
-		-- tsColumns[2][1] is the number of rows with plain dataes
-
-		if tsColumns[1][1]==0 then
-			--no rows in table -> do nothing
-			message_action = 'Keep TIMESTAMP (IS EMPTY)'
-
-		elseif tsColumns[2][1]==0 then
-			--rows in table but seems to be date only (without time information)
-			query_to_execute = "ALTER TABLE "..quote(res[i][1]).. "."..quote(res[i][2]).." MODIFY ("..quote(res[i][3]).." DATE);"
-			modify_column = true
-			message_action = 'TIMESTAMP --> DATE'
+		if not_null_count == 0 then
+			message_action = 'Keep DECIMAL (IS EMPTY)'
 		else
-			--real timestamp
-			message_action = 'Keep TIMESTAMP (IS EMPTY)'
+			-- needed_precision always includes the scale, so the target precision is
+			-- always > scale -> DECIMAL(target, scale) is guaranteed to be valid.
+			local target = smaller_integer_precision(needed_precision, precision)
+			if target ~= nil then
+				query_to_execute = "ALTER TABLE "..scm.."."..tbl.." MODIFY ("..col.." DECIMAL("..target..","..col_scale.."));"
+				modify_column    = true
+				message_action   = 'DECIMAL('..precision..', '..col_scale..')  --> DECIMAL('..target..', '..col_scale..'), needed precision: '..needed_precision
+			else
+				message_action = 'Keep DECIMAL('..precision..', '..col_scale..'), needed precision: '..needed_precision
+			end
 		end
-	if modify_column == true or log_for_all_columns then
-		result_table[#result_table+1] = {res[i][1], res[i][2], res[i][3],message_action, query_to_execute}
-	end
+
+		if modify_column or log_for_all_columns then
+			result_table[#result_table+1] = {res[i][1], res[i][2], res[i][3], message_action, query_to_execute}
+		end
 	end
 	return result_table
-end -- end of function convert_timestamp_to_date
+end -- convert_decimal_with_scale_to_smaller_decimal
 
+------------------------------------------------------------------------------------------------------
+-- TIMESTAMP / TIMESTAMP WITH LOCAL TIME ZONE --> DATE
+-- Convert timestamp columns that never carry a time component.
+------------------------------------------------------------------------------------------------------
+function convert_timestamp_to_date(schema_name, table_name, log_for_all_columns)
+
+	local result_table = {}
+	local res = query([[
+			select
+				column_schema,
+				column_table,
+				column_name,
+				column_type_id
+			from
+				exa_all_columns
+			where
+				column_type_id in (93, 124) and    -- 93 = TIMESTAMP, 124 = TIMESTAMP WITH LOCAL TIME ZONE
+				column_schema like :schema_filter and
+				column_table  like :table_filter and
+				column_object_type = 'TABLE' and   -- only base tables, never views/synonyms
+				column_is_virtual  = FALSE         -- never virtual schema columns
+		]], {schema_filter=schema_name, table_filter=table_name})
+
+	for i=1,#res do
+		local modify_column    = false
+		local message_action   = ''
+		local query_to_execute = ''
+
+		local scm = quote(res[i][1])
+		local tbl = quote(res[i][2])
+		local col = quote(res[i][3])
+
+		-- label the source type for the output messages
+		local type_label = 'TIMESTAMP'
+		if res[i][4] == 124 then
+			type_label = 'TIMESTAMP WITH LOCAL TIME ZONE'
+		end
+
+		-- Single table scan: not-null count + number of rows that carry a time
+		-- component. We use TRUNC() instead of subtracting datetimes, so the check
+		-- does NOT depend on the TIMESTAMP_ARITHMETIC_BEHAVIOR parameter (which
+		-- decides whether datetime subtraction yields an INTERVAL or a DOUBLE).
+		-- For TIMESTAMP WITH LOCAL TIME ZONE both the TRUNC check and the later DATE
+		-- conversion run in the current SESSIONTIMEZONE within the same session, so
+		-- they are consistent.
+		-- pquery so a problem skips the column instead of aborting the run.
+		local tsSuc, tsColumns = pquery([[
+			select
+				count(::col_name) as values_in_column,
+				count(case when ::col_name <> TRUNC(::col_name) then 1 end) as rows_with_time
+			from
+				::curr_schema.::curr_table
+		]], {curr_schema=scm, curr_table=tbl, col_name=col})
+
+		-- tsColumns[1][1] = number of not-null values
+		-- tsColumns[1][2] = number of rows that carry a time component
+		if not tsSuc then
+			message_action = 'Keep '..type_label..' (check failed)'
+
+		elseif tsColumns[1][1] == 0 then
+			message_action = 'Keep '..type_label..' (IS EMPTY)'
+
+		elseif tsColumns[1][2] == 0 then
+			-- date only (no hours, minutes, seconds, fraction)
+			query_to_execute = "ALTER TABLE "..scm.."."..tbl.." MODIFY ("..col.." DATE);"
+			modify_column    = true
+			message_action   = type_label..' --> DATE'
+
+		else
+			message_action = 'Keep '..type_label
+		end
+
+		if modify_column or log_for_all_columns then
+			result_table[#result_table+1] = {res[i][1], res[i][2], res[i][3], message_action, query_to_execute}
+		end
+	end
+	return result_table
+end -- convert_timestamp_to_date
+
+------------------------------------------------------------------------------------------------------
+-- VARCHAR --> smaller VARCHAR
 ------------------------------------------------------------------------------------------------------
 function convert_varchar_to_smaller_varchar(schema_name, table_name, log_for_all_columns)
 
 	local result_table = {}
-	res = query([[select
+	local res = query([[
+			select
 				column_schema,
 				column_table,
 				column_name,
-				column_maxsize
+				column_maxsize,
+				column_type
 			from
 				exa_all_columns
 			where
-				column_type_id = 12 and --type_id of VARCHAR
-				column_schema like :schema_filter and -- e.g. '%' to convert all schema
-				COLUMN_TABLE like :table_filter	--e.g. '%' to convert all tables
-				and column_OBJECT_TYPE='TABLE'
-				and column_maxsize > 3 -- do not modify columns that have a size <= 3 characters
-	]],{schema_filter=schema_name, table_filter=table_name})
+				column_type_id = 12 and            -- type_id of VARCHAR
+				column_schema like :schema_filter and
+				column_table  like :table_filter and
+				column_object_type = 'TABLE' and
+				column_is_virtual  = FALSE and
+				column_maxsize > 3                 -- do not modify columns of size <= 3
+		]], {schema_filter=schema_name, table_filter=table_name})
+
 	for i=1,#res do
-			local modify_column = false
-			local message_action = ''
-			local query_to_execute = ''
+		local modify_column    = false
+		local message_action   = ''
+		local query_to_execute = ''
 
-			scm 			= quote(res[i][1])
-			tbl				= quote(res[i][2])
-			col 			= quote(res[i][3])
-			current_maxsize = res[i][4]
+		local scm             = quote(res[i][1])
+		local tbl             = quote(res[i][2])
+		local col             = quote(res[i][3])
+		local current_maxsize = res[i][4]
 
+		-- Preserve the existing character set. COLUMN_TYPE looks like
+		-- "VARCHAR(2000000) ASCII" or "VARCHAR(2000000) UTF8". If the charset is
+		-- omitted in MODIFY, Exasol falls back to the UTF8 default and would silently
+		-- turn an ASCII column into UTF8 -- so we ALWAYS re-state the original charset.
+		local charset = 'UTF8'
+		if string.find(string.upper(res[i][5]), 'ASCII', 1, true) ~= nil then
+			charset = 'ASCII'
+		end
 
-			dColumns = query([[select
-					count(::col_name) "count", 'values_in_column' "title", 1 "order_column"
-				from
-					::curr_schema.::curr_table				
-			union all
-				select
-					max(length(::col_name)), 'actual maxlength', 2
-				from
-					::curr_schema.::curr_table
-			 order by 3 asc]], {curr_schema=scm, curr_table=tbl,col_name=col});
-			
-	
-			if dColumns[1][1]==0 then
+		-- Single table scan: not-null count + actual max character length.
+		local dColumns = query([[
+			select
+				count(::col_name) as values_in_column,
+				coalesce(max(length(::col_name)), 0) as max_length
+			from
+				::curr_schema.::curr_table
+		]], {curr_schema=scm, curr_table=tbl, col_name=col})
 
-				--no rows in table -> do nothing
-				message_action = 'Keep VARCHAR('..current_maxsize..') (IS EMPTY)'
+		local not_null_count = dColumns[1][1]
+		local max_length     = dColumns[1][2]
 
-			elseif (dColumns[2][1]<= 2000000) and (estimate_optimal_varchar_length(dColumns[2][1]) < current_maxsize) then
-				-- can find smaller varchar and still smaller than 2 mio
-				change_from = current_maxsize
-				change_to = estimate_optimal_varchar_length(dColumns[2][1]) -- actual varchar size + a bit of buffer
-				query_to_execute = "ALTER TABLE "..quote(res[i][1]).. "."..quote(res[i][2]).." MODIFY ("..quote(res[i][3]).." VARCHAR("..change_to.."));"
-				modify_column = true
-				message_action = 'VARCHAR('..change_from..')  --> VARCHAR('..change_to..'), max length: '..dColumns[2][1]
-				
-			else
-				message_action = 'Keep VARCHAR('..res[i][4]..'), max length: '..dColumns[2][1]
-			end
+		if not_null_count == 0 then
+			message_action = 'Keep VARCHAR('..current_maxsize..') '..charset..' (IS EMPTY)'
 
-		if modify_column == true or log_for_all_columns then
+		elseif (max_length <= 2000000) and (estimate_optimal_varchar_length(max_length) < current_maxsize) then
+			-- a smaller varchar fits and is still <= 2,000,000 (character set is preserved)
+			local change_to  = estimate_optimal_varchar_length(max_length)  -- actual length + a bit of buffer
+			query_to_execute = "ALTER TABLE "..scm.."."..tbl.." MODIFY ("..col.." VARCHAR("..change_to..") "..charset..");"
+			modify_column    = true
+			message_action   = 'VARCHAR('..current_maxsize..') '..charset..'  --> VARCHAR('..change_to..') '..charset..', max length: '..max_length
+
+		else
+			message_action = 'Keep VARCHAR('..current_maxsize..') '..charset..', max length: '..max_length
+		end
+
+		if modify_column or log_for_all_columns then
 			result_table[#result_table+1] = {res[i][1], res[i][2], res[i][3], message_action, query_to_execute}
 		end
-		end
+	end
 	return result_table
-	end -- end of function convert_varchar_to_smaller_varchar
-
+end -- convert_varchar_to_smaller_varchar
 
 ------------------------------------------------------------------------------------------------------
+-- Helper functions
+------------------------------------------------------------------------------------------------------
 
--- Helper function for varchar conversion, takes number as input, adds 20% and rounds to next bigger round decimal
+-- Takes a number as input, adds 20% headroom and rounds up to the next bigger round decimal.
 function estimate_optimal_varchar_length(n)
-	n_p20 = math.ceil(n + n*(0.2)) -- add 20% to make sure everything fits in
-	number_digits = string.len(n_p20)
-	magnitude = math.floor(10^(number_digits-1))
-	estimated_length = math.floor(n_p20/magnitude)*magnitude+magnitude
-	return math.min(estimated_length, 2000000) -- maximal varchar size is 2 mio
+	local n_p20            = math.ceil(n + n * 0.2)               -- add 20% so everything fits in
+	local number_digits    = string.len(n_p20)
+	local magnitude        = math.floor(10 ^ (number_digits - 1))
+	local estimated_length = math.floor(n_p20 / magnitude) * magnitude + magnitude
+	return math.min(estimated_length, 2000000)                   -- maximal varchar size is 2,000,000
 end
 
--- Helper function to get all actions into one result set
+-- Appends all rows of t2 to t1 and returns t1.
 function merge_tables(t1, t2)
-	for i = 1, #t2 do 
-    	t1[#t1+1] = t2[i]
+	for i = 1, #t2 do
+		t1[#t1+1] = t2[i]
 	end
 	return t1
 end
 
--- Helper function to get maximal string length for a column
+-- Returns the maximal string length found in one column of the result table.
 function getMaxLengthForColumn(input_table, column_number)
-	length = 1
-	for i=1, #input_table do
-		if(#input_table[i][column_number] > length) then
+	local length = 1
+	for i = 1, #input_table do
+		if #input_table[i][column_number] > length then
 			length = #input_table[i][column_number]
 		end
 	end
 	return length
 end
 
--- Helper fuction to execute one column containing sql and log it in the result table
-function exectue_sql_column(input_table, sql_col_number, log_col_number)
-
-	for i= 1, #input_table do
-		sql_stmt = input_table[i][sql_col_number]
-		sql_suc, sql_res = pquery(sql_stmt)
-		if sql_suc then
-			input_table[i][log_col_number] = 'true'
+-- Executes the SQL contained in one column and logs the outcome in another column.
+function execute_sql_column(input_table, sql_col_number, log_col_number)
+	for i = 1, #input_table do
+		local sql_stmt = input_table[i][sql_col_number]
+		if sql_stmt ~= nil and sql_stmt ~= '' then
+			local sql_suc, sql_res = pquery(sql_stmt)
+			if sql_suc then
+				input_table[i][log_col_number] = 'true'
+			else
+				input_table[i][log_col_number] = 'ERROR: ' .. sql_res.error_message
+			end
 		else
-			input_table[i][log_col_number] = 'ERROR: ' .. sql_res.error_message
+			input_table[i][log_col_number] = ''   -- nothing to execute (e.g. a "Keep" row)
 		end
 	end
 	return input_table
 end
 
 -----------------------------END OF FUNCTIONS, BEGINNING OF ACTUAL SCRIPT-----------------------------
-	
-	-- parameter to regulate amount of output
-	-- if false, a log message is only generated for columns that will be changed, if true, a message will be displayed for every column
-	log_for_all_columns = false
+
+	-- log_for_all_columns is a script parameter: if false, only columns that will be changed
+	-- are reported; if true, every inspected column is reported (including "Keep ..." rows).
 
 	local overall_res = {}
 
--------------------------------------------------
-	-- double to decimal
-	local res_double 	= convert_double_to_decimal(schema_name, table_name, log_for_all_columns)
-	overall_res			= merge_tables(overall_res, res_double)
-	
-	-- integer to smaller integer
-	local res_int 		= convert_integer_to_smaller_integer(schema_name, table_name, log_for_all_columns)
-	overall_res 		= merge_tables(overall_res, res_int)
+	-- Each conversion type runs only when its switch parameter is true.
+	-- double to decimal (directly to the smallest fitting DECIMAL)
+	if convert_double then
+		overall_res = merge_tables(overall_res, convert_double_to_decimal(schema_name, table_name, log_for_all_columns))
+	end
+
+	-- integer (scale 0) to smaller integer
+	if convert_integer then
+		overall_res = merge_tables(overall_res, convert_integer_to_smaller_integer(schema_name, table_name, log_for_all_columns))
+	end
 
 	-- decimal with scale to smaller decimal
-	local res_dec		= convert_decimal_with_scale_to_smaller_decimal(schema_name, table_name, log_for_all_columns)
-	overall_res 		= merge_tables(overall_res, res_dec)
-
-	-- convert timestamp to date
-	local res_timestamp = convert_timestamp_to_date(schema_name, table_name, log_for_all_columns)
-	overall_res 		= merge_tables(overall_res, res_timestamp)
-
-	-- convert varchar to smaller varchar
-	local res_varchar	= convert_varchar_to_smaller_varchar(schema_name, table_name, log_for_all_columns)
-	overall_res 		= merge_tables(overall_res, res_varchar)	
-	
-	
-	-- execute statements if apply_conversion is true
-	if (apply_conversion) then
-		overall_res 	= exectue_sql_column(overall_res,5,6)
+	if convert_decimal then
+		overall_res = merge_tables(overall_res, convert_decimal_with_scale_to_smaller_decimal(schema_name, table_name, log_for_all_columns))
 	end
--------------------------------------------------
 
-	-- check whether DOUBLES have been changed to DECIMALS
-	if(#res_dec > 0) then
-		if (apply_conversion) then
-			-- run convert decimal to smaller decimal once again, to make sure also columns that have just been changed from double to decimal are treated
-			local res_dec_second_run 	= convert_integer_to_smaller_integer(schema_name, table_name, log_for_all_columns)
-			res_dec_second_run 			= exectue_sql_column(res_dec_second_run,5,6)
-			overall_res 				= merge_tables(overall_res, res_dec_second_run)
+	-- timestamp / timestamp with local time zone to date
+	if convert_timestamp then
+		overall_res = merge_tables(overall_res, convert_timestamp_to_date(schema_name, table_name, log_for_all_columns))
+	end
+
+	-- varchar to smaller varchar
+	if convert_varchar then
+		overall_res = merge_tables(overall_res, convert_varchar_to_smaller_varchar(schema_name, table_name, log_for_all_columns))
+	end
+
+	-- execute the collected statements if apply_conversion is true
+	-- !!! ATTENTION: this irreversibly alters your tables - see the header banner. !!!
+	if apply_conversion then
+		overall_res = execute_sql_column(overall_res, 5, 6)
+	end
+
+	-- sort the whole output by schema_name, table_name, column_name
+	table.sort(overall_res, function(a, b)
+		if a[1] ~= b[1] then return a[1] < b[1] end
+		if a[2] ~= b[2] then return a[2] < b[2] end
+		return a[3] < b[3]
+	end)
+
+	-- friendly message when the result set would be empty.
+	-- With log_for_all_columns = true every inspected column is listed, so an empty result
+	-- means nothing matched the filter / enabled types at all; otherwise it means that no
+	-- column needs optimization.
+	if #overall_res == 0 then
+		local empty_msg
+		if log_for_all_columns then
+			empty_msg = 'No matching columns found (check the filters and the convert_* switches).'
 		else
-			info_row 	= {}
-			info_row[1] = {'', '', '', '', '-- Please execute the script again after having modified your tables to find also a matching size for the former DECIMAL columns.'}
-			overall_res = merge_tables(info_row,overall_res)
+			empty_msg = 'No columns found that need optimization.'
+		end
+		if apply_conversion then
+			overall_res[1] = {'', '', '', empty_msg, '', ''}
+		else
+			overall_res[1] = {'', '', '', empty_msg, ''}
 		end
 	end
 
 	-- build up output table: get length for each column to avoid exceptions when displaying output
-	length_schema 		= getMaxLengthForColumn(overall_res,1)
-	length_table 		= getMaxLengthForColumn(overall_res,2)
-	length_column 		= getMaxLengthForColumn(overall_res,3)
-	length_conversions 	= getMaxLengthForColumn(overall_res,4)
-	length_query 		= getMaxLengthForColumn(overall_res,5)
+	local length_schema      = getMaxLengthForColumn(overall_res, 1)
+	local length_table       = getMaxLengthForColumn(overall_res, 2)
+	local length_column      = getMaxLengthForColumn(overall_res, 3)
+	local length_conversions = getMaxLengthForColumn(overall_res, 4)
+	local length_query       = getMaxLengthForColumn(overall_res, 5)
 
-	if (apply_conversion) then
-		length_success		= getMaxLengthForColumn(overall_res,6)
-		exit(overall_res, "schema_name char("..length_schema.."), table_name char("..length_table.."), column_name char("..length_column.."),conversion char("..length_conversions.."), query_text char("..length_query.."), success char("..length_success..")")
+	if apply_conversion then
+		local length_success = getMaxLengthForColumn(overall_res, 6)
+		exit(overall_res, "schema_name char("..length_schema.."), table_name char("..length_table.."), column_name char("..length_column.."), conversion char("..length_conversions.."), query_text char("..length_query.."), success char("..length_success..")")
 	else
-		exit(overall_res, "schema_name char("..length_schema.."), table_name char("..length_table.."), column_name char("..length_column.."),conversion char("..length_conversions.."), query_text char("..length_query..")")
+		exit(overall_res, "schema_name char("..length_schema.."), table_name char("..length_table.."), column_name char("..length_column.."), conversion char("..length_conversions.."), query_text char("..length_query..")")
 	end
 /
 
 
+-- ====================================================================================
+-- !!! ATTENTION: run with apply_conversion = false first and REVIEW the output.   !!!
+-- !!! Only set apply_conversion = true when you are 100% sure, or - safer - copy   !!!
+-- !!! the generated statements and execute them yourself, one by one.              !!!
+-- ====================================================================================
 -- If executed with 'false' --> Script only displays what changes would be made
 execute script DATABASE_MIGRATION.CONVERT_DATATYPES(
-'MY_SCHEMA',		--	schema_name: 	  SCHEMA name or SCHEMA_FILTER (can be %)
-'%', 				-- 	table_name: 	  TABLE name or TABLE_FILTER  (can be %)	
-false				--	apply_conversion: If false, only output of what would be changed is generated, if true conversions are applied
+'MY_SCHEMA',  --  schema_name:       SCHEMA name or SCHEMA_FILTER (can be %)
+'%',          --  table_name:        TABLE name or TABLE_FILTER  (can be %)
+true,         --  convert_double:    DOUBLE       -> smallest fitting DECIMAL(p,0) / DECIMAL(p,s)
+true,         --  convert_integer:   DECIMAL(p,0) -> DECIMAL(9,0) / DECIMAL(18,0)
+true,         --  convert_decimal:   DECIMAL(p,s) -> DECIMAL(9,s) / DECIMAL(18,s)
+true,         --  convert_timestamp: TIMESTAMP / TIMESTAMP WITH LOCAL TIME ZONE -> DATE
+true,         --  convert_varchar:   VARCHAR(n)   -> smaller VARCHAR (same charset)
+false,        --  log_for_all_columns: false = only report columns that change, true = report every inspected column
+false         --  apply_conversion:  false = only report (recommended), true = irreversibly apply
 );
-


### PR DESCRIPTION
# Fix real bugs, add lossless DOUBLE→DECIMAL(p,s) & per-type switches, and harden `convert_datatypes`

## Summary
This PR fixes several **real defects** in `post_load_optimization/convert_datatypes.sql`
(virtual-schema columns, VARCHAR character set, a wrong guard, a parameter-dependent timestamp
check, a missing base-table filter, a misleading message), adds a set of **improvements** (lossless
`DOUBLE → DECIMAL(p,s)`, `TIMESTAMP WITH LOCAL TIME ZONE → DATE`, one-pass DOUBLE handling, per-type
switches, a `log_for_all_columns` parameter, sorted output, single-scan performance), and makes one
**breaking signature change**. Everything was validated end-to-end against a live Exasol database.

---

## 🐞 Bug fixes (actual defects in the previous version)

**1. Virtual schemas are now excluded (important).** Virtual-schema tables have
`COLUMN_OBJECT_TYPE = 'TABLE'`, so the object-type filter alone did **not** keep them out and the
script could emit `ALTER TABLE` against virtual tables. All catalog queries now also filter
`COLUMN_IS_VIRTUAL = FALSE`.

**2. VARCHAR character set (ASCII / UTF8) is now preserved (important).** A VARCHAR `MODIFY`
re-states the full data type, and an omitted charset falls back to the `UTF8` default — so the old
`MODIFY (col VARCHAR(n))` silently turned an `ASCII` column into `UTF8` (reproduced on a live DB).
The charset is now read from `COLUMN_TYPE` and always re-stated, e.g. `MODIFY (col VARCHAR(500) ASCII)`.

**3. Wrong result set guarded the second pass.** The re-shrink pass was guarded by `#res_dec`
(scaled-decimal result) instead of the double result, so freshly converted columns could be left
unshrunk. (The two-pass mechanism was subsequently removed entirely — see *Improvements*.)

**4. `TIMESTAMP → DATE` depended on `TIMESTAMP_ARITHMETIC_BEHAVIOR`.** The old datetime-subtraction
check returned an INTERVAL or a DOUBLE depending on that parameter and used `query()`, so with the
`DOUBLE` setting it aborted the whole script. Replaced with `col <> TRUNC(col)` and `pquery()`.

**5. Missing `column_object_type = 'TABLE'` filter for DOUBLE and TIMESTAMP.** These two detection
queries lacked the base-table filter the others had, so **view** columns were picked up and the
generated `ALTER TABLE <view> ...` failed. Filter added to both.

**6. Misleading message.** A real (non-empty) timestamp column was logged as
`Keep TIMESTAMP (IS EMPTY)` → now `Keep TIMESTAMP`.

#### Cleanup / robustness (folded in with the fixes)
- `local` scoping throughout (previously many implicit globals).
- Consistent positional result access (`res[i][1]`); the scaled-decimal function previously mixed
  in by-name access (`res[i].COLUMN_SCHEMA`).
- `length(floor(abs(...)))` instead of `length(round(abs(...)))` in the scaled-decimal measurement —
  `round()` over-counted e.g. `999.99` as 4 integer digits, missing valid shrinks (correctness fix).
- Renamed the misspelled `exectue_sql_column` → `execute_sql_column`.
- `execute_sql_column` skips empty SQL instead of executing an empty statement.
- Shared `smaller_integer_precision(needed, current_precision)` helper for the 32/64-bit decision.

---

## ✨ Improvements

**1. Prominent `apply_conversion` warning.** A clear, prominent warning was added to the script
header, the `--parameter` doc, the example call and the README: `TRUE` is irreversible; review the
dry-run first, or — safer — run the generated statements manually, one by one.

**2. DOUBLE → DECIMAL(p,s) with detected scale (lossless).** `DOUBLE` columns whose values have a
small constant number of decimals (e.g. prices `19.99`) are now converted to `DECIMAL(p,s)`,
generalizing the integer-only case. A scale `s` is accepted only when a **round-trip cast holds for
every row** — `cast(cast(v as decimal(36,s)) as double) = v` — proving the DECIMAL reproduces the
original DOUBLE bit-for-bit, so **no value is altered**. Genuine floats (e.g. `1/3`) stay `DOUBLE`.
Scale capped at 9, result ≤ 64-bit. The change is isolated to the branch that previously kept such
columns as `DOUBLE`; all other DOUBLE behaviour is byte-for-byte unchanged.

**3. `TIMESTAMP WITH LOCAL TIME ZONE` (type_id 124) → DATE.** The detection now matches
`column_type_id IN (93, 124)`, so both `TIMESTAMP` and `TIMESTAMP WITH LOCAL TIME ZONE` convert to
`DATE` when no value carries a time component (any precision `p` 0–9). For the time-zone variant the
`TRUNC` check and the `MODIFY ... DATE` both run in the current `SESSIONTIMEZONE` (same session, so
consistent). Output labels the source type accordingly.

**4. DOUBLE handling: one direct conversion instead of two passes.** A convertible `DOUBLE` is taken
straight to its optimal `DECIMAL` in a **single** `ALTER` — no intermediate `DECIMAL(18,0)` step, no
"please run again" note, no re-run. Dry-run and apply show identical, final statements.

**5. Per-conversion-type switches.** Each conversion type can be enabled/disabled independently via
the new `convert_*` parameters (see *Breaking change* for signature and rationale).

**6. `log_for_all_columns` is now a parameter** (was hard-coded). `false` reports only columns that
change; `true` reports every inspected column, including `Keep ...` rows.

**7. Output is sorted** by `schema_name`, `table_name`, `column_name`.

**8. "Nothing to do" output.** Instead of an empty result set, a single informative row is returned;
the wording adapts to `log_for_all_columns` (`No columns found that need optimization.` vs.
`No matching columns found (...)`).

**9. Performance — one table scan per column.** Each detection query was a `UNION ALL` of two
`SELECT`s over the same table (two scans per column); rewritten into a single `SELECT` with
conditional aggregation. (The DOUBLE scale detection adds one extra guarded scan, only for columns
that contain fractional values.)

> Case sensitivity is handled correctly: every schema/table/column name is processed as a delimited
> (double-quoted) identifier via `quote()` + the `::identifier` placeholder, so MixedCase/lowercase
> names work. The `schema_name`/`table_name` **filter** is a value comparison against the case-exact
> catalog names, so pass the name exactly as stored (or `%`).

---

## 💥 Breaking change — script signature

```
OLD: convert_datatypes(schema_name, table_name, apply_conversion)
NEW: convert_datatypes(schema_name, table_name,
                       convert_double, convert_integer, convert_decimal,
                       convert_timestamp, convert_varchar,
                       log_for_all_columns, apply_conversion)
```

Existing `EXECUTE SCRIPT` calls **must be updated** to pass the new arguments.

**Why this makes sense (rationale):**
- `apply_conversion = true` runs **irreversible** DDL — per-type switches let you apply only the
  conversions you trust (e.g. only `VARCHAR` shrink) and leave the rest untouched.
- **Staged rollouts:** convert one type at a time, verify, then enable the next.
- **Performance:** skip the scans for types you don't need (e.g. avoid the DOUBLE scale-detection
  scans entirely when `convert_double = false`).
- **Risk isolation:** numeric re-typing can be more sensitive for some analytics workloads than a
  pure `VARCHAR` shrink; each type is opt-in.
- `log_for_all_columns` as a parameter avoids editing the script body just to change output verbosity.

---

## Testing
`convert_datatypes_test.sql` covers: DOUBLE → DECIMAL(9,0)/(18,0)/(p,s) incl. the user's
`1.5/2.56/1.46575` case, "real double"/"too big"/empty; integer & scaled-decimal shrink incl. the
`floor()` boundary (`9999999.99`); TIMESTAMP/TIMESTAMP(9)/`WITH LOCAL TIME ZONE` → DATE incl.
sub-second detection; VARCHAR shrink/keep/tiny/empty with ASCII **and** UTF8 charset preservation;
MixedCase identifiers; per-type switches (Section E); `log_for_all_columns = true`; sorted output;
"nothing to do"; view & virtual exclusion.

## Validation
Validated end-to-end against a live Exasol database (version 2026.1.0), including a bit-for-bit
losslessness check for every converted DOUBLE (cast back to DOUBLE == original) and an idempotency
check (a second apply changes nothing). See `TEST_RESULTS.md` for the full evidence.


# convert_datatypes — Live Test Evidence

- **Database:** Exasol 2026.1.0 | **Schema:** EXASOL_BK_JDBCTEST | driver: pyexasol 2.2.1 on Python 3.12.13 over TLS
- 9-parameter signature compiled (CREATE SCRIPT): ✅
- Test objects use prefix `CDT` (dropped at the end); apply runs restricted to `CDT%` / single tables.

## 1) Dry-run proposals (all types ON, log=false) — note the schema/table/column ordering

```
  CDT_DATES     TS9_TO_DATE      TIMESTAMP --> DATE                                        
  CDT_DATES     TSLTZ_TO_DATE    TIMESTAMP WITH LOCAL TIME ZONE --> DATE                   
  CDT_DATES     TS_TO_DATE       TIMESTAMP --> DATE                                        
  CDT_DSCALE    BIGSCALE         DOUBLE --> DECIMAL(18, 1) (lossless)                      
  CDT_DSCALE    MIX_5            DOUBLE --> DECIMAL(9, 5) (lossless)                       
  CDT_DSCALE    ONE_DEC          DOUBLE --> DECIMAL(9, 1) (lossless)                       
  CDT_DSCALE    TWO_DEC          DOUBLE --> DECIMAL(9, 2) (lossless)                       
  CDT_LOG       D_CHANGE         DOUBLE --> DECIMAL(9, 0), max length: 1                   
  CDT_MixedTab  DoubleCol        DOUBLE --> DECIMAL(9, 0), max length: 1                   
  CDT_MixedTab  Var_Col          VARCHAR(500) ASCII  --> VARCHAR(20) ASCII, max length: 10 
  CDT_MixedTab  lower_ts         TIMESTAMP --> DATE                                        
  CDT_NUMBERS   DEC_INT_TO18     DECIMAL(36, 0)  --> DECIMAL(18, 0), max length: 18        
  CDT_NUMBERS   DEC_INT_TO9      DECIMAL(18, 0)  --> DECIMAL(9, 0), max length: 9          
  CDT_NUMBERS   DEC_SCALE_TO18   DECIMAL(36, 2)  --> DECIMAL(18, 2), needed precision: 18  
  CDT_NUMBERS   DEC_SCALE_TO9    DECIMAL(18, 2)  --> DECIMAL(9, 2), needed precision: 9    
  CDT_NUMBERS   D_TO_DEC18       DOUBLE --> DECIMAL(18, 0), max length: 11                 
  CDT_NUMBERS   D_TO_DEC9        DOUBLE --> DECIMAL(9, 0), max length: 1                   
  CDT_NUMBERS   D_TO_DECSCALE    DOUBLE --> DECIMAL(9, 2) (lossless)                       
  CDT_STRINGS   V_SHRINK_ASCII   VARCHAR(1000) ASCII  --> VARCHAR(20) ASCII, max length: 10
  CDT_STRINGS   V_SHRINK_UTF8    VARCHAR(1000) UTF8  --> VARCHAR(20) UTF8, max length: 10  
```
- Output sorted by (table, column): ✅

## 2) Apply (all types ON, log=false)

- Applied 20 statements, all success=true: ✅

## 3) Final column types vs. expected

**CDT_NUMBERS**

| column | final type | expected | result |
|---|---|---|---|
| D_TO_DEC9 | `DECIMAL(9,0)` | `DECIMAL(9,0)` | ✅ |
| D_TO_DEC18 | `DECIMAL(18,0)` | `DECIMAL(18,0)` | ✅ |
| D_TO_DECSCALE | `DECIMAL(9,2)` | `DECIMAL(9,2)` | ✅ |
| D_REAL_DOUBLE | `DOUBLE` | `DOUBLE` | ✅ |
| D_TOO_BIG | `DOUBLE` | `DOUBLE` | ✅ |
| D_HUGE | `DOUBLE` | `DOUBLE` | ✅ |
| D_ALL_NULL | `DOUBLE` | `DOUBLE` | ✅ |
| DEC_INT_TO9 | `DECIMAL(9,0)` | `DECIMAL(9,0)` | ✅ |
| DEC_INT_TO18 | `DECIMAL(18,0)` | `DECIMAL(18,0)` | ✅ |
| DEC_INT_KEEP | `DECIMAL(18,0)` | `DECIMAL(18,0)` | ✅ |
| DEC_SCALE_TO9 | `DECIMAL(9,2)` | `DECIMAL(9,2)` | ✅ |
| DEC_SCALE_TO18 | `DECIMAL(18,2)` | `DECIMAL(18,2)` | ✅ |
| DEC_SCALE_KEEP | `DECIMAL(18,4)` | `DECIMAL(18,4)` | ✅ |

**CDT_DSCALE**

| column | final type | expected | result |
|---|---|---|---|
| MIX_5 | `DECIMAL(9,5)` | `DECIMAL(9,5)` | ✅ |
| TWO_DEC | `DECIMAL(9,2)` | `DECIMAL(9,2)` | ✅ |
| ONE_DEC | `DECIMAL(9,1)` | `DECIMAL(9,1)` | ✅ |
| OVER9 | `DOUBLE` | `DOUBLE` | ✅ |
| BIGSCALE | `DECIMAL(18,1)` | `DECIMAL(18,1)` | ✅ |

**CDT_DATES**

| column | final type | expected | result |
|---|---|---|---|
| TS_TO_DATE | `DATE` | `DATE` | ✅ |
| TS9_TO_DATE | `DATE` | `DATE` | ✅ |
| TS_KEEP_TIME | `TIMESTAMP(3)` | `TIMESTAMP(3)` | ✅ |
| TS_KEEP_FRAC | `TIMESTAMP(3)` | `TIMESTAMP(3)` | ✅ |
| TSLTZ_TO_DATE | `DATE` | `DATE` | ✅ |
| TSLTZ_KEEP | `TIMESTAMP(3) WITH LOCAL TIME ZONE` | `TIMESTAMP(3) WITH LOCAL TIME ZONE` | ✅ |
| TS_ALL_NULL | `TIMESTAMP(3)` | `TIMESTAMP(3)` | ✅ |

**CDT_STRINGS**

| column | final type | expected | result |
|---|---|---|---|
| V_SHRINK_UTF8 | `VARCHAR(20) UTF8` | `VARCHAR(20) UTF8` | ✅ |
| V_SHRINK_ASCII | `VARCHAR(20) ASCII` | `VARCHAR(20) ASCII` | ✅ |
| V_KEEP | `VARCHAR(20) UTF8` | `VARCHAR(20) UTF8` | ✅ |
| V_TINY | `VARCHAR(3) UTF8` | `VARCHAR(3) UTF8` | ✅ |
| V_ALL_NULL | `VARCHAR(100) UTF8` | `VARCHAR(100) UTF8` | ✅ |

**CDT_MixedTab**

| column | final type | expected | result |
|---|---|---|---|
| DoubleCol | `DECIMAL(9,0)` | `DECIMAL(9,0)` | ✅ |
| lower_ts | `DATE` | `DATE` | ✅ |
| Var_Col | `VARCHAR(20) ASCII` | `VARCHAR(20) ASCII` | ✅ |

**CDT_NOOP**

| column | final type | expected | result |
|---|---|---|---|
| ALREADY_SMALL | `DECIMAL(9,0)` | `DECIMAL(9,0)` | ✅ |
| TINY_STR | `VARCHAR(3) UTF8` | `VARCHAR(3) UTF8` | ✅ |
| PURE_DATE | `DATE` | `DATE` | ✅ |
| FLAG | `BOOLEAN` | `BOOLEAN` | ✅ |

## 4) Losslessness — every converted DOUBLE cast back == original

| column | preserved | values |
|---|---|---|
| CDT_NUMBERS.D_TO_DEC9 | ✅ | `[1.0, 2.0, 3.0]` |
| CDT_NUMBERS.D_TO_DEC18 | ✅ | `[1.0, 12345678901.0, 99999999999.0]` |
| CDT_NUMBERS.D_TO_DECSCALE | ✅ | `[1.5, 2.25, 3.75]` |
| CDT_DSCALE.MIX_5 | ✅ | `[1.46575, 1.5, 2.56]` |
| CDT_DSCALE.TWO_DEC | ✅ | `[0.01, 19.99, 1234.5]` |
| CDT_DSCALE.ONE_DEC | ✅ | `[0.1, 2.5, 3.3]` |
| CDT_DSCALE.BIGSCALE | ✅ | `[1.5, 9.0, 12345678901234.5]` |

## 5) Idempotency — second apply changes nothing

- Second apply returns only the 'nothing to do' row: ✅

## 6) Per-conversion-type switches (one column per type in CDT_SW)

| double | integer | decimal | timestamp | varchar | proposed |
|:-:|:-:|:-:|:-:|:-:|---|
| · | · | · | · | · | _(none)_ |
| ✔ | · | · | · | · | D |
| · | ✔ | · | · | · | DEC0 |
| · | · | ✔ | · | · | DEC2 |
| · | · | · | ✔ | · | TS |
| · | · | · | · | ✔ | V |
| · | · | · | ✔ | ✔ | TS, V |
| ✔ | ✔ | ✔ | ✔ | ✔ | D, DEC0, DEC2, TS, V |

- All switch combinations behave exactly as expected: ✅

## 7) log_for_all_columns (CDT_LOG: D_CHANGE converts, D_KEEP stays, V_KEEP filtered out)

```
log_for_all_columns = false:
  D_CHANGE   DOUBLE --> DECIMAL(9, 0), max length: 1

log_for_all_columns = true:
  D_CHANGE   DOUBLE --> DECIMAL(9, 0), max length: 1
  D_KEEP     Keep DOUBLE                            
```
- log=false reports only the changed column (D_CHANGE): ✅
- log=true also reports the kept column (D_CHANGE + D_KEEP), V_KEEP still excluded: ✅

## 8) 'Empty result' message wording depends on log_for_all_columns

- log=false -> `No columns found that need optimization.`
- log=true  -> `No matching columns found (check the filters and the convert_* switches).`
- both return exactly one info row with the right wording: ✅

## 9) Edge cases

- NOOP table (no optimizable column): `No columns found that need optimization.` ✅
- VIEW excluded (CDT_VIEW): `No columns found that need optimization.` ✅

## Summary: **54 checks passed, 0 failed**

[convert_datatypes_test.sql](https://github.com/user-attachments/files/29011249/convert_datatypes_test.sql)
