### PR TITLE
convert_varchar follow-up: section markers in QUERY_TEXT, DECIMAL(p,s) precision rounded to 9/18/36, VARCHAR(n<=3) left untouched

### DIFF
--- a/post_load_optimization/README.md
+++ b/post_load_optimization/README.md
@@ -92,7 +92,7 @@ auto-detected.
 | If the sampled values look like … | Suggestion |
 |---|---|
 | integers | `DECIMAL(p)` (precision rounded up to 9 / 18 / 36) |
-| integers + decimals | `DECIMAL(p, s)` |
+| integers + decimals | `DECIMAL(p, s)` (precision **p** rounded up to 9 / 18 / 36; scale **s** kept) |
 | any numeric incl. scientific notation | `DOUBLE PRECISION` |
 | dates only (no time component) | `DATE` |
 | dates and/or timestamps | `TIMESTAMP(p)` with the **detected fractional-seconds precision** `p` (0–9), so micro/nanosecond values are not truncated; + hint to consider `TIMESTAMP WITH LOCAL TIME ZONE` |
@@ -100,7 +100,7 @@ auto-detected.
 | day-to-second intervals | `INTERVAL DAY(p) TO SECOND(fp)` |
 | year-to-month intervals | `INTERVAL YEAR(p) TO MONTH` |
 | WKT geometry (`POINT (…)`, `POLYGON (…)`, …) | `GEOMETRY` (+ hint to specify an SRID) |
-| nothing single fits, but values are shorter than the column | shrink to a smaller `VARCHAR` — actual max length **+ ~20% headroom, rounded up**, **character set preserved** |
+| nothing single fits, but values are shorter than the column | shrink to a smaller `VARCHAR` — actual max length **+ ~20% headroom, rounded up**, **character set preserved**. Columns with **n ≤ 3** are left untouched |
 | the **column name** looks like a date/timestamp but values don't parse | a hint with an example `UPDATE`/`ALTER` |
 | the column is empty (in the sample) | a hint that the column could be dropped |
 
@@ -142,7 +142,7 @@ Example (`log_for_all_columns = true`, session NLS at the ISO default):
 | schema_name | table_name | column_name | conversion | query_text | notes |
 |---|---|---|---|---|---|
 | MY_SCHEMA | CUSTOMERS | ACTIVE | `VARCHAR(10) UTF8 --> BOOLEAN` | `ALTER TABLE "MY_SCHEMA"."CUSTOMERS" MODIFY COLUMN "ACTIVE" BOOLEAN;` | NOTE: only 0/1 values. Verify these are real booleans, not flags/bits/codes you compute with. |
-| MY_SCHEMA | CUSTOMERS | AMOUNT | `VARCHAR(20) UTF8 --> DECIMAL(4, 2)` | `ALTER TABLE "MY_SCHEMA"."CUSTOMERS" MODIFY COLUMN "AMOUNT" DECIMAL(4, 2);` | |
+| MY_SCHEMA | CUSTOMERS | AMOUNT | `VARCHAR(20) UTF8 --> DECIMAL(9, 2)` | `ALTER TABLE "MY_SCHEMA"."CUSTOMERS" MODIFY COLUMN "AMOUNT" DECIMAL(9, 2);` | |
 | MY_SCHEMA | CUSTOMERS | COMMENT | `VARCHAR(2000000) UTF8 --> VARCHAR(20) UTF8, max length: 15` | `ALTER TABLE "MY_SCHEMA"."CUSTOMERS" MODIFY COLUMN "COMMENT" VARCHAR(20) UTF8;` | Mixed values; no single type fits. Shrinking the width (actual max length 15 + ~20% headroom); character set preserved. |
 | MY_SCHEMA | CUSTOMERS | CUST_ID | `VARCHAR(50) UTF8 --> DECIMAL(9, 0)` | `ALTER TABLE "MY_SCHEMA"."CUSTOMERS" MODIFY COLUMN "CUST_ID" DECIMAL(9, 0);` | WARNING: some values have leading zeros or a '+' sign (looks like an identifier: ID / ZIP / phone / article no.). Converting to DECIMAL LOSES them ('007' -> 7, '+49' -> 49). Review before applying! |
 | MY_SCHEMA | CUSTOMERS | DE_DATE | `VARCHAR(20) UTF8 --> DATE (format DD.MM.YYYY)` | `ALTER SESSION SET NLS_DATE_FORMAT='DD.MM.YYYY'; ALTER TABLE "MY_SCHEMA"."CUSTOMERS" MODIFY COLUMN "DE_DATE" DATE;` | Values match the date format 'DD.MM.YYYY' (not the session NLS_DATE_FORMAT). Run BOTH statements in query_text (the ALTER SESSION first). |

