### PR TITLE
convert_datatypes: precise conversion labels, full Keep listing under log_for_all_columns, and automatic FOREIGN KEY handling

### DIFF
--- a/post_load_optimization/README.md
+++ b/post_load_optimization/README.md
@@ -294,15 +294,34 @@ The output is **sorted by `schema_name`, `table_name`, `column_name`**.
 | Column | Meaning |
 |--------|---------|
 | `schema_name`, `table_name`, `column_name` | the inspected column |
-| `conversion` | what happens, e.g. `DOUBLE --> DECIMAL(9, 0), max length: 1`, `VARCHAR(1000) UTF8  --> VARCHAR(20) UTF8, max length: 10`, or `Keep VARCHAR(100) UTF8, max length: 12` |
-| `query_text` | the generated `ALTER TABLE ... MODIFY ...` statement |
+| `conversion` | the **exact current type** and **exact target type**, e.g. `DECIMAL(20, 0) --> DECIMAL(9, 0), max length: 1`, `TIMESTAMP(6) WITH LOCAL TIME ZONE --> DATE`, `VARCHAR(1000) UTF8 --> VARCHAR(20) UTF8, max length: 10`, or `Keep DECIMAL(5, 0) (already minimal precision)` / `Keep VARCHAR(3) UTF8 (n <= 3, left untouched)` |
+| `query_text` | the generated `ALTER TABLE ... MODIFY ...` statement (and the FK DROP/RE-ADD statements, see below) |
 | `success` | only present when `apply_conversion = true`: `true` or the error message |
+
+With `log_for_all_columns = true` every inspected column of an enabled type is listed — now also the
+**already-minimal** (`DECIMAL` precision ≤ 9, `VARCHAR` size ≤ 3) and empty columns, each with a `Keep …` row.
 
 If the result would be empty, the script returns a single informative row in the `conversion`
 column instead:
 - `log_for_all_columns = false` → `No columns found that need optimization.`
 - `log_for_all_columns = true`  → `No matching columns found (check the filters and the convert_* switches).`
   — i.e. no column matched the schema/table filter and the enabled `convert_*` switches at all.
+
+### Foreign keys (handled automatically)
+
+A type change on a **primary/foreign key** column fails in Exasol unless the linked PK and FK columns are
+changed to the **same** type (`constraint violation … wrong types`). When `FOREIGN KEY`s touch the analyzed
+tables, the script handles this:
+
+- **DROP/RE-ADD wrapper:** the output gains a **`### DROP FOREIGN KEYS — run FIRST ###`** step and a
+  **`### RE-ADD FOREIGN KEYS — run LAST ###`** step (in the `query_text` column; composite FKs included), so
+  the script — and `apply_conversion = true` — runs end to end. Each FK is re-added in its **original
+  `ENABLE`/`DISABLE` state** (never changed).
+- **Type harmonization:** every referential key group is converted to **one common target type** that fits all
+  its columns (never a blanket VARCHAR); if no common smaller type exists, the whole group is kept (FK stays valid).
+- **Single table with an FK to another table:** if a key column's group reaches a table **outside the filter**,
+  the column is kept unchanged with a note to include the related table(s).
+- With **no** foreign keys in scope the run is exactly as before (one cheap catalog check is the only overhead).
 
 ### How it works
 

--- a/post_load_optimization/convert_datatypes.sql
+++ b/post_load_optimization/convert_datatypes.sql
@@ -29,6 +29,20 @@ create schema if not exists database_migration;
       * views and synonyms are excluded (COLUMN_OBJECT_TYPE = 'TABLE')
       * VIRTUAL SCHEMA columns are excluded (COLUMN_IS_VIRTUAL = FALSE)
 
+    The "conversion" column always names the EXACT current data type on the left and the EXACT target type
+    on the right (e.g. DECIMAL(20, 0) --> DECIMAL(9, 0), TIMESTAMP(6) WITH LOCAL TIME ZONE --> DATE,
+    VARCHAR(200) ASCII --> VARCHAR(20) ASCII). With log_for_all_columns = TRUE every inspected column of an
+    enabled type is listed, including a "Keep ..." row for columns that are already minimal (DECIMAL
+    precision <= 9, VARCHAR size <= 3) or empty.
+
+    FOREIGN KEY handling (automatic): in Exasol a type change on a PRIMARY/FOREIGN KEY column fails unless
+    the linked PK and FK columns are changed to the SAME type. So when FOREIGN KEYs touch the analyzed
+    tables, the script (a) harmonizes every referential key group to ONE common target type that fits all of
+    its columns, and (b) wraps the output / execution in a "DROP FOREIGN KEYS" step (first) and a
+    "RE-ADD FOREIGN KEYS" step (last) - each FK is re-added in its ORIGINAL ENABLE/DISABLE state. A key
+    column whose group reaches a table OUTSIDE the current filter is kept unchanged, with a note. With no
+    FOREIGN KEYs in scope the run is unchanged (one cheap catalog check is the only overhead).
+
     ====================================================================================
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!  A T T E N T I O N  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     ====================================================================================
@@ -40,7 +54,8 @@ create schema if not exists database_migration;
          must really be performed.
       -> The SAFER way is to run with apply_conversion = FALSE first, then copy the
          generated statements from the "query_text" column and execute them YOURSELF,
-         one statement at a time, checking each result.
+         one statement at a time, checking each result. Run the statements IN THE ORDER
+         shown (DROP FOREIGN KEYS first, the MODIFYs, then RE-ADD FOREIGN KEYS).
       -> A conversion that does not fit the data will fail at execution time; with
          apply_conversion = TRUE the error only shows up in the "success" column.
 
@@ -118,411 +133,6 @@ function detect_lossless_double_scale(scm, tbl, col)
 	return nil
 end
 
