### PR TITLE
Improve convert_varchar: bug fixes, performance, structured output, multi-format date detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/post_load_optimization/README.md
+++ b/post_load_optimization/README.md
@@ -2,21 +2,201 @@
 
 This folder contains scripts that can be used after having imported data from another database.
 What they do:
-- Optimize the column's datatypes to minimize storage space on disk and to speed up joins, see section
-- Import primary keys from other databases
+- **Convert VARCHAR columns** that actually hold numbers / dates / booleans / … into their real data
+  types (`convert_varchar`)
+- **Optimize the column data types** to minimize storage space on disk and to speed up joins
+  (`convert_datatypes`)
+- **Import primary keys** from other databases (`set_primary_keys`)
+
+> 🔁 **Recommended order:** run [`convert_varchar`](#convert_varchar) **first** (turn string columns into
+> their real data types), then [`convert_datatypes`](#optimize_datatypes) to shrink everything to the
+> smallest sufficient size.
 
 
 ## Table of Contents
-1. [Optimize datatypes](#optimize_datatypes)
-2. [Migrate primary keys](#migrate_primary_keys)
+1. [Convert VARCHAR columns](#convert_varchar)
+2. [Optimize datatypes](#optimize_datatypes)
+3. [Migrate primary keys](#migrate_primary_keys)
 
 
-## Optimize datatypes
+## Convert VARCHAR columns to real data types <a name="convert_varchar"></a>
 
+The `convert_varchar.sql` script inspects the **`VARCHAR` columns** that match a schema/table filter and,
+based on a **sample** of the actual values, suggests the smallest/most appropriate data type for each
+column. It is meant for the typical post-import situation where everything arrived as `VARCHAR`.
+
+> 📖 **Background:** see Exasol's [Performance Best Practices](https://docs.exasol.com/db/latest/performance/best_practices.htm) —
+> using the smallest sufficient data type improves compression and join/query performance.
+
+> 🔁 **Recommended order: run `convert_varchar` FIRST, then `convert_datatypes`.**
+> `convert_varchar` turns string columns into their *true* types (`VARCHAR` → `DECIMAL`/`DATE`/
+> `TIMESTAMP`/`BOOLEAN`/…). Afterwards run [`convert_datatypes`](#optimize_datatypes) to squeeze those
+> (and the existing numeric/timestamp/varchar columns) down to the smallest sufficient size. Doing it the
+> other way round misses the columns that are still `VARCHAR`.
+
+Only **real, local base TABLE** columns are inspected (views/synonyms and **virtual schema** columns are
+excluded: `COLUMN_OBJECT_TYPE = 'TABLE'` and `COLUMN_IS_VIRTUAL = FALSE`).
+
+> ### 🌐 NLS settings & formats
+> Two detection paths:
+> 1. **Primary (session NLS).** `IS_DATE` / `IS_TIMESTAMP` / `IS_NUMBER` and the plain `ALTER`s use the
+>    current session settings (`NLS_DATE_FORMAT`, `NLS_TIMESTAMP_FORMAT`, `NLS_NUMERIC_CHARACTERS`,
+>    `NLS_DATE_LANGUAGE`) — a value is recognized here only if it matches the session format. The decimal
+>    separator is read from `NLS_NUMERIC_CHARACTERS` (so German `1234,56` works under `',.'`; no longer
+>    hard-coded `.`). `NLS_DATE_LANGUAGE` only matters for month/day **names**; `NLS_FIRST_DAY_OF_WEEK` is
+>    irrelevant.
+> 2. **Multi-format fallback (NLS-independent).** Columns not classified by path 1 are probed against a
+>    set of explicit format models — so a German `12.06.2026` (or `DD.MM.YYYY HH24:MI:SS`) is detected
+>    **regardless of the session NLS** (see *Multi-format detection* below).
+>
+> Note: the suggested **plain** `MODIFY COLUMN … DATE/TIMESTAMP/DECIMAL` (path 1) parses via the session
+> NLS — so apply it in a session whose NLS matches the data. The multi-format suggestions (path 2) already
+> include the matching `ALTER SESSION SET NLS_…_FORMAT='…'` so they are self-contained.
+
+### Multi-format detection (explicit format models)
+
+For columns that the session-NLS path does not classify, the script probes a set of common explicit
+formats and, when **exactly one** matches **all** sampled values, prints a self-contained recipe:
+
+| Example values | Output |
+|---|---|
+| `12.06.2026`, `31.12.2025` | `ALTER SESSION SET NLS_DATE_FORMAT='DD.MM.YYYY';` + `… MODIFY COLUMN c DATE;` |
+| `06/15/2026` | `… NLS_DATE_FORMAT='MM/DD/YYYY';` + `… DATE;` |
+| `2026.06.12` | `… NLS_DATE_FORMAT='YYYY.MM.DD';` + `… DATE;` |
+| `12.06.2026 10:00:00.123456` | `… NLS_TIMESTAMP_FORMAT='DD.MM.YYYY HH24:MI:SS.FF6';` + `… TIMESTAMP(6);` |
+| `01.02.2026`, `03.04.2026` (every day ≤ 12) | **AMBIGUOUS** warning — DD.MM vs MM.DD cannot be told apart, so it is *not* guessed; pick the format yourself |
+
+Probed formats: date orders `YYYY/MM/DD`, `DD/MM/YYYY`, `MM/DD/YYYY` with separators `-`, `.`, `/`
+(and the same with ` HH24:MI:SS[.FF]` for timestamps). The fractional-seconds precision (0–9) is detected
+from the values. Day/month order is only chosen when the data disambiguates it (some day > 12); otherwise
+it is reported as ambiguous. Time-of-day must be `HH24:MI:SS[.FF]` (24-hour); other time formats are not
+auto-detected.
+
+> ### ⚠️ REPORT ONLY — and review before you apply anything
+> This script **does not change your data**. It only **returns rows** describing the suggestion plus the
+> `ALTER TABLE ... MODIFY COLUMN` statement(s) you *could* run (in the `query_text` column). You execute
+> them yourself.
+>
+> - Decisions are based on a **SAMPLE** (see `sample_size`). A value **outside** the sample may not fit
+>   the suggested type, so a generated `ALTER` can still fail or change data.
+> - Numeric/date suggestions can be **LOSSY**: e.g. `'007' → 7` (leading zeros lost), `'+49' → 49`
+>   (sign/format lost). Zip codes, phone numbers and article numbers are typical traps.
+> - **Always review each statement** and ideally run them one by one, checking the result.
+>
+> The output also flags risky cases **per column, in the `notes` column**:
+> - a numeric column with **leading zeros or a `+` sign** → `WARNING: looks like an identifier … LOSES them … Review!`
+> - `0/1` → `BOOLEAN` and `TRUE/FALSE` → `BOOLEAN` → a `NOTE:` to verify it is really a boolean (not flags/codes).
+
+### What it detects
+
+| If the sampled values look like … | Suggestion |
+|---|---|
+| integers | `DECIMAL(p)` (precision rounded up to 9 / 18 / 36) |
+| integers + decimals | `DECIMAL(p, s)` |
+| any numeric incl. scientific notation | `DOUBLE PRECISION` |
+| dates only (no time component) | `DATE` |
+| dates and/or timestamps | `TIMESTAMP(p)` with the **detected fractional-seconds precision** `p` (0–9), so micro/nanosecond values are not truncated; + hint to consider `TIMESTAMP WITH LOCAL TIME ZONE` |
+| `TRUE`/`FALSE`, or only `0`/`1` | `BOOLEAN` |
+| day-to-second intervals | `INTERVAL DAY(p) TO SECOND(fp)` |
+| year-to-month intervals | `INTERVAL YEAR(p) TO MONTH` |
+| WKT geometry (`POINT (…)`, `POLYGON (…)`, …) | `GEOMETRY` (+ hint to specify an SRID) |
+| nothing single fits, but values are shorter than the column | shrink to a smaller `VARCHAR` — actual max length **+ ~20% headroom, rounded up**, **character set preserved** |
+| the **column name** looks like a date/timestamp but values don't parse | a hint with an example `UPDATE`/`ALTER` |
+| the column is empty (in the sample) | a hint that the column could be dropped |
+
+### Parameters
+
+```sql
+execute script DATABASE_MIGRATION.CONVERT_VARCHAR(
+    'MY_SCHEMA',   -- schema_pattern:      schema name or filter, wildcards (%) allowed
+    '%',           -- table_pattern:       table name or filter, wildcards (%) allowed
+    '5%',          -- sample_size:         number of rows (min 1000) or a percentage string like '5%'
+    false          -- log_for_all_columns: false = only columns that change, true = every inspected column
+);
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `SCHEMA_PATTERN` | Schema name or filter (`%` allowed). Must be a non-empty string. |
+| `TABLE_PATTERN` | Table name or filter (`%` allowed). Must be a non-empty string. |
+| `SAMPLE_SIZE` | How many rows to inspect per table: an integer (number of rows, minimum 1000) **or** a percentage string like `'5%'`. Anything else defaults to `1%`. **A 1–5% sample is usually statistically sufficient** for a reliable type guess and is much faster on large tables; use `'100%'` only when you must check every single value. |
+| `LOG_FOR_ALL_COLUMNS` | `true`/`false`. `false` = report only columns that get a **suggestion** (a conversion or shrink). `true` = report **every inspected** `VARCHAR` column, including `Keep VARCHAR(…)` rows and advisory rows (ambiguous formats, date-name hints, empty columns). |
+
+### Output
+
+The script returns **structured rows**, sorted by `schema_name`, `table_name`, `column_name`, with a
+`notes` column for the warnings/hints/recipes:
+
+| Column | Meaning |
+|--------|---------|
+| `schema_name`, `table_name`, `column_name` | the inspected column |
+| `conversion` | short description of the suggestion, e.g. `VARCHAR --> DECIMAL(9)` or `Keep VARCHAR(100) UTF8, max length: 12` |
+| `query_text` | the `ALTER` statement(s) you would run (empty for *keep*/advisory rows). Multi-format date/timestamp suggestions include the required `ALTER SESSION SET NLS_..._FORMAT='…';` **before** the `ALTER TABLE`, so the cell is runnable as-is |
+| `notes` | warnings (leading zeros / `+` sign), the `0/1`-boolean `NOTE`, the ambiguity message, the TIMESTAMP-precision recipe, column-name hints |
+
+`log_for_all_columns = false` returns only columns that get a suggestion; `= true` returns **every**
+inspected column (incl. `Keep …` rows and advisory rows).
+
+Example (`log_for_all_columns = true`, session NLS at the ISO default):
+
+| schema_name | table_name | column_name | conversion | query_text | notes |
+|---|---|---|---|---|---|
+| MY_SCHEMA | CUSTOMERS | ACTIVE | `VARCHAR --> BOOLEAN` | `ALTER TABLE "MY_SCHEMA"."CUSTOMERS" MODIFY COLUMN "ACTIVE" BOOLEAN;` | NOTE: only 0/1 values. Verify these are real booleans, not flags/bits/codes you compute with. |
+| MY_SCHEMA | CUSTOMERS | AMOUNT | `VARCHAR --> DECIMAL(4, 2)` | `ALTER TABLE "MY_SCHEMA"."CUSTOMERS" MODIFY COLUMN "AMOUNT" DECIMAL(4, 2);` | |
+| MY_SCHEMA | CUSTOMERS | COMMENT | `VARCHAR(2000000) UTF8 --> VARCHAR(20) UTF8, max length: 15` | `ALTER TABLE "MY_SCHEMA"."CUSTOMERS" MODIFY COLUMN "COMMENT" VARCHAR(20) UTF8;` | Mixed values; no single type fits. Shrinking the width (actual max length 15 + ~20% headroom); character set preserved. |
+| MY_SCHEMA | CUSTOMERS | CUST_ID | `VARCHAR --> DECIMAL(9)` | `ALTER TABLE "MY_SCHEMA"."CUSTOMERS" MODIFY COLUMN "CUST_ID" DECIMAL(9);` | WARNING: some values have leading zeros or a '+' sign (looks like an identifier: ID / ZIP / phone / article no.). Converting to DECIMAL LOSES them ('007' -> 7, '+49' -> 49). Review before applying! |
+| MY_SCHEMA | CUSTOMERS | DE_DATE | `VARCHAR --> DATE (format DD.MM.YYYY)` | `ALTER SESSION SET NLS_DATE_FORMAT='DD.MM.YYYY'; ALTER TABLE "MY_SCHEMA"."CUSTOMERS" MODIFY COLUMN "DE_DATE" DATE;` | Values match the date format 'DD.MM.YYYY' (not the session NLS_DATE_FORMAT). Run BOTH statements in query_text (the ALTER SESSION first). |
+| MY_SCHEMA | CUSTOMERS | ORDER_DATE | `VARCHAR --> DATE` | `ALTER TABLE "MY_SCHEMA"."CUSTOMERS" MODIFY COLUMN "ORDER_DATE" DATE;` | |
+
+If no `VARCHAR` column matches the filter (no such table, or the table has no `VARCHAR` columns), the
+script returns a single informative row instead of an empty result set (in the `conversion` column):
+
+- `log_for_all_columns = false` → `No columns found that need optimization.`
+- `log_for_all_columns = true`  → `No matching VARCHAR columns found (check the schema/table filter).`
+
+### How it works / notes
+
+- **Type-directed, single scan.** Each column is analyzed with one aggregate query whose inner `CASE`
+  classifies every value **once and short-circuits** — a numeric value is settled by `IS_NUMBER` alone and
+  never runs the costly date/timestamp/interval/geometry checks, so the per-row cost matches the column's
+  real type. When the sample covers the whole table (e.g. `'100%'`) the `LIMIT` subquery is **omitted**, so
+  the table is scanned straight into the aggregation instead of first being copied into a temporary table.
+  The NLS-independent multi-format probe is a separate query that runs **only for unclassified columns whose
+  values are date-LIKE** (a cheap one-regex pre-check skips it for name/code/free-text columns) and that
+  **also omits the `LIMIT`** on a full scan. The suggestion reflects the sample, not necessarily the whole column.
+- **Sampling is the main cost lever.** A **1–5% sample is usually statistically sufficient** to infer a
+  column's type reliably (often even `'1%'`), and it is dramatically faster than `'100%'` on large tables.
+  Prefer such a sample (or a fixed row count) over `'100%'`; reserve `'100%'` for when you truly must verify
+  that the suggested type fits *every* value. Avoid high-but-not-100% values like `'99%'` (they still
+  materialize almost all rows). With a sample, only those rows are materialized.
+- **Robust date/timestamp check.** Date vs. timestamp uses `IS_DATE` / `IS_TIMESTAMP` plus `TRUNC()`
+  to detect a time component; `TO_TIMESTAMP()` is only evaluated for values that are timestamps, so the
+  check does **not** depend on `TIMESTAMP_ARITHMETIC_BEHAVIOR` and works even when `NLS_DATE_FORMAT` and
+  `NLS_TIMESTAMP_FORMAT` differ (e.g. a German `DD.MM.YYYY` date format).
+- **TIMESTAMP precision (0–9).** The suggested `TIMESTAMP(p)` uses the detected number of fractional-
+  second digits, so values down to nanoseconds are preserved (a bare `TIMESTAMP` is `TIMESTAMP(3)` and
+  would truncate anything finer than milliseconds). If a column has **more** fractional digits than the
+  session `NLS_TIMESTAMP_FORMAT` can parse (e.g. data has 9 digits but the format is `FF6`), the output
+  warns that a plain `ALTER` would truncate and prints the `ALTER SESSION SET NLS_TIMESTAMP_FORMAT='…FF<p>'`
+  recipe needed to keep full precision.
+  `TIMESTAMP WITH LOCAL TIME ZONE` is only *suggested as a hint* (it cannot be told apart from a plain
+  timestamp by the text alone).
+- **Character set preserved.** When a column is only shrunk (`VARCHAR(n)`), its original `ASCII` / `UTF8`
+  character set is kept (e.g. `VARCHAR(2000000) ASCII` → `VARCHAR(20) ASCII`, never `UTF8`).
+- **Robust.** A single column or table that cannot be analyzed is reported and skipped.
+- **Limitations.** Geometry is recognized by a WKT text pattern (heuristic, may yield false positives);
+  numeric/date suggestions are lossy for identifier-like data (see the warning above).
+
+
+## Optimize datatypes <a name="optimize_datatypes"></a>
 
 The `convert_datatypes.sql` script optimizes table column datatypes to reduce disk
 storage and improve join performance. You typically run it once after importing your
 data. It first reports (or applies) the changes it would make, so you stay in control.
+
+> 🔁 **Tip:** if your data is still in `VARCHAR` columns, run [`convert_varchar`](#convert_varchar) first
+> to give those columns their real data types, then run this script to shrink everything to the smallest
+> sufficient size.
 
 > 📖 **Background:** see Exasol's [Performance Best Practices](https://docs.exasol.com/db/latest/performance/best_practices.htm).
 > Choosing the smallest sufficient data type improves compression and join/query performance —
@@ -140,8 +320,6 @@ names as stored in the catalog. Pass the name exactly as it was created (e.g.
      irreversibly in one go, with no undo.
 
 
-
-
-## Migrate primary keys
+## Migrate primary keys <a name="migrate_primary_keys"></a>
 
 See script [set_primary_keys.sql](set_primary_keys.sql)

--- a/post_load_optimization/convert_varchar.sql
+++ b/post_load_optimization/convert_varchar.sql
@@ -1,21 +1,68 @@
-CREATE SCHEMA IF NOT EXISTS database_migration;
+CREATE SCHEMA IF NOT EXISTS DATABASE_MIGRATION;
 
 /*
-    This script attempts to identify the optimal data type (and its size or precision) of VARCHAR columns
-        based on the values in the given column.
-    It generates the appropriate ALTER TABLE ... MODIFY COLUMN statements or advises you what steps you can
-        take to convert the data type.
+    convert_varchar - suggest a better data type for VARCHAR columns
+    ====================================================================================================
+    This script inspects the VARCHAR columns that match the given schema/table filter and, based on a
+    SAMPLE of the actual values, suggests the smallest/most appropriate data type for each column. It
+    detects: integer / decimal / double, DATE / TIMESTAMP, BOOLEAN, INTERVAL DAY TO SECOND,
+    INTERVAL YEAR TO MONTH and GEOMETRY; if no single type fits, it suggests shrinking the VARCHAR
+    width (keeping the original character set). For columns whose NAME looks like a date/timestamp but
+    whose values do not parse, it prints hints.
+
+    Each column is analyzed with ONE lean aggregate query over a sample: a short-circuiting CASE classifies
+    every value exactly once (a numeric value is settled by IS_NUMBER alone, without running the costly
+    date/timestamp/interval/geometry checks), so the per-row cost matches the column's real type. The
+    NLS-independent multi-format probe is a separate query that runs only for the few columns left
+    unclassified. For large tables prefer a sample over '100%' -- a 1-5% sample is usually statistically
+    sufficient for a reliable result and is much faster.
+
+    Only real, local base TABLE columns are inspected (views/synonyms and VIRTUAL SCHEMA columns are
+    excluded).
+
+    ----------------------------------------------------------------------------------------------------
+    REPORT ONLY - this script does NOT change anything. It only RETURNS rows: a "conversion" description,
+    the "query_text" you could run, and "notes" (warnings/hints). You execute the statements yourself.
+
+    !!! REVIEW BEFORE YOU APPLY ANYTHING !!!
+      - Decisions are based on a SAMPLE (see sample_size). A value OUTSIDE the sample may not fit the
+        suggested type, so a generated ALTER can still fail or, worse, change data.
+      - Numeric/date suggestions can be LOSSY: e.g. '007' -> 7 (leading zeros lost), '+49' -> 49
+        (sign/format lost), zip codes / phone numbers / article numbers are typical traps.
+      - Always review each statement and, ideally, run them one by one and check the result.
+    ----------------------------------------------------------------------------------------------------
+
+    Output columns (sorted by schema_name, table_name, column_name):
+      schema_name, table_name, column_name : the inspected column
+      conversion  : short description of the suggestion, e.g. "VARCHAR --> DECIMAL(9)" or
+                    "Keep VARCHAR(100) UTF8, max length: 12"
+      query_text  : the ALTER statement(s) to run (empty for "keep"/advisory rows). Multi-format
+                    date/timestamp suggestions include the required "ALTER SESSION SET NLS_..._FORMAT".
+      notes       : warnings (leading zeros / '+' sign), 0/1-boolean note, ambiguity, precision recipe, hints
+
+    Parameters:
+      schema_pattern      : schema name or filter, wildcards (%) allowed
+      table_pattern       : table name or filter, wildcards (%) allowed
+      sample_size         : table data sample size; either an integer (number of rows, min 1000) or a
+                            string expressing an integer percentage, e.g. '5%'. Anything else defaults to 1%.
+                            A 1-5% sample is usually statistically sufficient for a reliable type guess and
+                            is much faster on large tables; use '100%' only when you must check every value.
+      log_for_all_columns : false = only report columns that get a suggestion (a conversion or shrink);
+                            true  = report every inspected VARCHAR column (incl. "Keep ..." rows)
+
     No Animals Were Harmed in the Making of This Script.
 */
 
+--parameter	schema_pattern:      schema name or SCHEMA filter (can be %)
+--parameter	table_pattern:       table name or TABLE filter (can be %)
+--parameter	sample_size:         number of rows (min 1000) or a percentage string like '5%'
+--parameter	log_for_all_columns: false = only report columns that change, true = report every inspected column
 --/
-CREATE OR REPLACE SCRIPT database_migration.convert_varchar(schema_pattern, table_pattern, sample_size) RETURNS TABLE AS
+CREATE OR REPLACE SCRIPT database_migration.convert_varchar(schema_pattern, table_pattern, sample_size, log_for_all_columns) RETURNS TABLE AS
 
-    ret = {}
-    ret_type = "message VARCHAR(1000)"
-    sample_rows = 0
-    sample_pct  = 0
-    sample_min  = 1000
+    local sample_rows = 0
+    local sample_pct  = 0
+    local sample_min  = 1000
 
     function adjust_precision(prec)
         if prec <= 9 then
@@ -27,12 +74,126 @@ CREATE OR REPLACE SCRIPT database_migration.convert_varchar(schema_pattern, tabl
         end
     end
 
-    -- Check parameters
-    if schema_pattern == '' or type(schema_pattern) ~= 'string' or
-       table_pattern  == '' or type(schema_pattern) ~= 'string' then
-        exit(ret, ret_type)
+    -- VARCHAR shrink size: actual max length + ~20% headroom, rounded up to the next round number,
+    -- capped at 2,000,000.
+    function estimate_optimal_varchar_length(n)
+        local n_p20            = math.ceil(n + n * 0.2)
+        local number_digits    = string.len(n_p20)
+        local magnitude        = math.floor(10 ^ (number_digits - 1))
+        local estimated_length = math.floor(n_p20 / magnitude) * magnitude + magnitude
+        return math.min(estimated_length, 2000000)
     end
 
+    -- Reads a single session parameter; returns default_value if the query fails or is empty.
+    function param_value(name, default_value)
+        local ok, r = pquery([[SELECT session_value FROM exa_parameters WHERE parameter_name = :p]], {p = name})
+        if ok and r[1] ~= nil and r[1][1] ~= nil then
+            return r[1][1]
+        end
+        return default_value
+    end
+
+    -- Returns the maximal string length found in one column of the result table (>= 1, capped at 2000).
+    function getMaxLengthForColumn(input_table, column_number)
+        local length = 1
+        for i = 1, #input_table do
+            local v = input_table[i][column_number]
+            if v ~= nil and #v > length then length = #v end
+        end
+        return math.min(length, 2000)
+    end
+
+    -- Date-part candidates for the NLS-independent multi-format detection. "swap" is the day/month-swapped
+    -- sibling used for ambiguity detection (e.g. DD.MM vs MM.DD when every day is <= 12).
+    local CAND = {
+        {fmt='YYYY-MM-DD'}, {fmt='YYYY.MM.DD'}, {fmt='YYYY/MM/DD'},
+        {fmt='DD.MM.YYYY', swap='MM.DD.YYYY'}, {fmt='MM.DD.YYYY', swap='DD.MM.YYYY'},
+        {fmt='DD/MM/YYYY', swap='MM/DD/YYYY'}, {fmt='MM/DD/YYYY', swap='DD/MM/YYYY'},
+        {fmt='DD-MM-YYYY', swap='MM-DD-YYYY'}, {fmt='MM-DD-YYYY', swap='DD-MM-YYYY'}
+    }
+
+    -- Multi-format date/timestamp detection via EXPLICIT format models (NLS-independent). It runs its own
+    -- probe query and is called ONLY for the few columns the primary type check leaves unclassified (see
+    -- the else-branch), so its extra per-row cost (one IS_DATE + one IS_TIMESTAMP per candidate format) is
+    -- never paid for the numeric/date/etc. columns that make up most of a database. A format "matches" only
+    -- if it parses ALL non-null sampled values; a conversion is proposed only when exactly ONE unambiguous
+    -- format matches (an ambiguous day/month order is reported, not guessed).
+    -- Returns: nil | {ambiguous=true} | {fmt='DD.MM.YYYY', kind='DATE'|'TIMESTAMP', frac=<0..9>}
+    function detect_explicit_format(sch_raw, tab_raw, col_raw, sample, full_scan)
+        -- string.char(92) produces the backslash for the trailing-fraction regex without writing a literal
+        -- backslash in the Lua source (Lua rejects an invalid escape, and a backslash directly before a
+        -- quote is misread by some SQL clients as an escaped quote).
+        local sel = "SUM(CASE WHEN col IS NOT NULL THEN 1 ELSE 0 END) entries"
+                 .. ", MAX(CASE WHEN INSTR(col, CHR(58)) > 0 THEN 1 ELSE 0 END) has_time"
+                 .. ", MAX(COALESCE(LENGTH(REGEXP_SUBSTR(col, '" .. string.char(92) .. ".[0-9]+$')) - 1, 0)) maxfrac"
+        for i, c in ipairs(CAND) do
+            sel = sel .. ", SUM(CASE WHEN IS_DATE(col, '" .. c.fmt .. "') THEN 1 ELSE 0 END) df" .. i
+                      .. ", SUM(CASE WHEN IS_TIMESTAMP(col, '" .. c.fmt .. " HH24:MI:SS.FF9') THEN 1 ELSE 0 END) tf" .. i
+        end
+        -- Omit the LIMIT subquery on a full scan (the sample covers the whole table), so the probe does
+        -- not materialize a temporary copy either; with a real sample the LIMIT keeps it to the sample.
+        local from_src = [[ SELECT ::col AS col FROM ::sch.::tab ]]
+        local binds    = { sch = quote(sch_raw), tab = quote(tab_raw), col = quote(col_raw) }
+        if not full_scan then from_src = from_src .. [[ LIMIT :lmt ]]; binds.lmt = sample end
+        local ok, r = pquery([[ SELECT ]] .. sel .. [[ FROM ( ]] .. from_src .. [[ ) ]], binds)
+        if not ok then return nil end
+        local res3     = r[1]
+        local entries  = res3["ENTRIES"]
+        if entries == nil or entries == 0 then return nil end
+        local has_time = res3["HAS_TIME"] == 1
+        local maxfrac  = math.min(res3["MAXFRAC"] or 0, 9)
+        local prefix   = has_time and "TF" or "DF"
+        local matched  = {}
+        local nmatched = 0
+        for i, c in ipairs(CAND) do
+            if res3[prefix .. i] == entries then matched[c.fmt] = true; nmatched = nmatched + 1 end
+        end
+        if nmatched == 0 then return nil end
+        for i, c in ipairs(CAND) do                       -- ambiguous if a format AND its swap both match
+            if matched[c.fmt] and c.swap and matched[c.swap] then return { ambiguous = true } end
+        end
+        for i, c in ipairs(CAND) do                       -- the single unambiguous match
+            if matched[c.fmt] then
+                return { fmt = c.fmt, kind = (has_time and 'TIMESTAMP' or 'DATE'), frac = maxfrac }
+            end
+        end
+        return nil
+    end
+
+    -- Sorts the rows (schema, table, column), inserts a friendly message if empty, sizes the output
+    -- columns dynamically and exits. log_for_all_columns selects which empty message is shown.
+    function emit_and_exit(rows)
+        table.sort(rows, function(a, b)
+            if a[1] ~= b[1] then return a[1] < b[1] end
+            if a[2] ~= b[2] then return a[2] < b[2] end
+            return a[3] < b[3]
+        end)
+        if #rows == 0 then
+            local empty_msg
+            if log_for_all_columns then
+                empty_msg = 'No matching VARCHAR columns found (check the schema/table filter).'
+            else
+                empty_msg = 'No columns found that need optimization.'
+            end
+            rows[1] = {'', '', '', empty_msg, '', ''}
+        end
+        local ls  = getMaxLengthForColumn(rows, 1)
+        local lt  = getMaxLengthForColumn(rows, 2)
+        local lc  = getMaxLengthForColumn(rows, 3)
+        local lco = getMaxLengthForColumn(rows, 4)
+        local lq  = getMaxLengthForColumn(rows, 5)
+        local ln  = getMaxLengthForColumn(rows, 6)
+        exit(rows, "schema_name char(" .. ls .. "), table_name char(" .. lt .. "), column_name char(" .. lc
+                   .. "), conversion char(" .. lco .. "), query_text char(" .. lq .. "), notes char(" .. ln .. ")")
+    end
+
+    -- Check parameters (both schema_pattern AND table_pattern must be non-empty strings)
+    if schema_pattern == '' or type(schema_pattern) ~= 'string' or
+       table_pattern  == '' or type(table_pattern)  ~= 'string' then
+        emit_and_exit({ {'', '', '', 'Invalid parameters: schema_pattern and table_pattern must be non-empty strings.', '', ''} })
+    end
+
+    -- Sample size: integer rows (min 1000) or a percentage string like '5%'; default 1%
     if type(sample_size) == 'number' then
         sample_rows = math.max(math.floor(sample_size), sample_min)
     elseif type(sample_size) == 'string' then
@@ -42,249 +203,347 @@ CREATE OR REPLACE SCRIPT database_migration.convert_varchar(schema_pattern, tabl
             sample_rows = math.max(tonumber(string.match(sample_size, '^[0-9]+')), sample_min)
         else
             sample_pct = 1
-        end;
+        end
+    else
+        sample_pct = 1
     end
 
-    -- Getting decimal character
-    suc, res = pquery([[SELECT SUBSTR(session_value, 1, 1 ) FROM exa_parameters WHERE  parameter_name = 'NLS_NUMERIC_CHARACTERS']])
-    dec_char = res[1][1]
-    regexp_int = '^ *[+-]?[0-9]+ *$'
-    regexp_dec = '^ *[+-]?[0-9]*\\'  .. dec_char .. '[0-9]+ *$'
-    regexp_dpr = '^ *[+-]?[0-9]*(\\' .. dec_char .. '[0-9]+)?[eE][+-]?[0-9]+ *$'
+    -- Decimal character (default '.'), and the numeric recognition patterns
+    local dec_char = string.sub(param_value('NLS_NUMERIC_CHARACTERS', '.'), 1, 1)
+    if dec_char == '' then dec_char = '.' end
+    -- The regex pieces below deliberately avoid two characters that some SQL clients (e.g. DbVisualizer)
+    -- otherwise mistake for parameter markers when installing the script:
+    --   * "{0,1}" is used instead of the regex zero-or-one quantifier (the question-mark character) --
+    --     it is equivalent in the Exasol REGEXP_LIKE function.
+    --   * the backslash that escapes the decimal separator is produced with string.char(92), not written
+    --     as a literal, so the script text never contains a backslash immediately before a quote (a naive
+    --     parser reads that as an escaped quote and then loses track of where string literals end).
+    local dec_re     = string.char(92) .. dec_char   -- escaped decimal separator (backslash + dec char)
+    local regexp_int = '^ *[+-]{0,1}[0-9]+ *$'
+    local regexp_dec = '^ *[+-]{0,1}[0-9]*' .. dec_re .. '[0-9]+ *$'
+    local regexp_dpr = '^ *[+-]{0,1}[0-9]*(' .. dec_re .. '[0-9]+){0,1}[eE][+-]{0,1}[0-9]+ *$'
 
-    -- Getting NLS_DATE_FORMAT
-    suc, res = pquery([[SELECT session_value FROM exa_parameters WHERE parameter_name = 'NLS_DATE_FORMAT']])
-    nls_date_format = res[1][1]
+    -- Date/timestamp formats (used for the "column name looks like a date" hints and the FF recipe)
+    local nls_date_format      = param_value('NLS_DATE_FORMAT',      'YYYY-MM-DD')
+    local nls_timestamp_format = param_value('NLS_TIMESTAMP_FORMAT', 'YYYY-MM-DD HH24:MI:SS.FF6')
 
-    -- Getting NLS_TIMESTAMP_FORMAT
-    suc, res = pquery([[SELECT session_value FROM exa_parameters WHERE parameter_name = 'NLS_TIMESTAMP_FORMAT']])
-    nls_timestamp_format = res[1][1]
+    -- Fractional-seconds precision the current NLS_TIMESTAMP_FORMAT can PARSE (FF<n>); used to warn
+    -- when a column has more fractional digits than a plain ALTER (implicit conversion) would keep.
+    local nls_ff = 0
+    local ff_digit = string.match(nls_timestamp_format, 'FF(%d)')
+    if ff_digit ~= nil then
+        nls_ff = tonumber(ff_digit)
+    elseif string.find(nls_timestamp_format, 'FF', 1, true) ~= nil then
+        nls_ff = 6   -- 'FF' without a digit defaults to 6 in Exasol
+    end
 
-    -- Ensuring that timestamp arithmetic is interval to avoid error thrown when comparing
-    -- timestamp and date difference to interval
-    pquery([[ALTER SESSION SET TIMESTAMP_ARITHMETIC_BEHAVIOR = 'INTERVAL']])
+    -- Note on NLS: the PRIMARY detection (IS_DATE/IS_TIMESTAMP/IS_NUMBER and the plain ALTERs) uses the
+    -- current session NLS settings; additionally, unclassified columns are probed against explicit format
+    -- models (see detect_explicit_format), so e.g. a German '12.06.2026' is detected regardless of the NLS.
+    -- The date/timestamp split uses IS_DATE / IS_TIMESTAMP (no datetime subtraction), so it is independent
+    -- of TIMESTAMP_ARITHMETIC_BEHAVIOR and works even if the date and timestamp formats differ.
 
-    -- Getting columns
-    suc, res = pquery([[
+    -- Getting the VARCHAR columns (base tables only, no virtual schemas)
+    local suc, res = pquery([[
         SELECT column_schema
              , column_table
              , column_name
              , column_maxsize
+             , column_type
         FROM   exa_all_columns
         WHERE  column_schema      LIKE :schp
            AND column_table       LIKE :tabp
-           AND column_type_id     = 12  -- VARCHAR (Should CHAR be considered, too?)
-           AND column_object_type = 'TABLE'
+           AND column_type_id     = 12          -- VARCHAR
+           AND column_object_type = 'TABLE'     -- only base tables, never views/synonyms
+           AND column_is_virtual  = FALSE       -- never virtual schema columns
         ORDER  BY column_schema
                 , column_table
-                , column_ordinal_position
+                , column_name
      ]], {
          schp = schema_pattern
        , tabp = table_pattern
      })
+    if not suc then
+        emit_and_exit({ {'', '', '', 'Could not read EXA_ALL_COLUMNS: ' .. (res.error_message or 'unknown error'), '', ''} })
+    end
 
-    tab_name   = "-"
-    tab_rows   = 0;
-    tab_sample = 0;
+    local overall_res = {}
+    local tab_name    = "-"
+    local tab_rows    = 0
+    local tab_sample  = 0
+    local tab_status  = ""   -- "" = ok; otherwise an "empty"/"could not analyze" message for every column
 
     -- Iterating through tables and their columns
     for i = 1, #res do
-        curr_sch = res[i]["COLUMN_SCHEMA"]
-        curr_tab = res[i]["COLUMN_TABLE"]
-        curr_col = res[i]["COLUMN_NAME"]
-        curr_col_len = res[i]["COLUMN_MAXSIZE"]
-        if tab_name ~= curr_tab then -- New table
-            tab_name = curr_tab
-            suc, res2 = pquery([[
-                            SELECT COUNT(*) FROM ::sch.::tab
-                        ]], {
-                            sch = quote(curr_sch)
-                          , tab = quote(curr_tab)
-                        })
-            tab_rows = res2[1][1]
-            if tab_rows == 0 then -- Empty table
-                tab_sample = 0
-                ret[#ret + 1] = {"-- Table " .. curr_tab .. " is empty, can't identify alternative data types"}
+        local curr_sch      = res[i]["COLUMN_SCHEMA"]
+        local curr_tab      = res[i]["COLUMN_TABLE"]
+        local curr_col      = res[i]["COLUMN_NAME"]
+        local curr_col_len  = res[i]["COLUMN_MAXSIZE"]
+        local curr_col_type = res[i]["COLUMN_TYPE"]
+
+        if tab_name ~= curr_tab then -- New table: one COUNT(*) per table (needed for percentage sampling)
+            tab_name   = curr_tab
+            tab_status = ""
+            local csuc, cres = pquery([[ SELECT COUNT(*) FROM ::sch.::tab ]],
+                                      { sch = quote(curr_sch), tab = quote(curr_tab) })
+            if not csuc then
+                tab_rows   = 0
+                tab_status = "Table could not be analyzed (" .. (cres.error_message or 'error') .. ")"
             else
-                msg = "-- Table " .. curr_tab .. " (" .. tab_rows .. " rows; sample size is "
-                if sample_rows ~= 0 then -- Sample size is set as number of rows
-                    tab_sample = sample_rows
-                    msg = msg .. tab_sample .. " rows)"
-                else -- Sample size is set as percentage
-                    tab_sample = math.floor(tab_rows * (sample_pct / 100))
-                    if tab_sample < sample_min then
-                        tab_sample = math.min(tab_rows, sample_min)
-                        msg = msg .. tab_sample .. " rows)"
-                    else
-                        msg = msg .. tab_sample .. " rows, " .. sample_pct .. "%)"
-                    end -- if tab_sample < sample_min
-                end -- sample_rows ~= 0
-                ret[#ret + 1] = {msg}
-            end -- if tab_rows == 0
-        end -- if tab_name ~= curr_tab
-
-        if tab_rows > 0 then -- Table is not empty, investigation is possible
-
-            ret[#ret + 1] = {"   -- Column " .. curr_col}
-
-            suc, res2 = pquery([[
-                SELECT SUM(CASE WHEN col IS NOT NULL THEN 1 ELSE 0 END) AS entries
-                     , SUM(CASE WHEN IS_NUMBER(col) AND col REGEXP_LIKE :r_int
-                                THEN 1
-                                ELSE 0
-                           END) its_integer
-                     , MAX(CASE WHEN IS_NUMBER(col) AND col REGEXP_LIKE :r_int
-                                THEN LENGTH(LTRIM(TRIM(col), '+-'))
-                                ELSE 0
-                           END) its_integer_precision
-                     , SUM(CASE WHEN IS_NUMBER(col) AND col REGEXP_LIKE :r_dec
-                                THEN 1
-                                ELSE 0
-                           END) its_decimal
-                     , MAX(CASE WHEN IS_NUMBER(col) AND col REGEXP_LIKE :r_dec
-                                THEN LENGTH(LTRIM(TRIM(SUBSTR(col, 1, INSTR(col, '.') - 1), '+-')))
-                                ELSE 0
-                           END) its_decimal_precision
-                     , MAX(CASE WHEN IS_NUMBER(col) AND col REGEXP_LIKE :r_dec
-                                THEN LENGTH(LTRIM(TRIM(SUBSTR(col, INSTR(col, '.') + 1), '+-')))
-                                ELSE 0
-                           END) its_decimal_scale
-                     , SUM(CASE WHEN IS_NUMBER(col) AND col REGEXP_LIKE :r_dpr
-                                THEN 1
-                                ELSE 0
-                           END) its_double_precision
-                     , SUM(CASE WHEN IS_DATE(col) AND TO_TIMESTAMP(col) - TO_DATE(col) = INTERVAL '00:00:00.000000' HOUR TO SECOND
-                                THEN 1
-                                ELSE 0
-                           END) its_date
-                     , SUM(CASE WHEN IS_TIMESTAMP(col) AND TO_TIMESTAMP(col) - TO_DATE(col) <> INTERVAL '00:00:00.000000' HOUR TO SECOND
-                                THEN 1
-                                ELSE 0
-                           END) its_timestamp
-                     , SUM(CASE WHEN IS_BOOLEAN(col)    THEN 1 ELSE 0 END) its_boolean
-                     , SUM(CASE WHEN col IN ('0', '1')  THEN 1 ELSE 0 END) its_boolean_binary
-                     , SUM(CASE WHEN IS_DSINTERVAL(col) THEN 1 ELSE 0 END) its_dsinterval
-                     , MAX(CASE WHEN IS_DSINTERVAL(col)
-                                THEN LENGTH(LTRIM(SUBSTR(col, 1, INSTR(col, ' ') - 1), '+-'))
-                                ELSE 0
-                           END) its_dsinterval_p
-                     , MAX(CASE WHEN IS_DSINTERVAL(col)
-                                THEN LENGTH(SUBSTR(col, INSTR(col, '.') + 1))
-                                ELSE 0
-                           END) its_dsinterval_fp
-                     , SUM(CASE WHEN IS_YMINTERVAL(col) THEN 1 ELSE 0 END) its_yminterval
-                     , MAX(CASE WHEN IS_YMINTERVAL(col)
-                                THEN LENGTH(LTRIM(SUBSTR(col, 1, INSTR(col, '-') - 1), '+-'))
-                                ELSE 0
-                           END) its_yminterval_p
-                     , SUM(CASE WHEN UPPER(col) REGEXP_LIKE '.*POINT *\(.*'
-                                  OR UPPER(col) REGEXP_LIKE '.*LINESTRING *\(.*'
-                                  OR UPPER(col) REGEXP_LIKE '.*LINEARRING *\(.*'
-                                  OR UPPER(col) REGEXP_LIKE '.*POLYGON *\(.*'
-                                  OR UPPER(col) REGEXP_LIKE '.*GEOMETRYCOLLECTION *\(.*'
-                                  OR UPPER(col) REGEXP_LIKE '.*MULTIPOINT *\(.*'
-                                  OR UPPER(col) REGEXP_LIKE '.*MULTILINESTRING *\(.*'
-                                  OR UPPER(col) REGEXP_LIKE '.*MULTIPOLYGON *\(.*'
-                                THEN 1
-                                ELSE 0
-                           END) its_geometry
-                     , MAX(LENGTH(col)) max_length
-                FROM   (
-                           SELECT ::col AS col
-                           FROM   ::sch.::tab
-                           LIMIT  :lmt
-                       )
-            ]], {
-                sch   = quote(curr_sch)
-              , tab   = quote(curr_tab)
-              , col   = quote(curr_col)
-              , lmt   = tab_sample
-              , r_int = regexp_int
-              , r_dec = regexp_dec
-              , r_dpr = regexp_dpr
-            })
-
-            new_type  = "-"
-            ucol = string.upper(curr_col)
-
-            -- Let's try to figure out what would be the best data type
-            res3 = res2[1]
-            if res3["ENTRIES"] == 0 then -- No data in the column; can't decide data type
-                ret[#ret + 1] = {"      -- No data in column, can't identify alternative data type. Maybe column could be dropped?"}
-                ret[#ret + 1] = {"      -- ALTER TABLE " .. quote(curr_sch) .. "." .. quote(curr_tab) .. " DROP COLUMN " .. quote(curr_col) .. ";"}
-            elseif res3["ENTRIES"] == res3["ITS_INTEGER"] then -- All sample values were integers
-                -- But it could be a binary (0/1) boolean column...
-                if res3["ENTRIES"] == res3["ITS_BOOLEAN_BINARY"] then
-                    new_type = "BOOLEAN"
+                tab_rows = cres[1][1]
+                if tab_rows == 0 then
+                    tab_sample = 0
+                    tab_status = "Table is empty (no data)"
                 else
-                    if res3["ITS_INTEGER_PRECISION"] > 36 then
-                        ret[#ret + 1] = {"      -- WARNING: Largest decimal precision found was " .. res3["ITS_INTEGER_PRECISION"] .. "; larger than maximum 36. Data type conversion is not possible"}
-                    else
-                        new_type = "DECIMAL(" .. adjust_precision(res3["ITS_INTEGER_PRECISION"]) .. ")"
+                    if sample_rows ~= 0 then        -- sample size given as a number of rows
+                        tab_sample = sample_rows
+                    else                            -- sample size given as a percentage
+                        tab_sample = math.floor(tab_rows * (sample_pct / 100))
+                        if tab_sample < sample_min then
+                            tab_sample = math.min(tab_rows, sample_min)
+                        end
                     end
                 end
-            elseif res3["ENTRIES"] == res3["ITS_INTEGER"] + res3["ITS_DECIMAL"] then -- All sample values were integers and floats/decimals (but not in scientific notation)
-                total_precision = math.max(res3["ITS_INTEGER_PRECISION"], res3["ITS_DECIMAL_PRECISION"]) + res3["ITS_DECIMAL_SCALE"]
-                if total_precision > 36 then
-                    ret[#ret + 1] = {"      -- WARNING: Largest decimal precision found was " .. total_precision .. "; larger than maximum 36. Data type conversion is not possible"}
-                else
-                    new_type = "DECIMAL(" .. total_precision .. ", " .. res3["ITS_DECIMAL_SCALE"] .. ")"
-                end
-            elseif res3["ENTRIES"] == res3["ITS_INTEGER"] + res3["ITS_DECIMAL"] + res3["ITS_DOUBLE_PRECISION"] then -- All sample values were some kind of numerical values
-                new_type = "DOUBLE PRECISION"
-            elseif res3["ENTRIES"] == res3["ITS_DATE"] then -- All sample values were dates (but not timestamps)
-                new_type = "DATE"
-            elseif res3["ENTRIES"] == res3["ITS_DATE"] + res3["ITS_TIMESTAMP"] then -- All sample values were dates or timestamps
-                ret[#ret + 1] = {"      -- Consider if TIMESTAMP WITH LOCAL TIME ZONE was a more appropriate data type."}
-                new_type = "TIMESTAMP"
-            elseif res3["ENTRIES"] == res3["ITS_BOOLEAN"] then -- All sample values were Boolean
-                new_type = "BOOLEAN"
-            elseif res3["ENTRIES"] == res3["ITS_DSINTERVAL"] then -- All sample values were day-to-second intervals
-                new_type = "INTERVAL DAY(" .. math.min(math.max(res3["ITS_DSINTERVAL_P"], 1), 9) .. ") TO SECOND(" .. math.min(res3["ITS_DSINTERVAL_FP"], 9) .. ")"
-            elseif res3["ENTRIES"] == res3["ITS_YMINTERVAL"] then -- All sample values were year-to-months intervals
-                new_type = "INTERVAL YEAR(" .. math.min(math.max(res3["ITS_YMINTERVAL_P"], 1), 9) ..") TO MONTH"
-            elseif res3["ENTRIES"] == res3["ITS_GEOMETRY"] then -- All sample values seem to contain geospatial data
-                ret[#ret + 1] = {"      -- You might want to specify SRID (a reference coordinate system, query EXA_SPATIAL_REF_SYS for possible values)"}
-                new_type = "GEOMETRY"
-            elseif string.match(ucol, "_TIMESTAMP") or string.match(ucol, "TIMESTAMP$")or
-                   string.match(ucol, "_TS") or string.match(ucol, "TS$") or
-                   string.match(ucol, "_DATETIME") or string.match(ucol, "DATETIME$") or
-                   ucol == "TIMSTAMP" then -- Maybe timestamp column
-                ret[#ret + 1] = {"      -- This might be a timestamp column but the values do not match current timestamp format (" .. nls_timestamp_format .. ")"}
-                ret[#ret + 1] = {"      -- UPDATE " .. quote(curr_sch) .. "." .. quote(curr_tab) .. " SET " .. quote(curr_col) .. " = TO_CHAR(TO_TIMESTAMP(" .. quote(curr_col) .. ", '<timestamp_format>'), '" .. nls_timestamp_format .. "');"}
-                ret[#ret + 1] = {"      -- ALTER TABLE " .. quote(curr_sch) .. "." .. quote(curr_tab) .. " MODIFY COLUMN " .. quote(curr_col) .. " TIMESTAMP [WITH LOCAL TIME ZONE];"}
-            elseif string.match(ucol, "_DATE") or string.match(ucol, "DATE$") or string.match(ucol, "^DATE_") or
-                   string.match(ucol, "_DT") or string.match(ucol, "DT$") or
-                   ucol == "DATE" or ucol == 'DOB' then -- Maybe date column
-                ret[#ret + 1] = {"      -- This might be a date column but the values do not match current date format (" .. nls_date_format .. ")"}
-                ret[#ret + 1] = {"      -- UPDATE " .. quote(curr_sch) .. "." .. quote(curr_tab) .. " SET " .. quote(curr_col) .. " = TO_CHAR(TO_DATE(" .. quote(curr_col) .. ", '<date_format>'), '" .. nls_date_format .. "');"}
-                ret[#ret + 1] = {"      -- ALTER TABLE " .. quote(curr_sch) .. "." .. quote(curr_tab) .. " MODIFY COLUMN " .. quote(curr_col) .. " DATE;"}
-            elseif res3["MAX_LENGTH"] < curr_col_len then -- Mixed/unclear types of values, only shrink column width (if possible)
-                new_col_len = res3["MAX_LENGTH"]
-                --new_col_len = math.min(math.floor(res3["MAX_LENGTH"] * 1.2), 2000000) -- Not sure if we need to be prepared for even larger strings
-                if new_col_len < curr_col_len then
-                    ret[#ret + 1] = {"      -- Mixed values in column, retaining existing data type but shrinking maximum column length"}
-                    new_type = "VARCHAR(" .. new_col_len .. ")"
-                end
+            end
+        end -- new table
+
+        if tab_rows == 0 then
+            -- empty table / count failed: nothing to convert; only listed with log_for_all_columns
+            if log_for_all_columns then
+                overall_res[#overall_res + 1] = { curr_sch, curr_tab, curr_col, tab_status, "", "" }
+            end
+        else
+            -- ONE lean aggregate query per column. A short-circuiting CASE classifies each sampled value
+            -- exactly ONCE: a value that IS_NUMBER is settled without ever evaluating the (far more
+            -- expensive) date/timestamp/interval/geometry checks. So the per-row work matches the column's
+            -- real type instead of running every check on every row -- the key to performance on big tables.
+            -- The NLS-independent multi-format probe is NOT folded in here; it runs (see the else-branch)
+            -- only for the few columns this query leaves unclassified.
+            --
+            -- When the sample covers the whole table (e.g. '100%'), the LIMIT subquery is OMITTED: a
+            -- "... FROM (SELECT col FROM t LIMIT n)" makes Exasol first copy every row into a temporary
+            -- table (a costly INSERT step); without it the base table is scanned straight into the
+            -- aggregation. With a real sample the LIMIT stays and materializes only the small sample.
+            local from_src  = [[ SELECT ::col AS col FROM ::sch.::tab ]]
+            local full_scan = (sample_rows ~= 0 and sample_rows >= tab_rows)
+                           or (sample_rows == 0 and sample_pct >= 100)
+            local binds = { sch = quote(curr_sch), tab = quote(curr_tab), col = quote(curr_col)
+                          , r_int = regexp_int, r_dec = regexp_dec, r_dpr = regexp_dpr, dec = dec_char }
+            if not full_scan then
+                from_src  = from_src .. [[ LIMIT :lmt ]]
+                binds.lmt = tab_sample
+            end
+            local qsuc, res2 = pquery([[
+                SELECT COUNT(col) entries
+                     , SUM(CASE WHEN cat = 'INT' THEN 1 ELSE 0 END) its_integer
+                     , MAX(CASE WHEN cat = 'INT' THEN LENGTH(LTRIM(TRIM(col), '+-')) ELSE 0 END) its_integer_precision
+                     , SUM(CASE WHEN cat = 'DEC' THEN 1 ELSE 0 END) its_decimal
+                     , MAX(CASE WHEN cat = 'DEC' THEN LENGTH(LTRIM(TRIM(SUBSTR(col, 1, INSTR(col, :dec) - 1), '+-'))) ELSE 0 END) its_decimal_precision
+                     , MAX(CASE WHEN cat = 'DEC' THEN LENGTH(LTRIM(TRIM(SUBSTR(col, INSTR(col, :dec) + 1), '+-'))) ELSE 0 END) its_decimal_scale
+                     , SUM(CASE WHEN cat = 'DBL' THEN 1 ELSE 0 END) its_double_precision
+                     -- numeric values that look like identifiers: a leading zero (007, 0301234) or a leading
+                     -- '+' (+49170) -> a numeric conversion would silently lose them. Checked only for numerics.
+                     , SUM(CASE WHEN cat IN ('INT', 'DEC')
+                                 AND (TRIM(col) REGEXP_LIKE '[+-]{0,1}0[0-9].*' OR TRIM(col) REGEXP_LIKE '\+.*')
+                                THEN 1 ELSE 0 END) its_numeric_idlike
+                     , SUM(CASE WHEN cat = 'DATE' THEN 1 ELSE 0 END) its_date
+                     , SUM(CASE WHEN cat = 'TS'   THEN 1 ELSE 0 END) its_timestamp
+                     , MAX(CASE WHEN cat = 'TS' AND INSTR(col, '.') > 0
+                                THEN LENGTH(RTRIM(SUBSTR(col, INSTR(col, '.') + 1))) ELSE 0 END) its_timestamp_fp
+                     -- IS_BOOLEAN is evaluated directly (not via cat) so the boolean count is byte-for-byte
+                     -- what the previous version computed -- IS_BOOLEAN also accepts numeric 0/1/00/01, which
+                     -- a cat-based count would miss. (Numeric values are still classified INT/DEC/DBL above;
+                     -- this only adds the boolean tally needed for the ENTRIES = ITS_BOOLEAN branch.)
+                     , SUM(CASE WHEN IS_BOOLEAN(col) THEN 1 ELSE 0 END) its_boolean
+                     , SUM(CASE WHEN col IN ('0', '1') THEN 1 ELSE 0 END) its_boolean_binary
+                     , SUM(CASE WHEN cat = 'DSI' THEN 1 ELSE 0 END) its_dsinterval
+                     , MAX(CASE WHEN cat = 'DSI' THEN LENGTH(LTRIM(SUBSTR(col, 1, INSTR(col, ' ') - 1), '+-')) ELSE 0 END) its_dsinterval_p
+                     , MAX(CASE WHEN cat = 'DSI' AND INSTR(col, '.') > 0 THEN LENGTH(SUBSTR(col, INSTR(col, '.') + 1)) ELSE 0 END) its_dsinterval_fp
+                     , SUM(CASE WHEN cat = 'YMI' THEN 1 ELSE 0 END) its_yminterval
+                     , MAX(CASE WHEN cat = 'YMI' THEN LENGTH(LTRIM(SUBSTR(col, 1, INSTR(col, '-') - 1), '+-')) ELSE 0 END) its_yminterval_p
+                     , SUM(CASE WHEN cat = 'GEO' THEN 1 ELSE 0 END) its_geometry
+                     , MAX(LENGTH(col)) max_length
+                     -- cheap pre-check (one regex, only on UNCLASSIFIED values): whether they even look
+                     -- date-like (digits + . : / - separators). If not (names, codes, free text), the
+                     -- expensive multi-format probe in the else-branch is skipped entirely.
+                     , MAX(CASE WHEN cat = 'OTH' AND col REGEXP_LIKE '^ *[0-9][0-9 .:/-]*[0-9] *$'
+                                THEN 1 ELSE 0 END) maybe_dateish
+                FROM (
+                    -- classify each value once; the WHENs are ordered cheapest/most-common first and the
+                    -- CASE stops at the first match (Exasol evaluates WHEN conditions in order).
+                    SELECT col
+                         , CASE
+                               WHEN IS_NUMBER(col) THEN
+                                    CASE WHEN col REGEXP_LIKE :r_int THEN 'INT'
+                                         WHEN col REGEXP_LIKE :r_dec THEN 'DEC'
+                                         WHEN col REGEXP_LIKE :r_dpr THEN 'DBL'
+                                         ELSE 'OTH' END
+                               -- TO_TIMESTAMP only runs when IS_TIMESTAMP is true (AND short-circuits); TRUNC
+                               -- detects a time component independent of TIMESTAMP_ARITHMETIC_BEHAVIOR.
+                               WHEN IS_TIMESTAMP(col) AND TO_TIMESTAMP(col) <> TRUNC(TO_TIMESTAMP(col)) THEN 'TS'
+                               WHEN IS_DATE(col) THEN 'DATE'
+                               WHEN IS_DSINTERVAL(col) THEN 'DSI'
+                               WHEN IS_YMINTERVAL(col) THEN 'YMI'
+                               WHEN UPPER(col) REGEXP_LIKE '.*(POINT|LINESTRING|LINEARRING|POLYGON|GEOMETRYCOLLECTION|MULTIPOINT|MULTILINESTRING|MULTIPOLYGON) *\(.*' THEN 'GEO'
+                               ELSE 'OTH'
+                           END cat
+                    FROM ( ]] .. from_src .. [[ )
+                )
+            ]], binds)
+
+            local conversion = ""
+            local query_text = ""
+            local notes      = ""
+
+            if not qsuc then
+                -- Do not abort the whole run because of one problematic column; always surface the error.
+                conversion = "Could not analyze column"
+                notes      = res2.error_message or 'error'
+                overall_res[#overall_res + 1] = { curr_sch, curr_tab, curr_col, conversion, query_text, notes }
             else
-                ret[#ret + 1] = {"      -- Mixed values in column, retaining existing data type and size"}
-            end -- res3["ENTRIES"] == xxx
+                local r       = res2[1]
+                local ucol    = string.upper(curr_col)
+                local sch_q   = quote(curr_sch)
+                local tab_q   = quote(curr_tab)
+                local col_q   = quote(curr_col)
+                local altpfx  = "ALTER TABLE " .. sch_q .. "." .. tab_q .. " MODIFY COLUMN " .. col_q .. " "
 
-            if new_type ~= "-" then
-                ret[#ret + 1] = {"      ALTER TABLE " .. quote(curr_sch) .. "." .. quote(curr_tab) .. " MODIFY COLUMN " .. quote(curr_col) .. " " .. new_type .. ";"}
-            end -- new_type ~= "-"
+                -- Preserve the original character set for a possible VARCHAR shrink.
+                local charset = 'UTF8'
+                if string.find(string.upper(curr_col_type), 'ASCII', 1, true) ~= nil then
+                    charset = 'ASCII'
+                end
 
-        end -- if tab_rows > 0
+                if r["ENTRIES"] == 0 then -- No data in the (sampled) column
+                    conversion = "No data in the sample"
+                    notes      = "Column had no data in the sample - it may be a candidate for DROP COLUMN. Verify before dropping."
+                elseif r["ENTRIES"] == r["ITS_INTEGER"] then -- all sample values were integers
+                    if r["ENTRIES"] == r["ITS_BOOLEAN_BINARY"] then -- ...but could be a 0/1 boolean
+                        conversion = "VARCHAR --> BOOLEAN"
+                        query_text = altpfx .. "BOOLEAN;"
+                        notes      = "NOTE: only 0/1 values. Verify these are real booleans, not flags/bits/codes you compute with."
+                    elseif r["ITS_INTEGER_PRECISION"] > 36 then
+                        conversion = "Keep VARCHAR (integer precision " .. r["ITS_INTEGER_PRECISION"] .. " > max 36)"
+                        notes      = "Largest integer precision " .. r["ITS_INTEGER_PRECISION"] .. " exceeds the maximum DECIMAL precision of 36; not convertible."
+                    else
+                        conversion = "VARCHAR --> DECIMAL(" .. adjust_precision(r["ITS_INTEGER_PRECISION"]) .. ")"
+                        query_text = altpfx .. "DECIMAL(" .. adjust_precision(r["ITS_INTEGER_PRECISION"]) .. ");"
+                        if r["ITS_NUMERIC_IDLIKE"] > 0 then
+                            notes = "WARNING: some values have leading zeros or a '+' sign (looks like an identifier: ID / ZIP / phone / article no.). Converting to DECIMAL LOSES them ('007' -> 7, '+49' -> 49). Review before applying!"
+                        end
+                    end
+                elseif r["ENTRIES"] == r["ITS_INTEGER"] + r["ITS_DECIMAL"] then -- integers and decimals (not scientific)
+                    local total_precision = math.max(r["ITS_INTEGER_PRECISION"], r["ITS_DECIMAL_PRECISION"]) + r["ITS_DECIMAL_SCALE"]
+                    if total_precision > 36 then
+                        conversion = "Keep VARCHAR (decimal precision " .. total_precision .. " > max 36)"
+                        notes      = "Largest decimal precision " .. total_precision .. " exceeds the maximum DECIMAL precision of 36; not convertible."
+                    else
+                        conversion = "VARCHAR --> DECIMAL(" .. total_precision .. ", " .. r["ITS_DECIMAL_SCALE"] .. ")"
+                        query_text = altpfx .. "DECIMAL(" .. total_precision .. ", " .. r["ITS_DECIMAL_SCALE"] .. ");"
+                        if r["ITS_NUMERIC_IDLIKE"] > 0 then
+                            notes = "WARNING: some values have leading zeros or a '+' sign (looks like an identifier). Converting to DECIMAL LOSES them. Review before applying!"
+                        end
+                    end
+                elseif r["ENTRIES"] == r["ITS_INTEGER"] + r["ITS_DECIMAL"] + r["ITS_DOUBLE_PRECISION"] then -- any numeric (incl. scientific)
+                    conversion = "VARCHAR --> DOUBLE PRECISION"
+                    query_text = altpfx .. "DOUBLE PRECISION;"
+                elseif r["ENTRIES"] == r["ITS_DATE"] then -- dates only (no time component)
+                    conversion = "VARCHAR --> DATE"
+                    query_text = altpfx .. "DATE;"
+                elseif r["ENTRIES"] == r["ITS_DATE"] + r["ITS_TIMESTAMP"] then -- dates and/or timestamps
+                    local fp = math.min(r["ITS_TIMESTAMP_FP"], 9)
+                    conversion = "VARCHAR --> TIMESTAMP(" .. fp .. ")"
+                    query_text = altpfx .. "TIMESTAMP(" .. fp .. ");"
+                    notes      = "Consider TIMESTAMP(" .. fp .. ") WITH LOCAL TIME ZONE if that fits better."
+                    if fp > nls_ff then
+                        -- a plain ALTER parses via NLS_TIMESTAMP_FORMAT (FF<nls_ff>) and would truncate the
+                        -- extra fractional digits; prepend the session-format change that keeps full precision.
+                        local rec_fmt = string.gsub(nls_timestamp_format, 'FF%d*', 'FF' .. fp)
+                        if rec_fmt == nls_timestamp_format then rec_fmt = nls_timestamp_format .. '.FF' .. fp end
+                        query_text = "ALTER SESSION SET NLS_TIMESTAMP_FORMAT='" .. rec_fmt .. "'; " .. query_text
+                        notes = notes .. " Values have up to " .. fp .. " fractional-second digits but NLS_TIMESTAMP_FORMAT ('" .. nls_timestamp_format .. "') keeps fewer; the ALTER SESSION in query_text preserves full precision (a plain ALTER would truncate)."
+                    end
+                elseif r["ENTRIES"] == r["ITS_BOOLEAN"] then -- booleans
+                    conversion = "VARCHAR --> BOOLEAN"
+                    query_text = altpfx .. "BOOLEAN;"
+                    notes      = "NOTE: verify the column is really a boolean (not a status text you rely on)."
+                elseif r["ENTRIES"] == r["ITS_DSINTERVAL"] then -- day-to-second intervals
+                    local p  = math.min(math.max(r["ITS_DSINTERVAL_P"], 1), 9)
+                    local fp = math.min(r["ITS_DSINTERVAL_FP"], 9)
+                    conversion = "VARCHAR --> INTERVAL DAY(" .. p .. ") TO SECOND(" .. fp .. ")"
+                    query_text = altpfx .. "INTERVAL DAY(" .. p .. ") TO SECOND(" .. fp .. ");"
+                elseif r["ENTRIES"] == r["ITS_YMINTERVAL"] then -- year-to-month intervals
+                    local p = math.min(math.max(r["ITS_YMINTERVAL_P"], 1), 9)
+                    conversion = "VARCHAR --> INTERVAL YEAR(" .. p .. ") TO MONTH"
+                    query_text = altpfx .. "INTERVAL YEAR(" .. p .. ") TO MONTH;"
+                elseif r["ENTRIES"] == r["ITS_GEOMETRY"] then -- geospatial data
+                    conversion = "VARCHAR --> GEOMETRY"
+                    query_text = altpfx .. "GEOMETRY;"
+                    notes      = "Consider specifying an SRID (a reference coordinate system; query EXA_SPATIAL_REF_SYS for possible values)."
+                else
+                    -- Not classified above. Try (1) multi-format date/timestamp detection (its own probe
+                    -- query, run only for unclassified columns whose values are date-LIKE in length and
+                    -- shape -- see maybe_dateish; this keeps the probe off name/code/free-text columns),
+                    -- (2) column-name hints, (3) width shrink, (4) keep as is.
+                    local mf = nil
+                    if r["MAX_LENGTH"] >= 6 and r["MAX_LENGTH"] <= 40 and r["MAYBE_DATEISH"] == 1 then
+                        mf = detect_explicit_format(curr_sch, curr_tab, curr_col, tab_sample, full_scan)
+                    end
+                    if mf ~= nil and mf.ambiguous then
+                        conversion = "Ambiguous date format (DD.MM vs MM.DD) - not converted"
+                        notes      = "Values look like dates but the day/month order is ambiguous (every day is <= 12). Pick the format yourself, e.g. ALTER SESSION SET NLS_DATE_FORMAT='DD.MM.YYYY'; then " .. altpfx .. "DATE;"
+                    elseif mf ~= nil and mf.kind == 'DATE' then
+                        conversion = "VARCHAR --> DATE (format " .. mf.fmt .. ")"
+                        query_text = "ALTER SESSION SET NLS_DATE_FORMAT='" .. mf.fmt .. "'; " .. altpfx .. "DATE;"
+                        notes      = "Values match the date format '" .. mf.fmt .. "' (not the session NLS_DATE_FORMAT). Run BOTH statements in query_text (the ALTER SESSION first)."
+                    elseif mf ~= nil and mf.kind == 'TIMESTAMP' then
+                        local fp    = mf.frac
+                        local tsfmt = mf.fmt .. ' HH24:MI:SS'
+                        if fp > 0 then tsfmt = tsfmt .. '.FF' .. fp end
+                        conversion = "VARCHAR --> TIMESTAMP(" .. fp .. ") (format " .. tsfmt .. ")"
+                        query_text = "ALTER SESSION SET NLS_TIMESTAMP_FORMAT='" .. tsfmt .. "'; " .. altpfx .. "TIMESTAMP(" .. fp .. ");"
+                        notes      = "Values match the timestamp format '" .. tsfmt .. "' (not the session NLS_TIMESTAMP_FORMAT). Run BOTH statements in query_text (the ALTER SESSION first)."
+                    elseif string.match(ucol, "_TIMESTAMP") or string.match(ucol, "TIMESTAMP$") or
+                           string.match(ucol, "_TS") or string.match(ucol, "TS$") or
+                           string.match(ucol, "_DATETIME") or string.match(ucol, "DATETIME$") or
+                           ucol == "TIMSTAMP" then -- name looks like a timestamp
+                        conversion = "Keep VARCHAR (name looks like a timestamp; values do not match " .. nls_timestamp_format .. ")"
+                        notes      = "If this is a timestamp, normalize then convert, e.g.: UPDATE " .. sch_q .. "." .. tab_q .. " SET " .. col_q .. " = TO_CHAR(TO_TIMESTAMP(" .. col_q .. ", '<timestamp_format>'), '" .. nls_timestamp_format .. "'); then " .. altpfx .. "TIMESTAMP;"
+                    elseif string.match(ucol, "_DATE") or string.match(ucol, "DATE$") or string.match(ucol, "^DATE_") or
+                           string.match(ucol, "_DT") or string.match(ucol, "DT$") or
+                           ucol == "DATE" or ucol == 'DOB' then -- name looks like a date
+                        conversion = "Keep VARCHAR (name looks like a date; values do not match " .. nls_date_format .. ")"
+                        notes      = "If this is a date, normalize then convert, e.g.: UPDATE " .. sch_q .. "." .. tab_q .. " SET " .. col_q .. " = TO_CHAR(TO_DATE(" .. col_q .. ", '<date_format>'), '" .. nls_date_format .. "'); then " .. altpfx .. "DATE;"
+                    elseif estimate_optimal_varchar_length(r["MAX_LENGTH"]) < curr_col_len then -- shrink width
+                        local new_col_len = estimate_optimal_varchar_length(r["MAX_LENGTH"])
+                        conversion = "VARCHAR(" .. curr_col_len .. ") " .. charset .. " --> VARCHAR(" .. new_col_len .. ") " .. charset .. ", max length: " .. r["MAX_LENGTH"]
+                        query_text = altpfx .. "VARCHAR(" .. new_col_len .. ") " .. charset .. ";"
+                        notes      = "Mixed values; no single type fits. Shrinking the width (actual max length " .. r["MAX_LENGTH"] .. " + ~20% headroom); character set preserved."
+                    else
+                        conversion = "Keep VARCHAR(" .. curr_col_len .. ") " .. charset .. ", max length: " .. r["MAX_LENGTH"]
+                    end
+                end
+
+                if query_text ~= "" or log_for_all_columns then
+                    overall_res[#overall_res + 1] = { curr_sch, curr_tab, curr_col, conversion, query_text, notes }
+                end
+            end -- qsuc
+
+        end -- if tab_rows == 0
 
     end -- for i = 1, #res
 
-    exit(ret, ret_type)
+    emit_and_exit(overall_res)
 /
 
-EXECUTE SCRIPT database_migration.convert_varchar(
+-- ====================================================================================================
+-- REPORT ONLY - this prints suggestions; it does NOT change anything. REVIEW every statement before
+-- you run it (sample-based; numeric/date conversions can be lossy, e.g. '007' -> 7).
+-- ====================================================================================================
+EXECUTE SCRIPT DATABASE_MIGRATION.CONVERT_VARCHAR(
     'MY_SCHEMA'    -- schema_pattern: schema name or schema name filter (can be %)
   , '%'            -- table_pattern: table name or table name filter (can be %)
-  , '5%'           -- sample_size: table data sample size; either an integer value or a string expressing a integer percentage
+  , '5%'           -- sample_size: rows (min 1000) or a percentage like '5%'. A 1-5% sample is usually
+                   --              enough for a reliable result; '100%' scans the whole table (slower)
+  , false          -- log_for_all_columns: false = only columns that change, true = every inspected column
 );
-
--- EOF


### PR DESCRIPTION
## Summary
This PR overhauls `post_load_optimization/convert_varchar.sql`: it fixes several real **bugs**, improves
**stability and performance**, adds the missing **documentation** and a test script, adds two
**content-preserving features** (detected **TIMESTAMP fractional precision** 0–9 and **multi-format
date/timestamp detection**, e.g. German `DD.MM.YYYY` regardless of the session NLS), and **restructures the
output into columns and adds a `log_for_all_columns` switch**. The script remains **report-only** (it
returns suggested `ALTER` statements; it does not change data).

> 💥 **Breaking change (intended).** The output is now **structured columns**
> instead of one `message` text blob, and there is a **new 4th parameter `log_for_all_columns`**:
> `convert_varchar(schema_pattern, table_pattern, sample_size, log_for_all_columns)`. See *Output &
> signature* below.

> 🛠 **Installs cleanly in DbVisualizer.** The script text avoids characters that some SQL clients auto-detect
> as bind/parameter markers (`?`, `:'…'`, `:"…"`, a backslash directly before a quote), so installing it no
> longer pops an "Enter Data for Parameter Markers" dialog. Plain `:name`/`::name` Exasol placeholders are
> kept (those are not flagged).

## ✨ New feature — multi-format date/timestamp detection (NLS-independent)
The detection has always been bound to the session NLS, so a German `12.06.2026` under an ISO
`NLS_DATE_FORMAT` was not recognized. Columns that the session-NLS path does not classify are now probed
against a set of **explicit format models** (`IS_DATE`/`IS_TIMESTAMP` with an explicit format). When
**exactly one** format matches **all** sampled values, the script emits a self-contained recipe:
```
   ALTER SESSION SET NLS_DATE_FORMAT='DD.MM.YYYY';
   ALTER TABLE "S"."T" MODIFY COLUMN "C" DATE;
```
Day/month order is only chosen when the data disambiguates it (some day > 12); an **ambiguous** order
(e.g. `DD.MM` vs `MM.DD` when every day ≤ 12) is **reported, never guessed**. Datetimes →
`TIMESTAMP(p)` with the fractional precision detected from the values. Probed: date orders × separators
`-` `.` `/`, plus ` HH24:MI:SS[.FF]` for timestamps. The probe runs only for otherwise-unclassified
columns of date/timestamp length (bounded extra cost). Verified live (German/US/ISO-dot dates, German
datetimes incl. fractional, ambiguity warning, no false positives, and the recipe applied successfully).

---

## 🧱 Output & signature
The script previously returned a **single `message VARCHAR(2000)` text blob** — `-- Table …` headers and
per-column `-- Column …` lines with interleaved comments and `ALTER` statements. It now returns
**structured rows**, **sorted by schema/table/column**:

| schema_name | table_name | column_name | conversion | query_text | notes |
|---|---|---|---|---|---|
| MY_SCHEMA | CUSTOMERS | CUST_ID | `VARCHAR --> DECIMAL(9)` | `ALTER TABLE … MODIFY COLUMN "CUST_ID" DECIMAL(9);` | WARNING: leading zeros / '+' … LOSES them … Review! |
| MY_SCHEMA | CUSTOMERS | DE_DATE | `VARCHAR --> DATE (format DD.MM.YYYY)` | `ALTER SESSION SET NLS_DATE_FORMAT='DD.MM.YYYY'; ALTER TABLE … MODIFY COLUMN "DE_DATE" DATE;` | Run BOTH statements (the ALTER SESSION first). |

- `conversion` = short description; `query_text` = the runnable `ALTER` statement(s) (multi-format
  suggestions include the required `ALTER SESSION SET NLS_..._FORMAT='…';` first); `notes` = warnings /
  `0/1` boolean note / ambiguity / TIMESTAMP-precision recipe / column-name hints.
- **New 4th parameter `log_for_all_columns`**:
  `false` = only columns that get a suggestion; `true` = every inspected `VARCHAR` column (incl.
  `Keep …` and advisory rows). Empty result → `No columns found that need optimization.` /
  `No matching VARCHAR columns found (check the schema/table filter).`
- **Signature changed:** `convert_varchar(schema_pattern, table_pattern, sample_size, log_for_all_columns)`
  — existing 3-argument `EXECUTE SCRIPT` calls must add the 4th argument.

---

## 🐞 Bug fixes (actual defects in the previous version)

**1. Parameter check ignored `table_pattern`.** The guard tested `type(schema_pattern)` **twice** and
never validated `table_pattern`'s type — fixed to check `type(table_pattern)`.

**2. Virtual-schema columns were not excluded.** The catalog query filtered `column_object_type = 'TABLE'`
but virtual-schema tables also report `'TABLE'`, so virtual columns were inspected (and the per-column
sample query would run against the remote source). Added `AND column_is_virtual = FALSE`.

**3. VARCHAR shrink dropped the character set.** A shrink suggested `MODIFY COLUMN col VARCHAR(n)` with no
charset, which falls back to the `UTF8` default — silently turning an `ASCII` column into `UTF8`. The
original charset is now read from `COLUMN_TYPE` and re-stated, e.g. `VARCHAR(20) ASCII`.

**4. Day-to-second interval fractional precision was wrong.** `LENGTH(SUBSTR(col, INSTR(col,'.')+1))`
returned the **whole string length** when the value had no `'.'` (because `INSTR` returns 0), producing
e.g. `INTERVAL DAY(2) TO SECOND(9)` for `'5 12:30:00'`. Guarded with `INSTR(col,'.') > 0` → correct
`SECOND(0)`.

**5. Unchecked query results could crash the whole run.** The NLS-parameter lookups, the per-table
`COUNT(*)` and the per-column analysis query used `pquery` but never checked the success flag before
indexing the result (`res[1][1]` / `res2[1]`). A single failing table/column would abort the entire
script. All of these are now guarded; a failure is **reported and skipped**, the run continues.

**6. `ALTER SESSION` side effect removed.** The script set
`TIMESTAMP_ARITHMETIC_BEHAVIOR = 'INTERVAL'` (a session-wide change that persisted after the run) so its
date/timestamp detection (`TO_TIMESTAMP(col) - TO_DATE(col)`) would work. Replaced with a `TRUNC()`-based
check that is parameter-independent — verified to be **exactly equivalent** to the old classification —
so the `ALTER SESSION` is gone.

**7. TIMESTAMP fractional-seconds precision (data loss).** The script suggested a bare `TIMESTAMP`, which
is `TIMESTAMP(3)` — so converting a column with **micro- or nanosecond** values truncated them
(`.123456789 → .123`). It now detects the fractional precision and suggests `TIMESTAMP(p)` with the right
`p` (0–9). When the data has more fractional digits than the session `NLS_TIMESTAMP_FORMAT` can parse
(e.g. 9 digits with `FF6`), it additionally warns that a plain `ALTER` would still truncate and prints
the `ALTER SESSION SET NLS_TIMESTAMP_FORMAT='…FF<p>'` recipe that keeps full precision. Verified on a
live DB that `TIMESTAMP(6)` keeps `.123456` and the `FF9`+`TIMESTAMP(9)` recipe keeps `.123456789`.
(`TIMESTAMP WITH LOCAL TIME ZONE` cannot be told apart from a plain timestamp by text and stays a hint.)

**8. Decimal separator was hard-coded `.` (broke under non-ISO `NLS_NUMERIC_CHARACTERS`).** The integer-
/scale-precision split used `INSTR(col, '.')`. Under a German session (`NLS_NUMERIC_CHARACTERS=',.'`,
decimal `,`), `'1234,56'` has no `.` → `SUBSTR(... -1)` returned `NULL` → `MAX(...)` `NULL` → the Lua
`math.max(int, nil)` would crash the script (or emit a nonsensical `DECIMAL`). It now reads the decimal
character from `NLS_NUMERIC_CHARACTERS` and splits on it; verified live that `'1234,56'` → `DECIMAL(6, 2)`.

**9. Date/timestamp detection made robust to format mismatch.** `TO_TIMESTAMP()` is now only evaluated
for values that are timestamps (guarded by `IS_TIMESTAMP`, which short-circuits), so a pure date string
no longer reaches `TO_TIMESTAMP`. This fixes the case where `NLS_DATE_FORMAT` and `NLS_TIMESTAMP_FORMAT`
differ — e.g. a German date `12.06.2026` under `NLS_DATE_FORMAT='DD.MM.YYYY'` is now detected/converted
correctly instead of raising an error.

**NLS-dependency (documented, not "fixed"):** detection and the suggested plain `ALTER`s always use the
**current session** NLS settings (`NLS_DATE_FORMAT`, `NLS_TIMESTAMP_FORMAT`, `NLS_NUMERIC_CHARACTERS`,
`NLS_DATE_LANGUAGE`). A value is only recognized in the session's format — so to handle German dates you
set `NLS_DATE_FORMAT='DD.MM.YYYY'` before running *and* before applying. This is now prominently
documented in the header and README (no silent wrong conversions occur — an unmatched format simply
isn't detected).

---

## ✨ Stability & performance & documentation

- **Stability:** the suc-guards above mean one bad table/column no longer kills the run; NLS parameters
  fall back to sensible defaults; the output column was widened to `VARCHAR(2000)` to avoid truncating
  long statements.
- **Performance — type-directed scan, no temp-table copy.** Profiling a check query on a ~1.5-billion-row
  table showed two costs: an `INSERT on TEMPORARY table` (materializing the whole table) and a
  `GROUP BY GLOBAL` running ~all type-checks on every row. Both are fixed: (1) the per-column query now
  classifies each value with one **short-circuiting `CASE`** — a numeric value is settled by `IS_NUMBER`
  alone, never running the costly date/timestamp/interval/geometry checks, so the per-row cost matches the
  column's real type; (2) when the sample covers the whole table (`'100%'`) the `LIMIT` subquery is
  **omitted** (in both the main query and the multi-format probe), so the base table is scanned straight
  into the aggregation — the execution profile confirms that at `'100%'` no issued query contains `LIMIT`
  and the `INSERT on TEMPORARY table` step is gone. The multi-format probe is a separate query that runs
  only for unclassified columns whose values are **date-LIKE** (a cheap one-regex pre-check skips it for
  name/code/free-text columns). Excluding virtual schemas still avoids queries against remote sources.
  `sample_size` is the main cost lever: a **1–5% sample is usually statistically sufficient** for a
  reliable result (often even `'1%'`) and is far faster than `'100%'` on large tables; the example call
  uses `'5%'`. Avoid high-but-not-100% values like `'99%'` (they still materialize ~all rows).
- **Documentation:** added a thorough script header and `--parameter` lines, plus a complete
  `convert_varchar` section in `post_load_optimization/README.md` (was undocumented), including a
  prominent **REPORT-ONLY / review / lossy-conversion** warning and the **sampling** caveat.
- Cleanup: `local` scoping for new variables; a small `param_value()` helper for guarded NLS lookups.

## ✨ Safety: VARCHAR shrink + inline risk warnings
- **VARCHAR shrink uses a headroom buffer**: instead of shrinking to the exact max length, it uses the
  actual max length **+ ~20% headroom**, rounded up to the next round number (charset preserved) — e.g.
  max length 6 → `VARCHAR(9)`, max length 10 → `VARCHAR(20)`.
- **Per-column risk warnings** are now emitted inline, exactly where a risky conversion is suggested:
  - numeric columns with **leading zeros or a `+` sign** (IDs / ZIP / phone / article no.):
    `-- WARNING: … converting to DECIMAL LOSES them ('007' -> 7) … Review!` (genuine numbers incl.
    negatives like `-5` are *not* flagged).
  - `0/1 → BOOLEAN` and `TRUE/FALSE → BOOLEAN`: a `-- NOTE:` to verify it is really a boolean, not
    flags/bits/codes. (The general lossy warning in the header/README remains.)

---

## Notes
- **Detection logic is unchanged** — the same branches produce the same type decisions as before; what
  changed is the **packaging** (structured columns, sorting, the `log_for_all_columns` switch) and the
  **efficiency** (short-circuiting type-directed scan; no temp-table copy on full scans). The known
  *lossy numeric/date inference* and the *sample-based*
  nature remain documented as warnings rather than changed, since the script only proposes statements for
  you to review.
- The **signature change** (4th parameter) and the **structured output** are intentional. Existing
  3-argument calls must add the 4th argument.

## Testing & validation
Added `convert_varchar_test.sql` (one column per detection branch + ASCII charset + empty + date-name
hint + TIMESTAMP precisions 0/3/6/9 + mixed). Validated end-to-end against a live Exasol database
(2026.1.0): every detection branch produces the expected suggestion, the **character set is preserved**
on shrink (verified by applying the suggested `VARCHAR(n) ASCII` statement and re-reading `COLUMN_TYPE`),
the **dsinterval fraction fix** yields `SECOND(0)` (vs. the old expression's `SECOND(9)`), **TIMESTAMP
precision** is detected (`TIMESTAMP(0/3/6/9)`) and data preservation confirmed (TIMESTAMP(6) keeps
`.123456`; the FF9 recipe keeps `.123456789`), **German NLS** formats (date `12.06.2026` → `DATE`,
decimal `1234,56` → `DECIMAL(6, 2)`) detected and applied correctly, and empty tables / non-matching
filters behave gracefully; **multi-format** detection (German/US/ISO-dot dates, German datetimes, the
ambiguity warning, no false positives, recipe applied); the **VARCHAR shrink** with ~20% headroom
(`VARCHAR(9)` for max length 6) and the **inline risk warnings** (leading-zero/`+` numerics, `0/1` and
`TRUE/FALSE` booleans; clean numbers not flagged); the **structured 6-column output** (layout + sorting)
and the **`log_for_all_columns` toggle** (advisory/`Keep` rows hidden when `false`, shown when `true`;
changed columns present in both; correct empty messages per mode). Re-run against live Exasol 2026.1.0 with
the latest **pyexasol 2.2.1 on Python 3.12.13**. See `TEST_RESULTS_convert_varchar.md`
(**60/60 checks passed**).

[convert_varchar_test.sql](https://github.com/user-attachments/files/29044646/convert_varchar_test.sql)
[TEST_RESULTS_convert_varchar.md](https://github.com/user-attachments/files/29044748/TEST_RESULTS_convert_varchar.md)