--- a/post_load_optimization/convert_varchar.sql
+++ b/post_load_optimization/convert_varchar.sql
@@ -209,8 +209,8 @@ CREATE OR REPLACE SCRIPT database_migration.convert_varchar(schema_pattern, tabl
     function render_type(t)
         if     t.fam == 'NUM' then
             if t.scale == 0 then return "DECIMAL(" .. adjust_precision(t.idig) .. ", 0)" end
-            local total = t.idig + t.scale
-            if total > 36 then return "DOUBLE PRECISION" else return "DECIMAL(" .. total .. ", " .. t.scale .. ")" end
+            local raw = t.idig + t.scale
+            if raw > 36 then return "DOUBLE PRECISION" else return "DECIMAL(" .. adjust_precision(raw) .. ", " .. t.scale .. ")" end
         elseif t.fam == 'DBL'  then return "DOUBLE PRECISION"
         elseif t.fam == 'DATE' then return "DATE"
         elseif t.fam == 'TS'   then return "TIMESTAMP(" .. t.fp .. ")"
@@ -500,11 +500,13 @@ CREATE OR REPLACE SCRIPT database_migration.convert_varchar(schema_pattern, tabl
                         end
                     end
                 elseif r["ENTRIES"] == r["ITS_INTEGER"] + r["ITS_DECIMAL"] then -- integers and decimals (not scientific)
-                    local total_precision = math.max(r["ITS_INTEGER_PRECISION"], r["ITS_DECIMAL_PRECISION"]) + r["ITS_DECIMAL_SCALE"]
-                    if total_precision > 36 then
-                        conversion = "Keep " .. src_type .. " (decimal precision " .. total_precision .. " > max 36)"
-                        notes      = "Largest decimal precision " .. total_precision .. " exceeds the maximum DECIMAL precision of 36; not convertible."
+                    local raw_total = math.max(r["ITS_INTEGER_PRECISION"], r["ITS_DECIMAL_PRECISION"]) + r["ITS_DECIMAL_SCALE"]
+                    if raw_total > 36 then
+                        conversion = "Keep " .. src_type .. " (decimal precision " .. raw_total .. " > max 36)"
+                        notes      = "Largest decimal precision " .. raw_total .. " exceeds the maximum DECIMAL precision of 36; not convertible."
                     else
+                        -- round the precision up to 9 / 18 / 36, exactly like the integer case (the scale is kept)
+                        local total_precision = adjust_precision(raw_total)
                         conversion = src_type .. " --> DECIMAL(" .. total_precision .. ", " .. r["ITS_DECIMAL_SCALE"] .. ")"
                         query_text = altpfx .. "DECIMAL(" .. total_precision .. ", " .. r["ITS_DECIMAL_SCALE"] .. ");"
                         tgt        = { fam = 'NUM', idig = math.max(r["ITS_INTEGER_PRECISION"], r["ITS_DECIMAL_PRECISION"]), scale = r["ITS_DECIMAL_SCALE"] }
@@ -591,7 +593,7 @@ CREATE OR REPLACE SCRIPT database_migration.convert_varchar(schema_pattern, tabl
                            ucol == "DATE" or ucol == 'DOB' then -- name looks like a date
                         conversion = "Keep " .. src_type .. " (name looks like a date; values do not match " .. nls_date_format .. ")"
                         notes      = "If this is a date, normalize then convert, e.g.: UPDATE " .. sch_q .. "." .. tab_q .. " SET " .. col_q .. " = TO_CHAR(TO_DATE(" .. col_q .. ", '<date_format>'), '" .. nls_date_format .. "'); then " .. altpfx .. "DATE;"
-                    elseif estimate_optimal_varchar_length(r["MAX_LENGTH"]) < curr_col_len then -- shrink width
+                    elseif curr_col_len > 3 and estimate_optimal_varchar_length(r["MAX_LENGTH"]) < curr_col_len then -- shrink width (columns with n <= 3 are left untouched)
                         local new_col_len = estimate_optimal_varchar_length(r["MAX_LENGTH"])
                         conversion = src_type .. " --> VARCHAR(" .. new_col_len .. ") " .. charset .. ", max length: " .. r["MAX_LENGTH"]
                         query_text = altpfx .. "VARCHAR(" .. new_col_len .. ") " .. charset .. ";"
@@ -779,12 +781,13 @@ CREATE OR REPLACE SCRIPT database_migration.convert_varchar(schema_pattern, tabl
     end)
 
     if #drop_rows > 0 then
+        -- section dividers are SQL comments and go into QUERY_TEXT (the runnable column), not CONVERSION
         local out = {}
-        out[#out + 1] = { '', '', '', '-- ### DROP FOREIGN KEYS - run these FIRST (before the column changes) ###', '', '' }
+        out[#out + 1] = { '', '', '', '', '-- ### DROP FOREIGN KEYS - run these FIRST (before the column changes) ###', '' }
         for _, x in ipairs(drop_rows)  do out[#out + 1] = x end
-        out[#out + 1] = { '', '', '', '-- ### COLUMN TYPE CHANGES ###', '', '' }
+        out[#out + 1] = { '', '', '', '', '-- ### COLUMN TYPE CHANGES ###', '' }
         for _, x in ipairs(col_rows)   do out[#out + 1] = x end
-        out[#out + 1] = { '', '', '', '-- ### RE-ADD FOREIGN KEYS - run these LAST (after the column changes) ###', '', '' }
+        out[#out + 1] = { '', '', '', '', '-- ### RE-ADD FOREIGN KEYS - run these LAST (after the column changes) ###', '' }
         for _, x in ipairs(readd_rows) do out[#out + 1] = x end
         size_and_exit(out)
     else


### PR DESCRIPTION
## Summary
Two small, report-only follow-ups to `convert_varchar` on top of the foreign-key handling from
**#49**. No signature change; behavior is otherwise unchanged.

1. **Bug fix** — the section markers (`-- ### DROP FOREIGN KEYS … ###`, `-- ### COLUMN TYPE CHANGES ###`,
   `-- ### RE-ADD FOREIGN KEYS … ###`) were written into the **`conversion`** column. They are SQL comments
   and belong in the **`query_text`** column, which is the one you copy out and run.
2. **Improvement** — `DECIMAL(p, s)` suggestions now round the **precision `p` up to 9 / 18 / 36** (the
   standard internal sizes), exactly like the integer `DECIMAL(p)` case already did; and the VARCHAR width
   shrink now **leaves columns with `n <= 3` untouched** (consistent with `convert_datatypes`).

---

## 1) Bug fix — section markers belong in `query_text`, not `conversion`

**Before:** the divider rows put the `-- ### … ###` comment in `conversion`, with `query_text` empty — so
copying the `query_text` column gave the statements *without* the section comments, and the `conversion`
column contained text that is not a description of a column.

**After:** the divider rows have an empty `conversion` and the `-- ### … ###` comment in `query_text`, so
copying the `query_text` column yields a clean, runnable script with inline comment dividers:

```
-- ### DROP FOREIGN KEYS - run these FIRST (before the column changes) ###
ALTER TABLE "…"."ZF_C" DROP CONSTRAINT "zf_fk";
-- ### COLUMN TYPE CHANGES ###
ALTER TABLE "…"."ZF_C" MODIFY COLUMN "cid" DECIMAL(9, 0);
…
-- ### RE-ADD FOREIGN KEYS - run these LAST (after the column changes) ###
ALTER TABLE "…"."ZF_C" ADD CONSTRAINT "zf_fk" FOREIGN KEY ("pid") REFERENCES "…"."ZF_P" ("id") ENABLE;
```

(The DROP / MODIFY / RE-ADD statement rows were already in `query_text`; only the three section-header rows
moved.)

## 2) DECIMAL precision bucketing + VARCHAR `n <= 3` guard

- **`DECIMAL(p, s)` precision is now rounded up to 9 / 18 / 36** (the **scale `s` is kept**), so it matches
  the integer case which already produced `DECIMAL(9, 0)` / `DECIMAL(18, 0)` / `DECIMAL(36, 0)`. Examples:
  `DECIMAL(4, 2) → DECIMAL(9, 2)`, `DECIMAL(6, 2) → DECIMAL(9, 2)`, `DECIMAL(9, 3) → DECIMAL(9, 3)`. Values
  whose raw precision exceeds 36 are still reported as not convertible. This also flows into the FK
  key-group harmonization (groups land on the same rounded precision).
- **VARCHAR width shrink leaves columns with `n <= 3` untouched** (they are kept as is), consistent with the
  `convert_datatypes` rule.

## Testing & validation
See `TEST_RESULTS_convert_varchar_followup.md` / `convert_varchar_followup_test.sql`. Verified live on Exasol 8:

- **Markers:** every divider row has an **empty `conversion`** and the `-- ### … ###` text in `query_text`
  (0 divider rows with non-empty `conversion`); the DROP/MODIFY/RE-ADD statements remain in `query_text`.
- **Decimals:** `1.5/22.75` → `DECIMAL(9, 2)`, `1234.56` → `DECIMAL(9, 2)`, `123456.789` → `DECIMAL(9, 3)`,
  integers → `DECIMAL(9, 0)`.
- **n <= 3:** `VARCHAR(2)` and `VARCHAR(3)` columns are kept (`Keep VARCHAR(…)`), a `VARCHAR(50)` column is
  still shrunk.

## Notes
- **Report-only**; the script returns statements only. **No signature change.**
- Still DbVisualizer-clean (no `?` / bind-marker characters).
- Files changed: `post_load_optimization/convert_varchar.sql` and `post_load_optimization/README.md` (the
  "What it detects" table: the `DECIMAL(p, s)` rounding note and the `n <= 3` shrink note).


[TEST_RESULTS_convert_varchar_followup.md](https://github.com/user-attachments/files/29342234/TEST_RESULTS_convert_varchar_followup.md)
[convert_varchar_followup_test.sql](https://github.com/user-attachments/files/29342235/convert_varchar_followup_test.sql)
