### PR TITLE
Harden exasol_to_exasol: fix mixed-case PK/FK/keys, migrate DEFAULTs & comments, exclude virtual schemas, FORCE views, downgrade switch, enable-keys section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # Database migration
 [![Build Status](https://travis-ci.org/exasol/database-migration.svg?branch=master)](https://travis-ci.org/exasol/database-migration)
 
-###### Please note that this is an open source project which is *not officially supported* by Exasol. We will try to help you as much as possible, but can't guarantee anything since this is not an official Exasol product.
+> ## ⚠️ Please note
+>
+> This is an **open source project** and is **not officially supported by Exasol**. We are happy to help
+> wherever we can, but — since this is not an official Exasol product — **we cannot give any guarantees**.
 
 ## Table of Contents
 1. [Overview](#overview)
@@ -89,22 +92,61 @@ See script [db2_to_exasol.sql](db2_to_exasol.sql)
 
 ### Exasol
 
-Step by Step guide:
-* create connection to the Exasol database you want to import from
-* create the [exasol_to_exasol.sql](exasol_to_exasol.sql) script
-* adapt the variables for the execute script accordingly to your scenario and run the statement
-  * depending on your system and the amount of tables this might take a few seconds
-* copy the result set to another session and execute the statement in the output order
+The [exasol_to_exasol.sql](exasol_to_exasol.sql) script generates the statements to migrate one Exasol
+database to another. It runs on the **target**, reads the **source** metadata through a connection (EXA or
+JDBC) and **returns** the statements to recreate and load the source. It changes nothing itself — you review
+the output and run it, in the order returned.
 
-This script will generate the following information:
-* create schema
-* create table with primary keys
-* alter table add foreign keys
-* alter table set partion by 
-* alter table set distribution keys
-* import data
+**Step by step**
+* **Install** the script on the **target** database (run [exasol_to_exasol.sql](exasol_to_exasol.sql) once;
+  it creates `DATABASE_MIGRATION.EXASOL_TO_EXASOL`).
+* **Create a connection** on the target pointing at the **source** Exasol database. Both the native **EXA**
+  and the **JDBC** interface are built into Exasol — no driver to install (unlike every other source).
+  **Prefer EXA**: `IMPORT FROM EXA` is always parallelized, so loading directly from another Exasol database
+  is significantly faster. For self-signed certificates add the certificate fingerprint or `nocertcheck` and
+  list all source nodes. Ready-to-edit `CREATE CONNECTION` examples and a connection test are at the bottom
+  of the script (a self-managed Exasol — on-prem or in any cloud, e.g. AWS/GCP/Azure — and Exasol SaaS, which
+  uses a slightly different connection string).
+* **Adapt the `EXECUTE SCRIPT` parameters** to your scenario and run it (a few seconds, depending on the
+  number of tables).
+* **Copy the result set** into another session and execute the statements **in the output order**.
 
-See script [exasol_to_exasol.sql](exasol_to_exasol.sql) for more information!
+```sql
+EXECUTE SCRIPT DATABASE_MIGRATION.EXASOL_TO_EXASOL(
+   'EXASOL_EXA'  -- CONNECTION_NAME: the connection to the SOURCE database
+  ,'EXA'         -- CONNECTION_SETTING: 'EXA' (native, parallel, faster) or 'JDBC'
+  ,false         -- IDENTIFIER_CASE_INSENSITIVE: false = verbatim/quoted, recommended (preserves lower/MixedCase); true = fold ALL identifiers to UPPER
+  ,'%TPCDS_1GB%' -- SCHEMA_FILTER: schema name/filter, '%' = all (SYS, EXA_STATISTICS and virtual schemas are always excluded)
+  ,'%'           -- TABLE_FILTER: table name/filter, '%' = all
+  ,true          -- GENERATE_VIEWS: true/false, include views (emitted as CREATE OR REPLACE FORCE VIEW)
+  ,'%'           -- VIEW_FILTER: view name/filter, '%' = all
+  ,'DISABLE'     -- PK_SETTING: 'DISABLE' (faster load; appends an ENABLE-keys section) or 'ENABLE'
+  ,'8'           -- TARGET_VERSION: '8' (default) or '7' (downgrade: TIMESTAMP(p) -> TIMESTAMP)
+);
+```
+
+This script generates, in this order:
+* `CREATE SCHEMA` and `CREATE TABLE` — columns keep their **exact source type** (so every data type *and* its
+  character set `ASCII`/`UTF8` is reproduced 1:1), plus `NOT NULL`, `IDENTITY` and column `DEFAULT`s
+* primary keys (quoted, in constraint order) and `ALTER TABLE … ADD … FOREIGN KEY`
+* `ALTER TABLE … PARTITION BY` and `ALTER TABLE … DISTRIBUTE BY`
+* table & column `COMMENT`s
+* `IMPORT` of the data (typed transfer — differing source/target NLS does not affect the data; nanosecond
+  `TIMESTAMP(9)` is preserved over both EXA and JDBC)
+* when `PK_SETTING='DISABLE'`: an **ENABLE PRIMARY & FOREIGN KEYS** section to run after the import (loading
+  is much faster with keys disabled; primary keys are enabled before foreign keys)
+* views, including their comment, created `WITH FORCE`
+
+System schemas (`SYS`, `EXA_STATISTICS`) and **virtual** objects are skipped. `7.1 → 8` and `7.1 → 7.1`
+work out of the box; for a downgrade `8 → 7.1` set `TARGET_VERSION='7'`. Not migrated (out of scope):
+functions, scripts/UDFs/adapters, users/roles/privileges, connections.
+
+**Privileges/visibility:** the source metadata is read from the `EXA_ALL_*` system views **through the
+connection's user**, so the script sees — and generates statements for — only the objects that user may
+access on the source; the generated statements run on the target only where you have the matching
+privileges. **To migrate everything, use a user with DBA privileges on both the source and the target.**
+
+See the header of [exasol_to_exasol.sql](exasol_to_exasol.sql) for more information!
 
 ### Google BigQuery
 

--- a/exasol_to_exasol.sql
+++ b/exasol_to_exasol.sql
@@ -1,116 +1,242 @@
 create schema if not exists database_migration;
 
-/* 
-    This script will generate create schema, create table and create import statements 
-    to load all needed data from an EXASOL database. Automatic datatype conversion is 
-    applied whenever needed. Feel free to adjust it. 
+/*
+    EXASOL_TO_EXASOL - generate the statements to migrate an Exasol database to another Exasol database.
+
+    The script runs on the TARGET database, reads the SOURCE metadata through a database connection
+    (EXA or JDBC) and RETURNS the statements (CREATE SCHEMA / CREATE TABLE / constraints / DISTRIBUTE BY /
+    PARTITION BY / COMMENTs / IMPORT / CREATE VIEW) needed to recreate and load the source. It changes
+    nothing itself - you review and run the generated statements.
+
+    Data-type mapping is 1:1: every column keeps its source COLUMN_TYPE verbatim, so ALL data types are
+    covered automatically (incl. the character set, e.g. VARCHAR(n) ASCII / UTF8) and new types need no
+    maintenance. Because IMPORT transfers TYPED values (not formatted strings), differing NLS settings
+    between source and target do NOT affect the data (dates, timestamps incl. nanoseconds, decimals and
+    their separators are preserved over both EXA and JDBC connections).
+
+    Compatibility:
+      - 7.1 -> 8 and 7.1 -> 7.1 work out of the box (the source renders its own type strings).
+      - For a DOWNGRADE (e.g. 8 -> 7.1) set TARGET_VERSION = '7': Exasol 8 renders TIMESTAMP as
+        TIMESTAMP(p), which 7.x cannot parse; TARGET_VERSION='7' strips the precision (TIMESTAMP(p) ->
+        TIMESTAMP, CURRENT_TIMESTAMP(p) -> CURRENT_TIMESTAMP).
+
+    What is migrated: schemas, tables (columns/types incl. charset, NOT NULL, IDENTITY, DEFAULT),
+    primary keys, foreign keys, distribution keys, partition keys, table & column comments, data, views
+    (created WITH FORCE so view-to-view ordering does not matter). System schemas (SYS, EXA_STATISTICS)
+    and VIRTUAL schema objects are excluded.
+
+    Loading tip: data loads MUCH faster while primary/foreign keys are disabled. Run with PK_SETTING =
+    'DISABLE' (recommended): the keys are created in the DISABLEd state and the script appends a final
+    "ENABLE PRIMARY & FOREIGN KEYS" section. Run that section AFTER the IMPORTs to (re)validate and
+    activate every key (primary keys are enabled before foreign keys). With PK_SETTING = 'ENABLE' the keys
+    are active immediately and no ENABLE section is generated.
+
+    Not migrated (out of scope): functions, scripts/UDFs/adapters, users/roles/privileges, connections.
+
+    Connection: read over the native EXA or JDBC interface - both are built into Exasol (no driver to
+    install). Prefer EXA: IMPORT FROM EXA is always parallelized, so loading directly from another Exasol
+    database is significantly faster.
+
+    Privileges: the source metadata is read from the EXA_ALL_* views THROUGH the connection's user, so the
+    script only sees - and only generates statements for - the objects that user may access on the source;
+    the generated statements run on the target only where you have the matching privileges. To migrate
+    everything, use a user with DBA privileges on BOTH the source and the target.
+
+    Known limitation: a view body is copied verbatim; if you store identifiers case-insensitively
+    (IDENTIFIER_CASE_INSENSITIVE = true) but the source view text uses quoted lower/mixed-case names, the
+    view text is NOT re-cased and may need a manual adjustment. View comments are emitted as part of the
+    CREATE VIEW (COMMENT ON VIEW is not supported by Exasol).
 */
 --/
 create or replace script database_migration.EXASOL_TO_EXASOL(
-  CONNECTION_NAME              -- name of the database connection inside exasol -> e.g. my_exa
-  ,CONNECTION_SETTING          -- set to JDBC or EXA
-  ,IDENTIFIER_CASE_INSENSITIVE -- true if identifiers should be stored case-insensitiv (will be stored upper_case)
-  ,SCHEMA_FILTER               -- filter for the schemas to generate and load (except EXA_SATISTICS and SYS) -> '%' to load all
-  ,TABLE_FILTER                -- filter for the tables to generate and load -> '%' to load all
-  ,GENERATE_VIEWS              -- flag to control inclusion of views
-  ,VIEW_FILTER                 -- filter for the views to generate -> '%' to generate all
-  ,PK_SETTING                  -- disable/enable to set primary key  
+  CONNECTION_NAME              -- name of the database connection inside Exasol -> e.g. my_exa
+  ,CONNECTION_SETTING          -- set to EXA (native, parallel, faster) or JDBC; both are built into Exasol (no driver to install)
+  ,IDENTIFIER_CASE_INSENSITIVE -- true: store identifiers case-insensitively (folded to UPPER); false: case-sensitive (verbatim, quoted)
+  ,SCHEMA_FILTER               -- filter for the schemas to generate and load (SYS, EXA_STATISTICS and virtual schemas are always excluded) -> '%' for all
+  ,TABLE_FILTER                -- filter for the tables to generate and load -> '%' for all
+  ,GENERATE_VIEWS              -- true/false: include views
+  ,VIEW_FILTER                 -- filter for the views to generate -> '%' for all
+  ,PK_SETTING                  -- ENABLE or DISABLE: state of the generated primary/foreign key constraints. 'DISABLE' = much faster load; an "ENABLE PRIMARY & FOREIGN KEYS" section is appended to run after the IMPORTs
+  ,TARGET_VERSION              -- target Exasol major version: '8' (default, no change) or '7' (downgrade TIMESTAMP(p) -> TIMESTAMP)
 ) RETURNS TABLE
 AS
+
+-- IDENTIFIER_CASE_INSENSITIVE = true wraps every identifier in upper(...) so it is stored UPPER CASE.
+-- The wrapper is applied CONSISTENTLY to schemas, tables, columns, primary keys, foreign keys,
+-- distribution keys, partition keys and comments (previously only schemas/tables/columns were wrapped,
+-- which broke the FK/PARTITION/DISTRIBUTE statements for mixed-case sources).
 exa_upper_begin=''
 exa_upper_end=''
 if IDENTIFIER_CASE_INSENSITIVE == true then
 	exa_upper_begin='upper('
 	exa_upper_end=')'
 end
+
+-- Robust view flag: accept boolean true or the string 'TRUE' (any case). The view CTE and the view
+-- output rows are only added when this is true (instead of injecting a raw SQL boolean into the query).
+gen_views = (GENERATE_VIEWS == true) or (string.upper(tostring(GENERATE_VIEWS)) == 'TRUE')
+
+-- TARGET_VERSION downgrade: for an Exasol 7.x target, strip the fractional-seconds precision that only
+-- Exasol 8 understands. ts_open/ts_close wrap the whole column-type expression in a REGEXP_REPLACE that
+-- turns TIMESTAMP(p) -> TIMESTAMP (this also fixes a CURRENT_TIMESTAMP(p) default).
+ts_open=''
+ts_close=''
+if string.sub(tostring(TARGET_VERSION),1,1) == '7' then
+	ts_open='REGEXP_REPLACE('
+	ts_close=[[, ''TIMESTAMP\([0-9]+\)'', ''TIMESTAMP'')]]
+end
+
+-- Build the optional view CTE / output rows only when views are requested.
+view_cte=''
+view_union=''
+if gen_views then
+	view_cte=[[
+,vv_create_views as (
+  -- VIEW_TEXT already contains any view COMMENT (Exasol stores the comment inside the view definition and
+  -- COMMENT ON VIEW is not supported), so the comment migrates automatically. We only normalize the leading
+  -- CREATE [OR REPLACE] [FORCE] VIEW to "CREATE OR REPLACE FORCE VIEW" so view-to-view dependencies never
+  -- block the migration (FORCE lets a view be created before the objects it references exist).
+  -- The regex avoids the question-mark character (some SQL clients, e.g. DbVisualizer, treat a literal
+  -- question mark as a bind marker at install time): case-insensitivity via character classes, "optional"
+  -- via {0,1}.
+  select REGEXP_REPLACE(view_text, '^\s*[Cc][Rr][Ee][Aa][Tt][Ee]\s+([Oo][Rr]\s+[Rr][Ee][Pp][Ll][Aa][Cc][Ee]\s+){0,1}([Ff][Oo][Rr][Cc][Ee]\s+){0,1}[Vv][Ii][Ee][Ww]', 'CREATE OR REPLACE FORCE VIEW') || ';' as sql_text
+  from (import from ]]..CONNECTION_SETTING..[[ at ]]..CONNECTION_NAME..[[ statement
+    'select view_text from EXA_ALL_VIEWS
+       where view_schema like '']]..SCHEMA_FILTER..[[''
+       and view_name like '']]..VIEW_FILTER..[[''
+       order by view_schema, view_name') as exasql
+)]]
+	view_union="\n".. [[
+UNION ALL
+select 19, cast('-- ### VIEWS (created WITH FORCE - order-independent) ###' as varchar(2000000)) SQL_TEXT
+UNION ALL
+select 20, g.* from vv_create_views g]]
+end
+
+-- When the constraints are generated DISABLEd (PK_SETTING = 'DISABLE'), also emit the statements that
+-- ENABLE every primary and foreign key afterwards. Loading data is much faster while keys are disabled;
+-- run this section AFTER the IMPORTs to (re)validate and activate the keys. Primary keys are enabled
+-- before foreign keys (sections 17 then 18). Not generated when the keys are already created ENABLEd.
+enable_cte=''
+enable_union=''
+if string.upper(tostring(PK_SETTING)) == 'DISABLE' then
+	enable_cte=[[
+,vv_enable_keys as (
+  select alter_enable, key_ord from
+   (IMPORT FROM ]]..CONNECTION_SETTING..[[ at ]]..CONNECTION_NAME..[[ STATEMENT
+   'select CONCAT(''ALTER TABLE "'',]]..exa_upper_begin..[[CONSTRAINT_SCHEMA]]..exa_upper_end..[[,''"."'',]]..exa_upper_begin..[[CONSTRAINT_TABLE]]..exa_upper_end..[[,''" MODIFY CONSTRAINT "'',]]..exa_upper_begin..[[CONSTRAINT_NAME]]..exa_upper_end..[[,''" ENABLE;'') as alter_enable,
+           CASE WHEN CONSTRAINT_TYPE = ''PRIMARY KEY'' THEN 1 ELSE 2 END as key_ord
+    from "SYS"."EXA_ALL_CONSTRAINT_COLUMNS"
+    WHERE CONSTRAINT_TYPE IN (''PRIMARY KEY'',''FOREIGN KEY'')
+    AND CONSTRAINT_SCHEMA like '']]..SCHEMA_FILTER..[[''
+    AND CONSTRAINT_TABLE like '']]..TABLE_FILTER..[[''
+    GROUP BY CONSTRAINT_SCHEMA, CONSTRAINT_TABLE, CONSTRAINT_NAME, CONSTRAINT_TYPE') as enable_keys
+)]]
+	enable_union="\n".. [[
+UNION ALL
+select 16, cast('-- ### ENABLE PRIMARY & FOREIGN KEYS - run AFTER the data load (loading is much faster with keys disabled) ###' as varchar(2000000)) SQL_TEXT
+UNION ALL
+select 17, ek.alter_enable from vv_enable_keys ek where ek.key_ord = 1
+UNION ALL
+select 18, ek2.alter_enable from vv_enable_keys ek2 where ek2.key_ord = 2]]
+end
+
 suc, res = pquery([[
 with vv_exa_columns as (
-  select ]]..exa_upper_begin..[[table_schema]]..exa_upper_end..[[ as "exa_table_schema", ]]..exa_upper_begin..[[table_name]]..exa_upper_end..[[ as "exa_table_name", ]]..exa_upper_begin..[[column_name]]..exa_upper_end..[[ as "exa_column_name", exasql.* from  
-		(import from ]]..CONNECTION_SETTING..[[ at ]]..CONNECTION_NAME..[[ statement 
+  select ]]..exa_upper_begin..[[table_schema]]..exa_upper_end..[[ as "exa_table_schema", ]]..exa_upper_begin..[[table_name]]..exa_upper_end..[[ as "exa_table_name", ]]..exa_upper_begin..[[column_name]]..exa_upper_end..[[ as "exa_column_name", exasql.* from
+		(import from ]]..CONNECTION_SETTING..[[ at ]]..CONNECTION_NAME..[[ statement
 			'with constr_cols as (
-
-                                select * 
+                                select *
                                 from "SYS"."EXA_ALL_CONSTRAINT_COLUMNS"
-                                where (CONSTRAINT_TYPE IN (''PRIMARY KEY'') or CONSTRAINT_TYPE IS NULL)
+                                where CONSTRAINT_TYPE = ''PRIMARY KEY''
                                 AND constraint_schema like '']]..SCHEMA_FILTER..[[''
                                 AND constraint_table like '']]..TABLE_FILTER..[[''
                                 )
-                                select table_schema, table_name, c.column_name, COLUMN_ORDINAL_POSITION ordinal_position,  COLUMN_TYPE || CASE WHEN COLUMN_IDENTITY IS NOT NULL THEN '' IDENTITY '' || COLUMN_IDENTITY END || CASE WHEN COLUMN_IS_NULLABLE = FALSE THEN '' NOT NULL'' END data_type, column_type, COLUMN_MAXSIZE character_maximum_length, COLUMN_NUM_PREC numeric_precision, COLUMN_NUM_SCALE numeric_scale, cc.constraint_name ,cc.constraint_type
-                                        from EXA_ALL_COLUMNS c 
+                                select table_schema, table_name, c.column_name, COLUMN_ORDINAL_POSITION ordinal_position,
+                                       ]]..ts_open..[[COLUMN_TYPE
+                                         || CASE WHEN COLUMN_IDENTITY IS NOT NULL THEN '' IDENTITY '' || COLUMN_IDENTITY END
+                                         || CASE WHEN COLUMN_DEFAULT IS NOT NULL THEN '' DEFAULT '' || COLUMN_DEFAULT END
+                                         || CASE WHEN COLUMN_IS_NULLABLE = FALSE THEN '' NOT NULL'' END]]..ts_close..[[ data_type,
+                                       column_type, COLUMN_MAXSIZE character_maximum_length, COLUMN_NUM_PREC numeric_precision, COLUMN_NUM_SCALE numeric_scale,
+                                       cc.constraint_name, cc.constraint_type, cc.ordinal_position pk_ordinal,
+                                       t.table_comment, c.column_comment
+                                        from EXA_ALL_COLUMNS c
                                         join EXA_ALL_TABLES t on t.table_schema = c.column_schema and t.table_name = c.column_table
                                         left join constr_cols cc on cc.constraint_schema = c.column_schema and cc.constraint_table = c.column_table and cc.column_name = c.column_name
                                         where table_schema not in (''SYS'',''EXA_STATISTICS'')
+                                        AND t.table_is_virtual = FALSE
+                                        AND c.column_is_virtual = FALSE
                                         AND table_schema like '']]..SCHEMA_FILTER..[[''
                                         AND table_name like '']]..TABLE_FILTER..[[''
                                         ORDER BY c."COLUMN_ORDINAL_POSITION"
-                        ') as exasql  
-
-
+                        ') as exasql
 )
 ,vv_create_schemas as(
-  SELECT 'create schema "' || "exa_table_schema" || '";' as sql_text from vv_exa_columns  group by "exa_table_schema" order by "exa_table_schema"
+  SELECT 'CREATE SCHEMA IF NOT EXISTS "' || "exa_table_schema" || '";' as sql_text from vv_exa_columns group by "exa_table_schema" order by "exa_table_schema"
 )
 ,vv_create_tables as (
-  select 'create or replace table "' || "exa_table_schema" || '"."' || "exa_table_name" || '" (' || group_concat('"' || "exa_column_name" || '" ' || data_type	||' ' order by ordinal_position) || vv_pk_constraints.PK_CON || ');' as sql_text
+  select 'CREATE OR REPLACE TABLE "' || "exa_table_schema" || '"."' || "exa_table_name" || '" (' || group_concat('"' || "exa_column_name" || '" ' || data_type ||' ' order by ordinal_position) || vv_pk_constraints.PK_CON || ');' as sql_text
 	from vv_exa_columns
-	left join (select table_schema, table_name, constraint_name, (', CONSTRAINT "' || constraint_name || '" PRIMARY KEY (' || GROUP_CONCAT(COLUMN_NAME)) || ') ]]..PK_SETTING..[[' as PK_CON
+	left join (select "exa_table_schema" as pk_schema, "exa_table_name" as pk_table,
+                        (', CONSTRAINT "' || ]]..exa_upper_begin..[[constraint_name]]..exa_upper_end..[[ || '" PRIMARY KEY (' || GROUP_CONCAT('"' || "exa_column_name" || '"' ORDER BY pk_ordinal)) || ') ]]..PK_SETTING..[[' as PK_CON
                         from vv_exa_columns
-                        where table_schema not in ('SYS','EXA_STATISTICS') AND constraint_type = 'PRIMARY KEY'
-                       GROUP BY table_schema, table_name, constraint_name) as vv_pk_constraints on vv_exa_columns.table_schema = vv_pk_constraints.table_schema and vv_exa_columns.table_name = vv_pk_constraints.table_name
-	WHERE (CONSTRAINT_TYPE IS NULL OR CONSTRAINT_TYPE IN ('PRIMARY KEY','FOREIGN KEY')) 
+                        where constraint_type = 'PRIMARY KEY'
+                       GROUP BY "exa_table_schema", "exa_table_name", constraint_name) as vv_pk_constraints on vv_exa_columns."exa_table_schema" = vv_pk_constraints.pk_schema and vv_exa_columns."exa_table_name" = vv_pk_constraints.pk_table
 	group by "exa_table_schema", "exa_table_name", "PK_CON"
 	order by "exa_table_schema","exa_table_name", "PK_CON"
 )
 ,vv_create_foreignkey AS (
-        select * from 
+        select * from
          (IMPORT FROM ]]..CONNECTION_SETTING..[[ at ]]..CONNECTION_NAME..[[ STATEMENT
-         'select CONCAT(''ALTER TABLE "'',CONSTRAINT_SCHEMA,''"."'',CONSTRAINT_TABLE,''" ADD CONSTRAINT "'',CONSTRAINT_NAME,''" FOREIGN KEY ('',GROUP_CONCAT(CONCAT(''"'',COLUMN_NAME,''"'')),'') REFERENCES "'',REFERENCED_SCHEMA,''"."'',REFERENCED_TABLE,''" ]]..PK_SETTING..[[;'') AS ALTER_TABLE 
-         from "SYS"."EXA_ALL_CONSTRAINT_COLUMNS" 
+         'select CONCAT(''ALTER TABLE "'',]]..exa_upper_begin..[[CONSTRAINT_SCHEMA]]..exa_upper_end..[[,''"."'',]]..exa_upper_begin..[[CONSTRAINT_TABLE]]..exa_upper_end..[[,''" ADD CONSTRAINT "'',]]..exa_upper_begin..[[CONSTRAINT_NAME]]..exa_upper_end..[[,''" FOREIGN KEY ('',GROUP_CONCAT(CONCAT(''"'',]]..exa_upper_begin..[[COLUMN_NAME]]..exa_upper_end..[[,''"'') ORDER BY ORDINAL_POSITION),'') REFERENCES "'',]]..exa_upper_begin..[[REFERENCED_SCHEMA]]..exa_upper_end..[[,''"."'',]]..exa_upper_begin..[[REFERENCED_TABLE]]..exa_upper_end..[[,''" ]]..PK_SETTING..[[;'') AS ALTER_TABLE
+         from "SYS"."EXA_ALL_CONSTRAINT_COLUMNS"
          WHERE "EXA_ALL_CONSTRAINT_COLUMNS"."CONSTRAINT_TYPE" = ''FOREIGN KEY''
          AND "CONSTRAINT_SCHEMA" like '']]..SCHEMA_FILTER..[[''
-         AND "CONSTRAINT_NAME" like '']]..TABLE_FILTER..[[''
+         AND "CONSTRAINT_TABLE" like '']]..TABLE_FILTER..[[''
          GROUP BY "CONSTRAINT_SCHEMA", "CONSTRAINT_TABLE","CONSTRAINT_NAME","REFERENCED_SCHEMA","REFERENCED_TABLE"') AS foreign_keys
-				
 )
 ,vv_create_distribution_key as(
-select * from 
+select * from
          (IMPORT FROM ]]..CONNECTION_SETTING..[[ at ]]..CONNECTION_NAME..[[ STATEMENT
-         'select CONCAT('' ALTER TABLE "'',COLUMN_SCHEMA,''"."'',COLUMN_TABLE,''" DISTRIBUTE BY '',group_concat(concat(''"'',COLUMN_NAME,''"'')),'';''  ) 
-         from "SYS"."EXA_ALL_COLUMNS" 
+         'select CONCAT('' ALTER TABLE "'',]]..exa_upper_begin..[[COLUMN_SCHEMA]]..exa_upper_end..[[,''"."'',]]..exa_upper_begin..[[COLUMN_TABLE]]..exa_upper_end..[[,''" DISTRIBUTE BY '',group_concat(concat(''"'',]]..exa_upper_begin..[[COLUMN_NAME]]..exa_upper_end..[[,''"'') ORDER BY COLUMN_ORDINAL_POSITION),'';'')
+         from "SYS"."EXA_ALL_COLUMNS"
          WHERE "EXA_ALL_COLUMNS"."COLUMN_IS_DISTRIBUTION_KEY" = TRUE
+         AND COLUMN_IS_VIRTUAL = FALSE
          AND COLUMN_SCHEMA like '']]..SCHEMA_FILTER..[[''
-         AND COLUMN_TABLE like '']]..TABLE_FILTER..[['' 
+         AND COLUMN_TABLE like '']]..TABLE_FILTER..[[''
          GROUP BY "EXA_ALL_COLUMNS"."COLUMN_SCHEMA","EXA_ALL_COLUMNS"."COLUMN_TABLE"') AS distribution_keys
 )
 ,vv_create_partion_key as(
-select alter_partion from 
+select alter_partion from
          (IMPORT FROM ]]..CONNECTION_SETTING..[[ at ]]..CONNECTION_NAME..[[ STATEMENT
-         'SELECT CONCAT(COLUMN_SCHEMA,''.'',COLUMN_TABLE) as group_table_schema, CONCAT('' ALTER TABLE "'',COLUMN_SCHEMA,''"."'',COLUMN_TABLE,''" PARTITION BY '',GROUP_CONCAT(CONCAT(''"'',COLUMN_NAME,''"'') ORDER BY COLUMN_PARTITION_KEY_ORDINAL_POSITION),'';'') as alter_partion
-                FROM "SYS"."EXA_ALL_COLUMNS" 
+         'SELECT CONCAT('' ALTER TABLE "'',]]..exa_upper_begin..[[COLUMN_SCHEMA]]..exa_upper_end..[[,''"."'',]]..exa_upper_begin..[[COLUMN_TABLE]]..exa_upper_end..[[,''" PARTITION BY '',GROUP_CONCAT(CONCAT(''"'',]]..exa_upper_begin..[[COLUMN_NAME]]..exa_upper_end..[[,''"'') ORDER BY COLUMN_PARTITION_KEY_ORDINAL_POSITION),'';'') as alter_partion
+                FROM "SYS"."EXA_ALL_COLUMNS"
                 WHERE "EXA_ALL_COLUMNS"."COLUMN_PARTITION_KEY_ORDINAL_POSITION" > 0
+                AND COLUMN_IS_VIRTUAL = FALSE
                 AND COLUMN_SCHEMA like '']]..SCHEMA_FILTER..[[''
-                AND COLUMN_TABLE like '']]..TABLE_FILTER..[['' 
+                AND COLUMN_TABLE like '']]..TABLE_FILTER..[[''
                 GROUP BY COLUMN_SCHEMA,COLUMN_TABLE
                 ') AS partion_keys
 )
+,vv_table_comments as (
+  select 'COMMENT ON TABLE "' || "exa_table_schema" || '"."' || "exa_table_name" || '" IS ''' || REPLACE(table_comment, '''', '''''') || ''';' as sql_text
+        from vv_exa_columns where table_comment is not null
+        group by "exa_table_schema", "exa_table_name", table_comment
+        order by "exa_table_schema", "exa_table_name"
+)
+,vv_column_comments as (
+  select 'COMMENT ON COLUMN "' || "exa_table_schema" || '"."' || "exa_table_name" || '"."' || "exa_column_name" || '" IS ''' || REPLACE(column_comment, '''', '''''') || ''';' as sql_text
+        from vv_exa_columns where column_comment is not null
+        order by "exa_table_schema", "exa_table_name", ordinal_position
+)
 , vv_imports as (
-  select 'import into "' || "exa_table_schema" || '"."' || "exa_table_name" || '" from ]]..CONNECTION_SETTING..[[ at ]]..CONNECTION_NAME..[[ table "' || table_schema||'"."'||table_name||'";'  as sql_text
+  select 'IMPORT INTO "' || "exa_table_schema" || '"."' || "exa_table_name" || '" FROM ]]..CONNECTION_SETTING..[[ AT ]]..CONNECTION_NAME..[[ TABLE "' || table_schema||'"."'||table_name||'";'  as sql_text
 	from vv_exa_columns group by "exa_table_schema","exa_table_name", table_schema,table_name
 	order by "exa_table_schema","exa_table_name", table_schema,table_name
-)
-,vv_create_views as(
-  select view_text || ';' as sql_text from  
-		(import from ]]..CONNECTION_SETTING..[[ at ]]..CONNECTION_NAME..[[ statement 
-			'select view_text from EXA_ALL_VIEWS
-				where view_schema like '']]..SCHEMA_FILTER..[[''
-				and ]]..GENERATE_VIEWS..[[
-				and view_name like '']]..VIEW_FILTER..[[''
-				order by view_schema, view_name
-		') as exasql 
-)
+)]]..enable_cte..view_cte..[[
 select SQL_TEXT from (
 select 1 as ord, cast('-- ### SCHEMAS ###' as varchar(2000000)) SQL_TEXT
-union all 
+union all
 select 2, a.* from vv_create_schemas a
 UNION ALL
 select 3, cast('-- ### TABLES ###' as varchar(2000000)) SQL_TEXT
@@ -121,7 +247,7 @@ select 5, cast('-- ### FOREIGN KEYS ###' as varchar(2000000)) SQL_TEXT
 UNION ALL
 select 6, c.* from vv_create_foreignkey c
 UNION ALL
-select 7, cast('-- ### PARTION BY ###' as varchar(2000000)) SQL_TEXT
+select 7, cast('-- ### PARTITION BY ###' as varchar(2000000)) SQL_TEXT
 UNION ALL
 select 8, d.* from vv_create_partion_key d
 UNION ALL
@@ -129,14 +255,15 @@ select 9, cast('-- ### DISTRIBUTION KEY ###' as varchar(2000000)) SQL_TEXT
 UNION ALL
 select 10, e.* from vv_create_distribution_key e
 UNION ALL
-select 11, cast('-- ### IMPORTS ###' as varchar(2000000)) SQL_TEXT
+select 11, cast('-- ### COMMENTS ###' as varchar(2000000)) SQL_TEXT
+UNION ALL
+select 12, h.* from vv_table_comments h
+UNION ALL
+select 13, i.* from vv_column_comments i
+UNION ALL
+select 14, cast('-- ### IMPORTS ###' as varchar(2000000)) SQL_TEXT
 union all
-select 12, f.* from vv_imports f
-union all
-select 13, cast('-- ### VIEWS - Add FORCE as needed to avoid ordering dependencies ###' as varchar(2000000)) SQL_TEXT
-from dual where ]]..GENERATE_VIEWS..[[ -- the whitespace at the end is important and must not be removed
-union all
-select 14, g.* from vv_create_views g
+select 15, f.* from vv_imports f]]..enable_union..view_union..[[
 ) order by ord
 ]],{})
 
@@ -146,22 +273,110 @@ end
 
 return(res)
 /
-										  
--- Create a connection to the your other Exasol database
-create connection SECOND_EXASOL_DB to '192.168.6.11..14:8563' user 'username' identified by 'exasolRocks!';
 
--- JDBC connection
-CREATE CONNECTION SECOND_EXASOL_DB TO 'jdbc:exa:192.168.6.11..14:8563' user 'username' identified by 'exasolRocks!';
-										  
-execute script database_migration.EXASOL_TO_EXASOL(
-   'SECOND_EXASOL_DB' -- name of your database connection   
-   ,'JDBC'             -- set if import from EXA or JDBC connection
-   ,FALSE             -- case sensitivity handling for identifiers -> false: handle them case sensitiv / true: handle them case insensitiv --> recommended: true
-   ,'%TPC%'           -- schema filter --> '%' to load all schemas except 'SYS' and 'EXA_STATISTICS'/ '%pub%' to load all schemas like '%pub%'
-   ,'%'               -- table filter --> '%' to load all tables
-   ,'FALSE'           -- view inclusion flag --> 'TRUE' to include views
-   ,'%'               -- view filter --> '%' to generate all views
-   ,'DISABLE'         -- pk & fk setting --> disable/enable to create disabled/enabled primary key
+-- EXASOL_TO_EXASOL Data Migration
+--
+-- You can load data from another Exasol database using the native EXA or JDBC interface; both are built
+-- into Exasol (no driver to install). Prefer the native EXA interface: IMPORT FROM EXA is always
+-- parallelized, so loading directly from another Exasol database is significantly faster.
+--
+-- Prerequisites:
+-- The other Exasol database and Port 8563 must be reachable from this Exasol database (Firewall settings source and target).
+-- The port range from 20000 to 21000 must be opened in the other database if you want to use the native EXA interface (only for Exasol v8 Versions 2025.1.2 and earlier)
+-- The user credentials in the connection must be valid.
+--
+-- JDBC Driver:
+-- There is no need to install an Exasol JDBC driver. It is automatically integrated in the product.
+--
+-- Further documentation: https://docs.exasol.com/db/latest/loading_data/connect_sources/exasol.htm
+--
+-- Create a connection to the other Exasol database:
+-- To create a connection, run one of the following statements.
+-- Replace the connection string and credentials as needed.
+-- If you use self-signed certificates in your other Exasol database, make sure you add either the fingerprint
+-- or the keyword nocertcheck in your connection string.
+-- Additionally always make sure you add all your database nodes to the connection string.
+-- See also: https://docs.exasol.com/db/latest/connect_exasol/drivers/jdbc.htm
+--
+-- EXA Connection (fast)
+CREATE OR REPLACE CONNECTION EXASOL_EXA
+    TO '192.168.6.11..14/nocertcheck:8563'
+    USER 'user'
+    IDENTIFIED BY 'password';
+--
+-- To test the connection, run the following statement.
+--
+SELECT * FROM
+(
+IMPORT FROM EXA AT EXASOL_EXA
+STATEMENT 'SELECT ''Connection works'' '
 );
+--
+--
+-- EXA Connection to an Exasol SaaS database (fast)
+CREATE OR REPLACE CONNECTION EXASOL_SAAS_EXA
+    TO 'my_database_id.clusters.exasol.com:8563'
+    USER 'my_user_name'
+    IDENTIFIED BY 'my_personal_access_token';
+--
+-- To test the connection, run the following statement.
+--
+SELECT * FROM
+(
+IMPORT FROM EXA AT EXASOL_SAAS_EXA
+STATEMENT 'SELECT ''Connection works'' '
+);
+--
+--
+-- JDBC Connection (slower than EXA Connection)
+CREATE OR REPLACE CONNECTION EXASOL_JDBC
+    TO 'jdbc:exa:192.168.6.11..14/nocertcheck:8563'
+    USER 'user'
+    IDENTIFIED BY 'password';
+--
+-- To test the connection, run the following statement.
+--
+SELECT * FROM
+(
+IMPORT FROM JDBC AT EXASOL_JDBC
+STATEMENT 'SELECT ''Connection works'' '
+);
+--
+--
+-- JDBC Connection to an Exasol SaaS database (slower than EXA Connection)
+CREATE OR REPLACE CONNECTION EXASOL_SAAS_JDBC
+    TO 'jdbc:exa:my_database_id.clusters.exasol.com:8563'
+    USER 'my_user_name'
+    IDENTIFIED BY 'my_personal_access_token';
+--
+-- To test the connection, run the following statement.
+--
+SELECT * FROM
+(
+IMPORT FROM JDBC AT EXASOL_SAAS_JDBC
+STATEMENT 'SELECT ''Connection works'' '
+);
+--
+/*
+    This script will generate create schema, create table and create import statements
+    to load all needed data from an EXASOL database. Automatic datatype conversion is
+    applied whenever needed. Copy out the generated statements and execute them in a separate
+    SQL Commander window, in the order they are returned.
 
-commit;
+    Tip: loading is MUCH faster with primary/foreign keys disabled. With PK_SETTING = 'DISABLE'
+    (as below) the keys are created disabled and the output ends with an
+    "ENABLE PRIMARY & FOREIGN KEYS" section - run that section LAST, after the IMPORTs, to
+    (re)validate and activate every key (primary keys first, then foreign keys).
+*/
+--
+EXECUTE SCRIPT DATABASE_MIGRATION.EXASOL_TO_EXASOL(
+   'EXASOL_EXA'  -- CONNECTION_NAME: the connection to the SOURCE database
+  ,'EXA'         -- CONNECTION_SETTING: 'EXA' (native, parallel, faster) or 'JDBC'
+  ,false         -- IDENTIFIER_CASE_INSENSITIVE: false = verbatim/quoted, recommended (preserves lower/MixedCase); true = fold ALL identifiers to UPPER
+  ,'%TPCDS_1GB%' -- SCHEMA_FILTER: schema name/filter, '%' = all (SYS, EXA_STATISTICS and virtual schemas are always excluded)
+  ,'%'           -- TABLE_FILTER: table name/filter, '%' = all
+  ,true          -- GENERATE_VIEWS: true/false, include views (emitted as CREATE OR REPLACE FORCE VIEW)
+  ,'%'           -- VIEW_FILTER: view name/filter, '%' = all
+  ,'DISABLE'     -- PK_SETTING: 'DISABLE' (faster load; appends an ENABLE-keys section) or 'ENABLE'
+  ,'8'           -- TARGET_VERSION: '8' (default) or '7' (downgrade: TIMESTAMP(p) -> TIMESTAMP)
+);


### PR DESCRIPTION
## Summary
This PR makes `exasol_to_exasol.sql` correct and complete for real-world migrations while keeping its
metadata-driven design and its **1:1 `COLUMN_TYPE` mapping** (which already covers every data type and the
`ASCII`/`UTF8` character set automatically). It fixes several DDL-generation **bugs**, migrates information
that was previously **dropped** (column DEFAULTs, comments), **excludes virtual schemas**, emits views
`WITH FORCE`, and adds a `TARGET_VERSION` switch for downgrade migrations.

> 💥 **Signature change:** one new parameter `TARGET_VERSION` is appended (`'8'` default / `'7'` downgrade);
> all existing parameters keep their meaning and position. Existing 8-argument calls must add the 9th argument.

All changes were **validated live** against Exasol 8 (2026.1.0) through both the EXA and JDBC connections,
including an end-to-end run where the generated statements were executed and the rebuilt objects compared
1:1 to the source.

## 🐞 Bug fixes
1. **PK columns were not quoted** → `CREATE TABLE` failed for any lower/MixedCase PK column
   (`PRIMARY KEY (Id)` vs. column `"Id"`). Now double-quoted **and ordered by the constraint ordinal**.
2. **Foreign keys filtered by `CONSTRAINT_NAME` instead of `CONSTRAINT_TABLE`** → FKs silently vanished
   when a `TABLE_FILTER` ≠ `'%'` was used. Fixed.
3. **`IDENTIFIER_CASE_INSENSITIVE` applied inconsistently** → in UPPER mode the tables were uppercased but
   the `FOREIGN KEY` / `PARTITION BY` / `DISTRIBUTE BY` statements still used the source's original case, so
   those `ALTER`s failed. The upper() wrapper is now applied consistently everywhere.
4. **Non-deterministic key column order** (`GROUP_CONCAT` without `ORDER BY`) for PK/FK/distribution/partition
   → now ordered by ordinal position (and FK columns quoted).
5. **`create schema "X"`** → **`create schema if not exists "X"`**.
6. **`GENERATE_VIEWS` injected as a raw SQL boolean** → now evaluated in the script (accepts `true` or
   `'TRUE'`); view parts are only generated when requested.

## ✨ Completeness — previously dropped information
- **Column DEFAULTs** are migrated (`DEFAULT 5`, `DEFAULT CURRENT_TIMESTAMP`, …).
- **Table & column comments** are migrated (`COMMENT ON …`, quotes escaped). View comments migrate
  automatically (they are stored inside the view definition that is copied).
- **Virtual schema objects are excluded** (`TABLE_IS_VIRTUAL`/`COLUMN_IS_VIRTUAL = FALSE`) so the script no
  longer tries to recreate/load a virtual table (`SYS`/`EXA_STATISTICS` were already excluded).

## ✨ Improvements
- **Views** emitted as `CREATE OR REPLACE FORCE VIEW` → view-to-view dependencies no longer block migration.
- **`TARGET_VERSION='7'`** down-converts the Exasol-8-only `TIMESTAMP(p)` → `TIMESTAMP` (and
  `CURRENT_TIMESTAMP(p)` → `CURRENT_TIMESTAMP`) for 7.x targets.
- New **`ENABLE PRIMARY & FOREIGN KEYS`** section, emitted only when `PK_SETTING='DISABLE'`: after the
  imports it returns `ALTER TABLE … MODIFY CONSTRAINT … ENABLE` for every primary key, then every foreign key.
  Loading is **much faster with keys disabled**, so the recommended flow is `DISABLE` → load → run this
  section (PKs are enabled before FKs so the targets exist).
- New **`COMMENTS`** output section; order is
  `SCHEMAS → TABLES → FOREIGN KEYS → PARTITION BY → DISTRIBUTION KEY → COMMENTS → IMPORTS → ENABLE KEYS → VIEWS`.
- **Usability:** the example footer now ships ready-to-use EXA and JDBC connection examples (for a
  self-managed Exasol — on-prem or in any cloud — and for Exasol SaaS, which uses a slightly different
  connection string) with prerequisites, TLS guidance (`nocertcheck`/fingerprint, all nodes) and a
  connection-test snippet; the unnecessary trailing `commit;` was removed.
- **Docs:** clarified that the native EXA and JDBC interfaces are both built into Exasol (no driver to
  install) and that `IMPORT FROM EXA` is always parallelized (significantly faster); documented that
  metadata visibility (and thus what can be generated/run) depends on the connection user's privileges
  on the source and the executing user's privileges on the target.

## Answers to the questions this PR set out to resolve
- **Different NLS on source vs. target?** No problem — `IMPORT … TABLE` transfers *typed* values, not
  formatted strings. Proven: importing under a deliberately different session NLS preserved timestamps
  (incl. nanoseconds) and decimals bit-exactly.
- **Nanosecond timestamps?** `TIMESTAMP(9)` is preserved over **both** EXA and JDBC connections (not
  truncated to FF6). Only relevant 8↔8.
- **Character set?** Already preserved via `COLUMN_TYPE` (`VARCHAR(n) ASCII`/`UTF8`, `CHAR(n) ASCII`) —
  confirmed.
- **Version compatibility?** `7.1 → 8` and `7.1 → 7.1` work out of the box; `8 → 7.1` needs `TARGET_VERSION='7'`.
- **Virtual/system objects?** System schemas were already skipped; virtual objects are now skipped too.
- **Lower/MixedCase?** Fully handled with `IDENTIFIER_CASE_INSENSITIVE=false` (everything double-quoted,
  verbatim — including PK/FK/distribution/partition keys).

## Testing & validation
See `TEST_RESULTS_exasol_to_exasol.md`. Highlights (live, Exasol 8, EXA + JDBC):
- **Full end-to-end with every data type and real content.** A source covering all Exasol types
  (`DECIMAL`/`DOUBLE`/`VARCHAR UTF8`&`ASCII`/`CHAR`/`BOOLEAN`/`DATE`/`TIMESTAMP(3)`/`TIMESTAMP(9)`/
  `TIMESTAMP WITH LOCAL TIME ZONE`/`INTERVAL YEAR TO MONTH`/`INTERVAL DAY TO SECOND`/`GEOMETRY`/`HASHTYPE`/
  `IDENTITY`/`DEFAULT`/`NOT NULL`) in three content profiles (fully populated, all-NULL, edge values) was
  migrated by **running the generated statements unchanged**. **0 statement failures**, **structure
  identical**, and **every value identical** source↔target — incl. Unicode, FF9 nanoseconds, 36-digit
  decimals, intervals, GEOMETRY WKT, HASHTYPE, applied DEFAULTs, and **identity values preserved by IMPORT**.
- **ENABLE KEYS section**: emitted only for `PK_SETTING='DISABLE'`, lists PKs before FKs, sits after the
  imports (and before views); the generated `MODIFY CONSTRAINT … ENABLE` statements ran and flipped a
  disabled composite PK and FK to enabled.
- Generation verified in all three modes: case-sensitive, case-insensitive/UPPER (consistent across
  FK/partition/distribution/ENABLE), and `TARGET_VERSION='7'` downgrade.

## Notes / out of scope
- Functions, scripts/UDFs/adapters, users/roles/privileges and connections are not migrated.
- **Privileges/visibility:** the source metadata is read from the `EXA_ALL_*` views *through the connection's
  user*, so the script only generates statements for objects that user may access on the source; running them
  on the target requires the matching privileges there. To migrate everything, use a user with **DBA
  privileges on both source and target**.
- A view body is copied verbatim; under `IDENTIFIER_CASE_INSENSITIVE=true` a view text that quotes
  lower/MixedCase identifiers is not re-cased (documented limitation).

[TEST_RESULTS_exasol_to_exasol.md](https://github.com/user-attachments/files/29070451/TEST_RESULTS_exasol_to_exasol.md)

[exasol_to_exasol_test.sql](https://github.com/user-attachments/files/29070453/exasol_to_exasol_test.sql)