-------------------------------------------------------------------------------------------------------
--- DOUBLE --> DECIMAL : convert DOUBLE columns that contain only integer values, or only
--- values that are exactly representable as a small-scale DECIMAL, directly to the smallest
--- fitting DECIMAL (one single, lossless ALTER statement).
-------------------------------------------------------------------------------------------------------
-function convert_double_to_decimal(schema_name, table_name, log_for_all_columns)
-
-	local result_table = {}
-	local res = query([[
-			select
-				column_schema,
-				column_table,
-				column_name
-			from
-				exa_all_columns
-			where
-				column_type_id = 8 and             -- type_id of DOUBLE
-				column_schema like :schema_filter and
-				column_table  like :table_filter and
-				column_object_type = 'TABLE' and   -- only base tables, never views/synonyms
-				column_is_virtual  = FALSE         -- never virtual schema columns
-		]], {schema_filter=schema_name, table_filter=table_name})
-
-	for i=1,#res do
-		local modify_column    = false
-		local message_action   = ''
-		local query_to_execute = ''
-
-		local scm = quote(res[i][1])
-		local tbl = quote(res[i][2])
-		local col = quote(res[i][3])
-
-		-- Single table scan: not-null count, number of rows that are NOT a plain
-		-- integer, and the max number of integer digits (only meaningful when all
-		-- values are integers). pquery: if a value cannot be cast to DECIMAL at all
-		-- (overflow) we keep the column instead of aborting the whole script.
-		local tsSuc, tsColumns = pquery([[
-			select
-				count(::col_name) as values_in_column,
-				count(case when
-					not(
-						abs(::col_name - cast(::col_name as decimal)) < 0.00000000001
-							and
-						(
-							to_char(::col_name) = '0'
-								or
-							abs(::col_name) >= 1
-						)
-							and
-						abs(::col_name) < 1E14
-					)
-				then 1 end) as non_integer_rows,
-				coalesce(max(length(cast(abs(::col_name) as decimal(18,0)))), 0) as max_int_length
-			from
-				::curr_schema.::curr_table
-		]], {curr_schema=scm, curr_table=tbl, col_name=col})
-
-		-- tsColumns[1][1] = number of not-null values
-		-- tsColumns[1][2] = number of rows that are NOT plain integers
-		-- tsColumns[1][3] = max number of integer digits
-		if not tsSuc then
-			message_action = 'Keep DOUBLE (too big for DECIMAL)'
-
-		elseif tsColumns[1][1] == 0 then
-			message_action = 'Keep DOUBLE (IS EMPTY)'
-
-		elseif tsColumns[1][2] == 0 then
-			-- integer only -> convert directly to the smallest fitting DECIMAL.
-			-- (values are < 1E14, so they always fit into DECIMAL(18,0))
-			local max_int_length = tsColumns[1][3]
-			local target
-			if max_int_length <= 9 then
-				target = 9    -- fits into 32-bit
-			else
-				target = 18   -- fits into 64-bit
-			end
-			query_to_execute = "ALTER TABLE "..scm.."."..tbl.." MODIFY ("..col.." DECIMAL("..target..",0));"
-			modify_column    = true
-			message_action   = 'DOUBLE --> DECIMAL('..target..', 0), max length: '..max_int_length
-
-		else
-			-- contains fractional values -> only convert if a DECIMAL(p,s) can represent
-			-- EVERY value losslessly (proven by a round-trip cast). Otherwise keep DOUBLE.
-			local s, max_int_digits = detect_lossless_double_scale(scm, tbl, col)
-			if s ~= nil then
-				local p = max_int_digits + s
-				local target
-				if p <= 9 then
-					target = 9    -- fits into 32-bit
-				else
-					target = 18   -- fits into 64-bit
-				end
-				query_to_execute = "ALTER TABLE "..scm.."."..tbl.." MODIFY ("..col.." DECIMAL("..target..","..s.."));"
-				modify_column    = true
-				message_action   = 'DOUBLE --> DECIMAL('..target..', '..s..') (lossless)'
-			else
-				message_action = 'Keep DOUBLE'
-			end
-		end
-
-		if modify_column or log_for_all_columns then
-			result_table[#result_table+1] = {res[i][1], res[i][2], res[i][3], message_action, query_to_execute}
-		end
-	end
-	return result_table
-end -- convert_double_to_decimal
-
-------------------------------------------------------------------------------------------------------
--- DECIMAL(p,0) --> smaller integer DECIMAL
-------------------------------------------------------------------------------------------------------
-function convert_integer_to_smaller_integer(schema_name, table_name, log_for_all_columns)
-
-	local result_table = {}
-	local res = query([[
-			select
-				column_schema,
-				column_table,
-				column_name,
-				column_num_prec
-			from
-				exa_all_columns
-			where
-				column_type_id = 3 and             -- type_id of DECIMAL
-				column_schema like :schema_filter and
-				column_table  like :table_filter and
-				column_object_type = 'TABLE' and
-				column_is_virtual  = FALSE and
-				column_num_scale = 0 and           -- only columns without scale
-				column_num_prec  > 9
-		]], {schema_filter=schema_name, table_filter=table_name})
-
-	for i=1,#res do
-		local modify_column    = false
-		local message_action   = ''
-		local query_to_execute = ''
-
-		local scm       = quote(res[i][1])
-		local tbl       = quote(res[i][2])
-		local col       = quote(res[i][3])
-		local precision = res[i][4]
-
-		-- Single table scan: not-null count + max number of digits.
-		local dColumns = query([[
-			select
-				count(::col_name) as values_in_column,
-				coalesce(max(length(abs(::col_name))), 0) as max_length
-			from
-				::curr_schema.::curr_table
-		]], {curr_schema=scm, curr_table=tbl, col_name=col})
-
-		local not_null_count = dColumns[1][1]
-		local max_length     = dColumns[1][2]
-
-		if not_null_count == 0 then
-			message_action = 'Keep DECIMAL (IS EMPTY)'
-		else
-			local target = smaller_integer_precision(max_length, precision)
-			if target ~= nil then
-				query_to_execute = "ALTER TABLE "..scm.."."..tbl.." MODIFY ("..col.." DECIMAL("..target..",0));"
-				modify_column    = true
-				message_action   = 'DECIMAL('..precision..', 0)  --> DECIMAL('..target..', 0), max length: '..max_length
-			else
-				message_action = 'Keep DECIMAL('..precision..', 0), max length: '..max_length
-			end
-		end
-
-		if modify_column or log_for_all_columns then
-			result_table[#result_table+1] = {res[i][1], res[i][2], res[i][3], message_action, query_to_execute}
-		end
-	end
-	return result_table
-end -- convert_integer_to_smaller_integer
-
-------------------------------------------------------------------------------------------------------
--- DECIMAL(p,s) --> smaller DECIMAL (scale preserved)
-------------------------------------------------------------------------------------------------------
-function convert_decimal_with_scale_to_smaller_decimal(schema_name, table_name, log_for_all_columns)
-
-	local result_table = {}
-	local res = query([[
-			select
-				column_schema,
-				column_table,
-				column_name,
-				column_num_prec,
-				column_num_scale
-			from
-				exa_all_columns
-			where
-				column_type_id = 3 and             -- type_id of DECIMAL
-				column_schema like :schema_filter and
-				column_table  like :table_filter and
-				column_object_type = 'TABLE' and
-				column_is_virtual  = FALSE and
-				column_num_scale <> 0 and          -- only columns that have a scale
-				column_num_prec   > 9
-		]], {schema_filter=schema_name, table_filter=table_name})
-
-	for i=1,#res do
-		local modify_column    = false
-		local message_action   = ''
-		local query_to_execute = ''
-
-		local scm       = quote(res[i][1])
-		local tbl       = quote(res[i][2])
-		local col       = quote(res[i][3])
-		local precision = res[i][4]
-		local col_scale = res[i][5]
-
-		-- Single table scan: not-null count + max length of the integer part.
-		-- floor() (not round()) so a value like 999.99 counts as 3 integer digits,
-		-- not 4 -- otherwise an otherwise-possible shrink would be missed.
-		local dColumns = query([[
-			select
-				count(::col_name) as values_in_column,
-				coalesce(max(length(floor(abs(::col_name)))), 0) as max_int_length
-			from
-				::curr_schema.::curr_table
-		]], {curr_schema=scm, curr_table=tbl, col_name=col})
-
-		local not_null_count   = dColumns[1][1]
-		local max_int_length   = dColumns[1][2]
-		local needed_precision = max_int_length + col_scale
-
-		if not_null_count == 0 then
-			message_action = 'Keep DECIMAL (IS EMPTY)'
-		else
-			-- needed_precision always includes the scale, so the target precision is
-			-- always > scale -> DECIMAL(target, scale) is guaranteed to be valid.
-			local target = smaller_integer_precision(needed_precision, precision)
-			if target ~= nil then
-				query_to_execute = "ALTER TABLE "..scm.."."..tbl.." MODIFY ("..col.." DECIMAL("..target..","..col_scale.."));"
-				modify_column    = true
-				message_action   = 'DECIMAL('..precision..', '..col_scale..')  --> DECIMAL('..target..', '..col_scale..'), needed precision: '..needed_precision
-			else
-				message_action = 'Keep DECIMAL('..precision..', '..col_scale..'), needed precision: '..needed_precision
-			end
-		end
-
-		if modify_column or log_for_all_columns then
-			result_table[#result_table+1] = {res[i][1], res[i][2], res[i][3], message_action, query_to_execute}
-		end
-	end
-	return result_table
-end -- convert_decimal_with_scale_to_smaller_decimal
-
-------------------------------------------------------------------------------------------------------
--- TIMESTAMP / TIMESTAMP WITH LOCAL TIME ZONE --> DATE
--- Convert timestamp columns that never carry a time component.
-------------------------------------------------------------------------------------------------------
-function convert_timestamp_to_date(schema_name, table_name, log_for_all_columns)
-
-	local result_table = {}
-	local res = query([[
-			select
-				column_schema,
-				column_table,
-				column_name,
-				column_type_id
-			from
-				exa_all_columns
-			where
-				column_type_id in (93, 124) and    -- 93 = TIMESTAMP, 124 = TIMESTAMP WITH LOCAL TIME ZONE
-				column_schema like :schema_filter and
-				column_table  like :table_filter and
-				column_object_type = 'TABLE' and   -- only base tables, never views/synonyms
-				column_is_virtual  = FALSE         -- never virtual schema columns
-		]], {schema_filter=schema_name, table_filter=table_name})
-
-	for i=1,#res do
-		local modify_column    = false
-		local message_action   = ''
-		local query_to_execute = ''
-
-		local scm = quote(res[i][1])
-		local tbl = quote(res[i][2])
-		local col = quote(res[i][3])
-
-		-- label the source type for the output messages
-		local type_label = 'TIMESTAMP'
-		if res[i][4] == 124 then
-			type_label = 'TIMESTAMP WITH LOCAL TIME ZONE'
-		end
-
-		-- Single table scan: not-null count + number of rows that carry a time
-		-- component. We use TRUNC() instead of subtracting datetimes, so the check
-		-- does NOT depend on the TIMESTAMP_ARITHMETIC_BEHAVIOR parameter (which
-		-- decides whether datetime subtraction yields an INTERVAL or a DOUBLE).
-		-- For TIMESTAMP WITH LOCAL TIME ZONE both the TRUNC check and the later DATE
-		-- conversion run in the current SESSIONTIMEZONE within the same session, so
-		-- they are consistent.
-		-- pquery so a problem skips the column instead of aborting the run.
-		local tsSuc, tsColumns = pquery([[
-			select
-				count(::col_name) as values_in_column,
-				count(case when ::col_name <> TRUNC(::col_name) then 1 end) as rows_with_time
-			from
-				::curr_schema.::curr_table
-		]], {curr_schema=scm, curr_table=tbl, col_name=col})
-
-		-- tsColumns[1][1] = number of not-null values
-		-- tsColumns[1][2] = number of rows that carry a time component
-		if not tsSuc then
-			message_action = 'Keep '..type_label..' (check failed)'
-
-		elseif tsColumns[1][1] == 0 then
-			message_action = 'Keep '..type_label..' (IS EMPTY)'
-
-		elseif tsColumns[1][2] == 0 then
-			-- date only (no hours, minutes, seconds, fraction)
-			query_to_execute = "ALTER TABLE "..scm.."."..tbl.." MODIFY ("..col.." DATE);"
-			modify_column    = true
-			message_action   = type_label..' --> DATE'
-
-		else
-			message_action = 'Keep '..type_label
-		end
-
-		if modify_column or log_for_all_columns then
-			result_table[#result_table+1] = {res[i][1], res[i][2], res[i][3], message_action, query_to_execute}
-		end
-	end
-	return result_table
-end -- convert_timestamp_to_date
-
-------------------------------------------------------------------------------------------------------
--- VARCHAR --> smaller VARCHAR
-------------------------------------------------------------------------------------------------------
-function convert_varchar_to_smaller_varchar(schema_name, table_name, log_for_all_columns)
-
-	local result_table = {}
-	local res = query([[
-			select
-				column_schema,
-				column_table,
-				column_name,
-				column_maxsize,
-				column_type
-			from
-				exa_all_columns
-			where
-				column_type_id = 12 and            -- type_id of VARCHAR
-				column_schema like :schema_filter and
-				column_table  like :table_filter and
-				column_object_type = 'TABLE' and
-				column_is_virtual  = FALSE and
-				column_maxsize > 3                 -- do not modify columns of size <= 3
-		]], {schema_filter=schema_name, table_filter=table_name})
-
-	for i=1,#res do
-		local modify_column    = false
-		local message_action   = ''
-		local query_to_execute = ''
-
-		local scm             = quote(res[i][1])
-		local tbl             = quote(res[i][2])
-		local col             = quote(res[i][3])
-		local current_maxsize = res[i][4]
-
-		-- Preserve the existing character set. COLUMN_TYPE looks like
-		-- "VARCHAR(2000000) ASCII" or "VARCHAR(2000000) UTF8". If the charset is
-		-- omitted in MODIFY, Exasol falls back to the UTF8 default and would silently
-		-- turn an ASCII column into UTF8 -- so we ALWAYS re-state the original charset.
-		local charset = 'UTF8'
-		if string.find(string.upper(res[i][5]), 'ASCII', 1, true) ~= nil then
-			charset = 'ASCII'
-		end
-
-		-- Single table scan: not-null count + actual max character length.
-		local dColumns = query([[
-			select
-				count(::col_name) as values_in_column,
-				coalesce(max(length(::col_name)), 0) as max_length
-			from
-				::curr_schema.::curr_table
-		]], {curr_schema=scm, curr_table=tbl, col_name=col})
-
-		local not_null_count = dColumns[1][1]
-		local max_length     = dColumns[1][2]
-
-		if not_null_count == 0 then
-			message_action = 'Keep VARCHAR('..current_maxsize..') '..charset..' (IS EMPTY)'
-
-		elseif (max_length <= 2000000) and (estimate_optimal_varchar_length(max_length) < current_maxsize) then
-			-- a smaller varchar fits and is still <= 2,000,000 (character set is preserved)
-			local change_to  = estimate_optimal_varchar_length(max_length)  -- actual length + a bit of buffer
-			query_to_execute = "ALTER TABLE "..scm.."."..tbl.." MODIFY ("..col.." VARCHAR("..change_to..") "..charset..");"
-			modify_column    = true
-			message_action   = 'VARCHAR('..current_maxsize..') '..charset..'  --> VARCHAR('..change_to..') '..charset..', max length: '..max_length
-
-		else
-			message_action = 'Keep VARCHAR('..current_maxsize..') '..charset..', max length: '..max_length
-		end
-
-		if modify_column or log_for_all_columns then
-			result_table[#result_table+1] = {res[i][1], res[i][2], res[i][3], message_action, query_to_execute}
-		end
-	end
-	return result_table
-end -- convert_varchar_to_smaller_varchar
-
-------------------------------------------------------------------------------------------------------
--- Helper functions
-------------------------------------------------------------------------------------------------------
-
 -- Takes a number as input, adds 20% headroom and rounds up to the next bigger round decimal.
 function estimate_optimal_varchar_length(n)
 	local n_p20            = math.ceil(n + n * 0.2)               -- add 20% so everything fits in
@@ -532,30 +142,362 @@ function estimate_optimal_varchar_length(n)
 	return math.min(estimated_length, 2000000)                   -- maximal varchar size is 2,000,000
 end
 
+------------------------------------------------------------------------------------------------------
+-- Renders the EXACT target type string from a harmonized group target (or a per-column target).
+------------------------------------------------------------------------------------------------------
+function render_target(t)
+	if     t.fam == 'DEC0' then return "DECIMAL("..t.target..", 0)"
+	elseif t.fam == 'DECS' then return "DECIMAL("..t.target..", "..t.s..")"
+	elseif t.fam == 'DBL'  then return "DECIMAL("..t.p..", "..t.s..")"
+	elseif t.fam == 'TS'   then return "DATE"
+	elseif t.fam == 'VC'   then return "VARCHAR("..t.target..") "..t.cs
+	else                        return nil end -- KEEP
+end
+
+------------------------------------------------------------------------------------------------------
+-- Decides ONE common target for a referential key group (all members share the same source type,
+-- because an FK requires identical types). Returns a target descriptor or {fam='KEEP'} when the
+-- group cannot be converted (then the columns stay as they are and the FK remains valid).
+------------------------------------------------------------------------------------------------------
+function group_target(members)
+	for i = 1, #members do
+		if members[i].tgt.fam == 'KEEP' then return {fam='KEEP'} end
+	end
+	local fam = members[1].tgt.fam
+	if fam == 'DEC0' then
+		local need = 0
+		for i = 1, #members do if members[i].tgt.need > need then need = members[i].tgt.need end end
+		local target = smaller_integer_precision(need, members[1].tgt.p)
+		if target == nil then return {fam='KEEP'} end
+		return {fam='DEC0', target=target}
+	elseif fam == 'DECS' then
+		local need = 0
+		for i = 1, #members do if members[i].tgt.need > need then need = members[i].tgt.need end end
+		local target = smaller_integer_precision(need, members[1].tgt.p)
+		if target == nil then return {fam='KEEP'} end
+		return {fam='DECS', target=target, s=members[1].tgt.s}
+	elseif fam == 'VC' then
+		local ml = 0
+		for i = 1, #members do if members[i].tgt.maxlen > ml then ml = members[i].tgt.maxlen end end
+		local tl = estimate_optimal_varchar_length(ml)
+		if tl < members[1].tgt.n then return {fam='VC', target=tl, cs=members[1].tgt.cs} end
+		return {fam='KEEP'}
+	elseif fam == 'TS' then
+		for i = 1, #members do if members[i].tgt.has_time then return {fam='KEEP'} end end
+		return {fam='TS'}
+	elseif fam == 'DBL' then
+		local p, s = members[1].tgt.p, members[1].tgt.s
+		for i = 1, #members do
+			if not members[i].tgt.conv or members[i].tgt.p ~= p or members[i].tgt.s ~= s then return {fam='KEEP'} end
+		end
+		return {fam='DBL', p=p, s=s}
+	end
+	return {fam='KEEP'}
+end
+
+------------------------------------------------------------------------------------------------------
+-- DOUBLE --> DECIMAL
+------------------------------------------------------------------------------------------------------
+function convert_double_to_decimal(schema_name, table_name)
+	local result_table = {}
+	local res = query([[
+			select column_schema, column_table, column_name
+			from   exa_all_columns
+			where  column_type_id = 8 and             -- type_id of DOUBLE
+			       column_schema like :schema_filter and
+			       column_table  like :table_filter and
+			       column_object_type = 'TABLE' and
+			       column_is_virtual  = FALSE
+		]], {schema_filter=schema_name, table_filter=table_name})
+
+	for i=1,#res do
+		local modify_column, message_action, query_to_execute = false, '', ''
+		local tgt = {fam='KEEP'}
+		local scm, tbl, col = quote(res[i][1]), quote(res[i][2]), quote(res[i][3])
+		local src = 'DOUBLE'
+
+		local tsSuc, tsColumns = pquery([[
+			select
+				count(::col_name) as values_in_column,
+				count(case when
+					not(
+						abs(::col_name - cast(::col_name as decimal)) < 0.00000000001
+							and
+						( to_char(::col_name) = '0' or abs(::col_name) >= 1 )
+							and
+						abs(::col_name) < 1E14
+					)
+				then 1 end) as non_integer_rows,
+				coalesce(max(length(cast(abs(::col_name) as decimal(18,0)))), 0) as max_int_length
+			from ::curr_schema.::curr_table
+		]], {curr_schema=scm, curr_table=tbl, col_name=col})
+
+		if not tsSuc then
+			message_action = 'Keep DOUBLE (values exceed DECIMAL range)'
+		elseif tsColumns[1][1] == 0 then
+			message_action = 'Keep DOUBLE (empty)'
+		elseif tsColumns[1][2] == 0 then
+			local max_int_length = tsColumns[1][3]
+			local target = 9
+			if max_int_length > 9 then target = 18 end
+			query_to_execute = "ALTER TABLE "..scm.."."..tbl.." MODIFY ("..col.." DECIMAL("..target..",0));"
+			modify_column    = true
+			message_action   = src..' --> DECIMAL('..target..', 0), max length: '..max_int_length
+			tgt = {fam='DBL', conv=true, p=target, s=0}
+		else
+			local s, max_int_digits = detect_lossless_double_scale(scm, tbl, col)
+			if s ~= nil then
+				local p = max_int_digits + s
+				local target = 9
+				if p > 9 then target = 18 end
+				query_to_execute = "ALTER TABLE "..scm.."."..tbl.." MODIFY ("..col.." DECIMAL("..target..","..s.."));"
+				modify_column    = true
+				message_action   = src..' --> DECIMAL('..target..', '..s..') (lossless)'
+				tgt = {fam='DBL', conv=true, p=target, s=s}
+			else
+				message_action = 'Keep DOUBLE (not losslessly representable as DECIMAL)'
+			end
+		end
+		result_table[#result_table+1] = {sch=res[i][1], tab=res[i][2], col=res[i][3], src=src,
+			message=message_action, query=query_to_execute, modify=modify_column, tgt=tgt}
+	end
+	return result_table
+end
+
+------------------------------------------------------------------------------------------------------
+-- DECIMAL(p,0) --> smaller integer DECIMAL
+------------------------------------------------------------------------------------------------------
+function convert_integer_to_smaller_integer(schema_name, table_name)
+	local result_table = {}
+	local res = query([[
+			select column_schema, column_table, column_name, column_num_prec
+			from   exa_all_columns
+			where  column_type_id = 3 and             -- type_id of DECIMAL
+			       column_schema like :schema_filter and
+			       column_table  like :table_filter and
+			       column_object_type = 'TABLE' and
+			       column_is_virtual  = FALSE and
+			       column_num_scale = 0                -- only columns without scale
+		]], {schema_filter=schema_name, table_filter=table_name})
+
+	for i=1,#res do
+		local modify_column, message_action, query_to_execute = false, '', ''
+		local tgt = {fam='KEEP'}
+		local scm, tbl, col = quote(res[i][1]), quote(res[i][2]), quote(res[i][3])
+		local precision = res[i][4]
+		local src = 'DECIMAL('..precision..', 0)'
+
+		if precision <= 9 then
+			-- already the smallest integer type -> no scan needed
+			message_action = 'Keep '..src..' (already minimal precision)'
+		else
+			local dColumns = query([[
+				select count(::col_name) as values_in_column,
+				       coalesce(max(length(abs(::col_name))), 0) as max_length
+				from ::curr_schema.::curr_table
+			]], {curr_schema=scm, curr_table=tbl, col_name=col})
+			local not_null_count, max_length = dColumns[1][1], dColumns[1][2]
+			if not_null_count == 0 then
+				message_action = 'Keep '..src..' (empty)'
+				tgt = {fam='DEC0', p=precision, need=0}   -- empty: no constraint for a key group
+			else
+				local target = smaller_integer_precision(max_length, precision)
+				tgt = {fam='DEC0', p=precision, need=max_length}
+				if target ~= nil then
+					query_to_execute = "ALTER TABLE "..scm.."."..tbl.." MODIFY ("..col.." DECIMAL("..target..",0));"
+					modify_column    = true
+					message_action   = src..' --> DECIMAL('..target..', 0), max length: '..max_length
+				else
+					message_action = 'Keep '..src..', max length: '..max_length
+				end
+			end
+		end
+		result_table[#result_table+1] = {sch=res[i][1], tab=res[i][2], col=res[i][3], src=src,
+			message=message_action, query=query_to_execute, modify=modify_column, tgt=tgt}
+	end
+	return result_table
+end
+
+------------------------------------------------------------------------------------------------------
+-- DECIMAL(p,s) --> smaller DECIMAL (scale preserved)
+------------------------------------------------------------------------------------------------------
+function convert_decimal_with_scale_to_smaller_decimal(schema_name, table_name)
+	local result_table = {}
+	local res = query([[
+			select column_schema, column_table, column_name, column_num_prec, column_num_scale
+			from   exa_all_columns
+			where  column_type_id = 3 and             -- type_id of DECIMAL
+			       column_schema like :schema_filter and
+			       column_table  like :table_filter and
+			       column_object_type = 'TABLE' and
+			       column_is_virtual  = FALSE and
+			       column_num_scale <> 0               -- only columns that have a scale
+		]], {schema_filter=schema_name, table_filter=table_name})
+
+	for i=1,#res do
+		local modify_column, message_action, query_to_execute = false, '', ''
+		local tgt = {fam='KEEP'}
+		local scm, tbl, col = quote(res[i][1]), quote(res[i][2]), quote(res[i][3])
+		local precision, col_scale = res[i][4], res[i][5]
+		local src = 'DECIMAL('..precision..', '..col_scale..')'
+
+		if precision <= 9 then
+			message_action = 'Keep '..src..' (already minimal precision)'
+		else
+			local dColumns = query([[
+				select count(::col_name) as values_in_column,
+				       coalesce(max(length(floor(abs(::col_name)))), 0) as max_int_length
+				from ::curr_schema.::curr_table
+			]], {curr_schema=scm, curr_table=tbl, col_name=col})
+			local not_null_count, max_int_length = dColumns[1][1], dColumns[1][2]
+			local needed_precision = max_int_length + col_scale
+			if not_null_count == 0 then
+				message_action = 'Keep '..src..' (empty)'
+				tgt = {fam='DECS', p=precision, s=col_scale, need=col_scale}
+			else
+				local target = smaller_integer_precision(needed_precision, precision)
+				tgt = {fam='DECS', p=precision, s=col_scale, need=needed_precision}
+				if target ~= nil then
+					query_to_execute = "ALTER TABLE "..scm.."."..tbl.." MODIFY ("..col.." DECIMAL("..target..","..col_scale.."));"
+					modify_column    = true
+					message_action   = src..' --> DECIMAL('..target..', '..col_scale..'), needed precision: '..needed_precision
+				else
+					message_action = 'Keep '..src..', needed precision: '..needed_precision
+				end
+			end
+		end
+		result_table[#result_table+1] = {sch=res[i][1], tab=res[i][2], col=res[i][3], src=src,
+			message=message_action, query=query_to_execute, modify=modify_column, tgt=tgt}
+	end
+	return result_table
+end
+
+------------------------------------------------------------------------------------------------------
+-- TIMESTAMP / TIMESTAMP WITH LOCAL TIME ZONE --> DATE
+------------------------------------------------------------------------------------------------------
+function convert_timestamp_to_date(schema_name, table_name)
+	local result_table = {}
+	local res = query([[
+			select column_schema, column_table, column_name, column_type
+			from   exa_all_columns
+			where  column_type_id in (93, 124) and    -- 93 = TIMESTAMP, 124 = TIMESTAMP WITH LOCAL TIME ZONE
+			       column_schema like :schema_filter and
+			       column_table  like :table_filter and
+			       column_object_type = 'TABLE' and
+			       column_is_virtual  = FALSE
+		]], {schema_filter=schema_name, table_filter=table_name})
+
+	for i=1,#res do
+		local modify_column, message_action, query_to_execute = false, '', ''
+		local tgt = {fam='KEEP'}
+		local scm, tbl, col = quote(res[i][1]), quote(res[i][2]), quote(res[i][3])
+		local src = res[i][4]   -- exact current type from the catalog, e.g. "TIMESTAMP(6)" / "TIMESTAMP(3) WITH LOCAL TIME ZONE"
+
+		local tsSuc, tsColumns = pquery([[
+			select count(::col_name) as values_in_column,
+			       count(case when ::col_name <> TRUNC(::col_name) then 1 end) as rows_with_time
+			from ::curr_schema.::curr_table
+		]], {curr_schema=scm, curr_table=tbl, col_name=col})
+
+		if not tsSuc then
+			message_action = 'Keep '..src..' (check failed)'
+		elseif tsColumns[1][1] == 0 then
+			message_action = 'Keep '..src..' (empty)'
+			tgt = {fam='TS', has_time=false}   -- empty: convertible if the rest of its key group is
+		elseif tsColumns[1][2] == 0 then
+			query_to_execute = "ALTER TABLE "..scm.."."..tbl.." MODIFY ("..col.." DATE);"
+			modify_column    = true
+			message_action   = src..' --> DATE'
+			tgt = {fam='TS', has_time=false}
+		else
+			message_action = 'Keep '..src..' (has a time component)'
+			tgt = {fam='TS', has_time=true}
+		end
+		result_table[#result_table+1] = {sch=res[i][1], tab=res[i][2], col=res[i][3], src=src,
+			message=message_action, query=query_to_execute, modify=modify_column, tgt=tgt}
+	end
+	return result_table
+end
+
+------------------------------------------------------------------------------------------------------
+-- VARCHAR(n) --> smaller VARCHAR (charset preserved)
+------------------------------------------------------------------------------------------------------
+function convert_varchar_to_smaller_varchar(schema_name, table_name)
+	local result_table = {}
+	local res = query([[
+			select column_schema, column_table, column_name, column_maxsize, column_type
+			from   exa_all_columns
+			where  column_type_id = 12 and            -- type_id of VARCHAR
+			       column_schema like :schema_filter and
+			       column_table  like :table_filter and
+			       column_object_type = 'TABLE' and
+			       column_is_virtual  = FALSE
+		]], {schema_filter=schema_name, table_filter=table_name})
+
+	for i=1,#res do
+		local modify_column, message_action, query_to_execute = false, '', ''
+		local tgt = {fam='KEEP'}
+		local scm, tbl, col = quote(res[i][1]), quote(res[i][2]), quote(res[i][3])
+		local current_maxsize = res[i][4]
+		local charset = 'UTF8'
+		if string.find(string.upper(res[i][5]), 'ASCII', 1, true) ~= nil then charset = 'ASCII' end
+		local src = 'VARCHAR('..current_maxsize..') '..charset
+
+		if current_maxsize <= 3 then
+			message_action = 'Keep '..src..' (n <= 3, left untouched)'
+		else
+			local dColumns = query([[
+				select count(::col_name) as values_in_column,
+				       coalesce(max(length(::col_name)), 0) as max_length
+				from ::curr_schema.::curr_table
+			]], {curr_schema=scm, curr_table=tbl, col_name=col})
+			local not_null_count, max_length = dColumns[1][1], dColumns[1][2]
+			if not_null_count == 0 then
+				message_action = 'Keep '..src..' (empty)'
+				tgt = {fam='VC', n=current_maxsize, cs=charset, maxlen=0}
+			elseif (max_length <= 2000000) and (estimate_optimal_varchar_length(max_length) < current_maxsize) then
+				local change_to  = estimate_optimal_varchar_length(max_length)
+				query_to_execute = "ALTER TABLE "..scm.."."..tbl.." MODIFY ("..col.." VARCHAR("..change_to..") "..charset..");"
+				modify_column    = true
+				message_action   = src..' --> VARCHAR('..change_to..') '..charset..', max length: '..max_length
+				tgt = {fam='VC', n=current_maxsize, cs=charset, maxlen=max_length}
+			else
+				message_action = 'Keep '..src..', max length: '..max_length
+				tgt = {fam='VC', n=current_maxsize, cs=charset, maxlen=max_length}
+			end
+		end
+		result_table[#result_table+1] = {sch=res[i][1], tab=res[i][2], col=res[i][3], src=src,
+			message=message_action, query=query_to_execute, modify=modify_column, tgt=tgt}
+	end
+	return result_table
+end
+
+------------------------------------------------------------------------------------------------------
+-- Helper functions
+------------------------------------------------------------------------------------------------------
+
 -- Appends all rows of t2 to t1 and returns t1.
 function merge_tables(t1, t2)
-	for i = 1, #t2 do
-		t1[#t1+1] = t2[i]
-	end
+	for i = 1, #t2 do t1[#t1+1] = t2[i] end
 	return t1
 end
 
--- Returns the maximal string length found in one column of the result table.
+-- Returns the maximal string length found in one column of the (positional) result table.
 function getMaxLengthForColumn(input_table, column_number)
 	local length = 1
 	for i = 1, #input_table do
-		if #input_table[i][column_number] > length then
-			length = #input_table[i][column_number]
-		end
+		local v = input_table[i][column_number]
+		if v ~= nil and #v > length then length = #v end
 	end
 	return length
 end
 
--- Executes the SQL contained in one column and logs the outcome in another column.
+-- Executes the SQL in one column of the positional table and logs the outcome in another column.
+-- Comment-only rows (section dividers starting with '--') and empty rows are skipped, NOT executed.
 function execute_sql_column(input_table, sql_col_number, log_col_number)
 	for i = 1, #input_table do
 		local sql_stmt = input_table[i][sql_col_number]
-		if sql_stmt ~= nil and sql_stmt ~= '' then
+		if sql_stmt ~= nil and sql_stmt ~= '' and string.sub(sql_stmt, 1, 2) ~= '--' then
 			local sql_suc, sql_res = pquery(sql_stmt)
 			if sql_suc then
 				input_table[i][log_col_number] = 'true'
@@ -563,7 +505,7 @@ function execute_sql_column(input_table, sql_col_number, log_col_number)
 				input_table[i][log_col_number] = 'ERROR: ' .. sql_res.error_message
 			end
 		else
-			input_table[i][log_col_number] = ''   -- nothing to execute (e.g. a "Keep" row)
+			input_table[i][log_col_number] = ''   -- nothing to execute (a "Keep" row or a section divider)
 		end
 	end
 	return input_table
@@ -571,54 +513,171 @@ end
 
 -----------------------------END OF FUNCTIONS, BEGINNING OF ACTUAL SCRIPT-----------------------------
 
-	-- log_for_all_columns is a script parameter: if false, only columns that will be changed
-	-- are reported; if true, every inspected column is reported (including "Keep ..." rows).
+	-- 1) Collect every inspected column of the ENABLED types (records, not yet filtered by log_for_all_columns)
+	local analyzed = {}
+	if convert_double    then analyzed = merge_tables(analyzed, convert_double_to_decimal(schema_name, table_name)) end
+	if convert_integer   then analyzed = merge_tables(analyzed, convert_integer_to_smaller_integer(schema_name, table_name)) end
+	if convert_decimal   then analyzed = merge_tables(analyzed, convert_decimal_with_scale_to_smaller_decimal(schema_name, table_name)) end
+	if convert_timestamp then analyzed = merge_tables(analyzed, convert_timestamp_to_date(schema_name, table_name)) end
+	if convert_varchar   then analyzed = merge_tables(analyzed, convert_varchar_to_smaller_varchar(schema_name, table_name)) end
 
+	-- 2) FOREIGN KEY handling (only when FKs touch the analyzed tables; otherwise no effect)
+	local function nodek(s, t, c) return s .. string.char(1) .. t .. string.char(1) .. c end
+	local acol = {}
+	for i = 1, #analyzed do acol[nodek(analyzed[i].sch, analyzed[i].tab, analyzed[i].col)] = analyzed[i] end
+	local tabset = {}
+	for i = 1, #analyzed do tabset[analyzed[i].sch .. string.char(1) .. analyzed[i].tab] = true end
+
+	local fk_suc, fk = pquery([[
+		SELECT cc.constraint_schema, cc.constraint_table, cc.constraint_name, cc.ordinal_position,
+		       cc.column_name, cc.referenced_schema, cc.referenced_table, cc.referenced_column,
+		       c.constraint_enabled
+		FROM   exa_all_constraint_columns cc
+		JOIN   exa_all_constraints c
+		       ON  c.constraint_schema = cc.constraint_schema
+		       AND c.constraint_table  = cc.constraint_table
+		       AND c.constraint_name   = cc.constraint_name
+		WHERE  cc.constraint_type = 'FOREIGN KEY'
+		  AND  (cc.constraint_schema LIKE :schp1 OR cc.referenced_schema LIKE :schp2)
+		ORDER  BY cc.constraint_schema, cc.constraint_table, cc.constraint_name, cc.ordinal_position
+	]], {schp1 = schema_name, schp2 = schema_name})
+
+	local drop_rows, readd_rows = {}, {}
+
+	if fk_suc and #fk > 0 then
+		local parent, nodedisp = {}, {}
+		local function find(x)
+			if parent[x] == nil then parent[x] = x end
+			while parent[x] ~= x do parent[x] = parent[parent[x]]; x = parent[x] end
+			return x
+		end
+		local function union(a, b) local ra, rb = find(a), find(b); if ra ~= rb then parent[ra] = rb end end
+		local fkdef, fkorder = {}, {}
+		for i = 1, #fk do
+			local cs, ct, cn = fk[i][1], fk[i][2], fk[i][3]
+			local cc         = fk[i][5]
+			local rs, rt, rc = fk[i][6], fk[i][7], fk[i][8]
+			local cnode, rnode = nodek(cs, ct, cc), nodek(rs, rt, rc)
+			nodedisp[cnode] = '"'..cs..'"."'..ct..'"'; nodedisp[rnode] = '"'..rs..'"."'..rt..'"'
+			union(cnode, rnode)
+			local key = nodek(cs, ct, cn)
+			if fkdef[key] == nil then
+				fkdef[key] = {csch=cs, ctab=ct, cname=cn, cols={}, rsch=rs, rtab=rt, rcols={}, enabled=fk[i][9]}
+				fkorder[#fkorder+1] = key
+			end
+			fkdef[key].cols[#fkdef[key].cols+1]   = cc
+			fkdef[key].rcols[#fkdef[key].rcols+1] = rc
+		end
+
+		local groups = {}
+		for nkey in pairs(parent) do
+			local root = find(nkey)
+			if groups[root] == nil then groups[root] = {} end
+			groups[root][#groups[root]+1] = nkey
+		end
+
+		local converting = {}
+		for root, nodes in pairs(groups) do
+			local members, missing = {}, {}
+			for _, nkey in ipairs(nodes) do
+				if acol[nkey] ~= nil then members[#members+1] = acol[nkey] else missing[#missing+1] = nkey end
+			end
+			if #members > 0 then
+				if #missing > 0 then
+					local seen, rel = {}, {}
+					for _, nkey in ipairs(missing) do
+						local d = nodedisp[nkey] or '(unknown table)'
+						if not seen[d] then seen[d] = true; rel[#rel+1] = d end
+					end
+					local relstr = table.concat(rel, ', ')
+					for _, a in ipairs(members) do
+						a.message = 'Keep '..a.src..' (FK key column - related table out of scope)'
+						a.query = ''; a.modify = false
+					end
+				else
+					local gt = group_target(members)
+					local ttype = render_target(gt)
+					if ttype ~= nil then
+						converting[root] = true
+						for _, a in ipairs(members) do
+							a.query   = "ALTER TABLE "..quote(a.sch).."."..quote(a.tab).." MODIFY ("..quote(a.col).." "..ttype..");"
+							a.message = a.src..' --> '..ttype..'  [FK key group - harmonized]'
+							a.modify  = true
+						end
+					else
+						for _, a in ipairs(members) do
+							a.message = 'Keep '..a.src..' (FK key group: no common smaller type - not changed)'
+							a.query = ''; a.modify = false
+						end
+					end
+				end
+			end
+		end
+
+		local function q(x) return '"'..x..'"' end
+		for _, key in ipairs(fkorder) do
+			local d = fkdef[key]
+			local touches = false
+			for _, cc in ipairs(d.cols) do
+				if converting[find(nodek(d.csch, d.ctab, cc))] then touches = true; break end
+			end
+			if touches then
+				local en    = d.enabled
+				local state = (en == false or en == 'FALSE' or en == 'false' or en == 0 or en == '0') and 'DISABLE' or 'ENABLE'
+				local ccols, rcols = {}, {}
+				for _, c in ipairs(d.cols)  do ccols[#ccols+1]  = q(c) end
+				for _, c in ipairs(d.rcols) do rcols[#rcols+1] = q(c) end
+				drop_rows[#drop_rows+1] = {sch=d.csch, tab=d.ctab, col='', message='drop foreign key '..d.cname,
+					query='ALTER TABLE '..q(d.csch)..'.'..q(d.ctab)..' DROP CONSTRAINT '..q(d.cname)..';'}
+				readd_rows[#readd_rows+1] = {sch=d.csch, tab=d.ctab, col='', message='re-add foreign key '..d.cname..' ('..state..')',
+					query='ALTER TABLE '..q(d.csch)..'.'..q(d.ctab)..' ADD CONSTRAINT '..q(d.cname)..
+					      ' FOREIGN KEY ('..table.concat(ccols, ', ')..') REFERENCES '..q(d.rsch)..'.'..q(d.rtab)..
+					      ' ('..table.concat(rcols, ', ')..') '..state..';'}
+			end
+		end
+	end
+
+	-- 3) Build the column rows honoring log_for_all_columns, sorted by schema/table/column
+	local col_recs = {}
+	for i = 1, #analyzed do
+		if analyzed[i].modify or log_for_all_columns then col_recs[#col_recs+1] = analyzed[i] end
+	end
+	table.sort(col_recs, function(a, b)
+		if a.sch ~= b.sch then return a.sch < b.sch end
+		if a.tab ~= b.tab then return a.tab < b.tab end
+		return a.col < b.col
+	end)
+
+	-- 4) Assemble the final ordered list of records (DROP FKs first, MODIFYs, RE-ADD FKs last)
+	local ordered = {}
+	if #drop_rows > 0 then
+		ordered[#ordered+1] = {sch='', tab='', col='', message='', query='-- ### DROP FOREIGN KEYS - run these FIRST (before the column changes) ###'}
+		for _, x in ipairs(drop_rows)  do ordered[#ordered+1] = x end
+		ordered[#ordered+1] = {sch='', tab='', col='', message='', query='-- ### COLUMN TYPE CHANGES ###'}
+		for _, x in ipairs(col_recs)   do ordered[#ordered+1] = x end
+		ordered[#ordered+1] = {sch='', tab='', col='', message='', query='-- ### RE-ADD FOREIGN KEYS - run these LAST (after the column changes) ###'}
+		for _, x in ipairs(readd_rows) do ordered[#ordered+1] = x end
+	else
+		ordered = col_recs
+	end
+
+	-- 5) Turn records into positional rows (add a success slot when applying)
 	local overall_res = {}
-
-	-- Each conversion type runs only when its switch parameter is true.
-	-- double to decimal (directly to the smallest fitting DECIMAL)
-	if convert_double then
-		overall_res = merge_tables(overall_res, convert_double_to_decimal(schema_name, table_name, log_for_all_columns))
+	for i = 1, #ordered do
+		local r = ordered[i]
+		if apply_conversion then
+			overall_res[#overall_res+1] = {r.sch, r.tab, r.col, r.message, r.query, ''}
+		else
+			overall_res[#overall_res+1] = {r.sch, r.tab, r.col, r.message, r.query}
+		end
 	end
 
-	-- integer (scale 0) to smaller integer
-	if convert_integer then
-		overall_res = merge_tables(overall_res, convert_integer_to_smaller_integer(schema_name, table_name, log_for_all_columns))
-	end
-
-	-- decimal with scale to smaller decimal
-	if convert_decimal then
-		overall_res = merge_tables(overall_res, convert_decimal_with_scale_to_smaller_decimal(schema_name, table_name, log_for_all_columns))
-	end
-
-	-- timestamp / timestamp with local time zone to date
-	if convert_timestamp then
-		overall_res = merge_tables(overall_res, convert_timestamp_to_date(schema_name, table_name, log_for_all_columns))
-	end
-
-	-- varchar to smaller varchar
-	if convert_varchar then
-		overall_res = merge_tables(overall_res, convert_varchar_to_smaller_varchar(schema_name, table_name, log_for_all_columns))
-	end
-
-	-- execute the collected statements if apply_conversion is true
-	-- !!! ATTENTION: this irreversibly alters your tables - see the header banner. !!!
+	-- 6) Apply (in the assembled order: DROP -> MODIFY -> RE-ADD); section dividers are skipped
 	if apply_conversion then
 		overall_res = execute_sql_column(overall_res, 5, 6)
 	end
 
-	-- sort the whole output by schema_name, table_name, column_name
-	table.sort(overall_res, function(a, b)
-		if a[1] ~= b[1] then return a[1] < b[1] end
-		if a[2] ~= b[2] then return a[2] < b[2] end
-		return a[3] < b[3]
-	end)
-
-	-- friendly message when the result set would be empty.
-	-- With log_for_all_columns = true every inspected column is listed, so an empty result
-	-- means nothing matched the filter / enabled types at all; otherwise it means that no
-	-- column needs optimization.
+	-- 7) Friendly message when nothing matched
 	if #overall_res == 0 then
 		local empty_msg
 		if log_for_all_columns then
@@ -626,20 +685,16 @@ end
 		else
 			empty_msg = 'No columns found that need optimization.'
 		end
-		if apply_conversion then
-			overall_res[1] = {'', '', '', empty_msg, '', ''}
-		else
-			overall_res[1] = {'', '', '', empty_msg, ''}
-		end
+		if apply_conversion then overall_res[1] = {'', '', '', empty_msg, '', ''}
+		else                     overall_res[1] = {'', '', '', empty_msg, ''} end
 	end
 
-	-- build up output table: get length for each column to avoid exceptions when displaying output
+	-- 8) Size the output columns and return (order is intentional - do NOT re-sort)
 	local length_schema      = getMaxLengthForColumn(overall_res, 1)
 	local length_table       = getMaxLengthForColumn(overall_res, 2)
 	local length_column      = getMaxLengthForColumn(overall_res, 3)
 	local length_conversions = getMaxLengthForColumn(overall_res, 4)
 	local length_query       = getMaxLengthForColumn(overall_res, 5)
-
 	if apply_conversion then
 		local length_success = getMaxLengthForColumn(overall_res, 6)
 		exit(overall_res, "schema_name char("..length_schema.."), table_name char("..length_table.."), column_name char("..length_column.."), conversion char("..length_conversions.."), query_text char("..length_query.."), success char("..length_success..")")
@@ -652,7 +707,7 @@ end
 -- ====================================================================================
 -- !!! ATTENTION: run with apply_conversion = false first and REVIEW the output.   !!!
 -- !!! Only set apply_conversion = true when you are 100% sure, or - safer - copy   !!!
--- !!! the generated statements and execute them yourself, one by one.              !!!
+-- !!! the generated statements and execute them yourself, in the shown order.      !!!
 -- ====================================================================================
 -- If executed with 'false' --> Script only displays what changes would be made
 execute script DATABASE_MIGRATION.CONVERT_DATATYPES(


### PR DESCRIPTION
## Summary
Three improvements to `convert_datatypes.sql`, mirroring what was done for `convert_varchar`. **Report-only
behavior and the parameter signature are unchanged.**

1. **Precise `conversion` field** — exact current type `-->` exact target type everywhere (incl. real
   TIMESTAMP precision and the `WITH LOCAL TIME ZONE` distinction, and the original `ASCII`/`UTF8`).
2. **`log_for_all_columns = true` lists every inspected column** of an enabled type — now also the
   already-minimal (`DECIMAL` precision ≤ 9, `VARCHAR` size ≤ 3) and empty columns, each with a `Keep …` row.
3. **Automatic FOREIGN KEY handling** (same systematic as `convert_varchar`): harmonize key-group types and
   wrap the changes in DROP / RE-ADD FOREIGN KEY steps, preserving each FK's ENABLE/DISABLE state.

## 1) Precise `conversion` labels
- Exact source **and** target, e.g. `DECIMAL(20, 0) --> DECIMAL(9, 0)`, `VARCHAR(200) ASCII --> VARCHAR(20) ASCII`.
- **TIMESTAMP** uses its real fractional precision from `COLUMN_TYPE` and distinguishes the variant:
  `TIMESTAMP(6) --> DATE`, `TIMESTAMP(3) WITH LOCAL TIME ZONE --> DATE` (was just `TIMESTAMP`).
- Empty-column `Keep` now carries the exact type (`Keep DECIMAL(20, 0) (empty)` instead of
  `Keep DECIMAL (IS EMPTY)`); wording/spacing standardized.

## 2) Full Keep listing under `log_for_all_columns = true`
- Columns previously filtered out at the query level are now listed (no table scan needed):
  `Keep DECIMAL(p, s) (already minimal precision)` (precision ≤ 9), `Keep VARCHAR(n) <charset> (n <= 3, left
  untouched)`. Empty columns are listed as `Keep … (empty)`.
- Still only **handled types** with their **`convert_*` switch on**; `log_for_all_columns = false` reports
  only changing columns (unchanged).

## 3) Automatic FOREIGN KEY handling
- A key-column type change fails unless the linked PK/FK columns change to the **same** type. When FKs touch
  the analyzed tables, the output/execution is wrapped:
  ```
  -- ### DROP FOREIGN KEYS - run these FIRST (before the column changes) ###
  ALTER TABLE … DROP CONSTRAINT …;
  -- ### COLUMN TYPE CHANGES ###
  ALTER TABLE … MODIFY (… DECIMAL(9,0));
  -- ### RE-ADD FOREIGN KEYS - run these LAST (after the column changes) ###
  ALTER TABLE … ADD CONSTRAINT … FOREIGN KEY (…) REFERENCES … (…) ENABLE;   -- or DISABLE
  ```
  These section markers live in the **`query_text`** column. With `apply_conversion = true` the statements
  execute in exactly that order (DROP → MODIFY → RE-ADD); the comment dividers are skipped, not executed.
- Each FK is re-added in its **original `ENABLE`/`DISABLE` state** (read from `EXA_ALL_CONSTRAINTS`).
- **Type harmonization:** each referential key group (composite keys included) → one common target type that
  fits all its columns; if none exists, the group is kept (FK stays valid).
- A key column whose group reaches a table **outside the filter** is kept + warned.
- **Performance guard:** no FKs in scope → run unchanged (one cheap catalog read).

## Testing & validation
See `TEST_RESULTS_convert_datatypes.md` / `convert_datatypes_test.sql`. Verified live on Exasol 8:
- precise labels for every type incl. `TIMESTAMP(6) WITH LOCAL TIME ZONE --> DATE` and ASCII VARCHAR;
- `already minimal` / `n <= 3` / `empty` Keep rows under `log_for_all_columns = true`;
- FK harmonization + DROP/RE-ADD wrapper; **`apply_conversion = true` end to end with 0 failures**, all FKs
  restored, ENABLE/DISABLE state preserved; out-of-scope single-table warning.

## Notes
- **Report-only** by default; `apply_conversion = true` irreversibly applies (unchanged warning).
- **No signature change.** Installs cleanly in DbVisualizer (no `?` / bind-marker characters).
- Files changed: `post_load_optimization/convert_datatypes.sql` and `post_load_optimization/README.md`.


[TEST_RESULTS_convert_datatypes.md](https://github.com/user-attachments/files/29359471/TEST_RESULTS_convert_datatypes.md)
[convert_datatypes_test.sql](https://github.com/user-attachments/files/29359474/convert_datatypes_test.sql)
