### PR TITLE
mysql_to_exasol: full rewrite (fix silently-dropped JSON, BIT(64)/UNSIGNED overflow, TIME & sub-second loss, binary corruption; add PK/FK/comments/views/PARTITION BY, base64 binary, fail-loud limits, mapping-aware CHECK_MIGRATION); MySQL 8/9

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,23 +217,101 @@ For the actual data-migration, see script [mariadb_to_exasol.sql](mariadb_to_exa
 
 ### MySQL
 
-Create a connection:
-```SQL
-CREATE CONNECTION <name_of_connection>
-TO 'jdbc:mysql://192.168.137.5:3306'
-USER '<user>'
-IDENTIFIED BY '<password>';
-```
+The [mysql_to_exasol.sql](mysql_to_exasol.sql) script generates the statements to migrate a MySQL
+database (**MySQL 8 / 9**, backward compatible with earlier 5.x) to Exasol v8. It runs on the **target** Exasol
+database, reads the **source** metadata through a JDBC connection and **returns** the statements to recreate and
+load the source. It changes nothing itself — you review the output and run it, in the order returned.
 
-Test your connection:
-```SQL
-SELECT * FROM
-(
-IMPORT FROM JDBC AT <name_of_connection>
-STATEMENT 'SELECT 42 FROM DUAL'
+**Step by step**
+* **Install** the script on the **target** database (run [mysql_to_exasol.sql](mysql_to_exasol.sql) once; it
+  creates `DATABASE_MIGRATION.MYSQL_TO_EXASOL`).
+* **Install the JDBC driver** in BucketFS: use the latest MySQL **`mysql-connector-j`** driver
+  ([Maven](https://mvnrepository.com/artifact/com.mysql/mysql-connector-j)). See
+  [Load data from MySQL](https://docs.exasol.com/db/latest/loading_data/connect_sources/mysql.htm).
+* **Create a connection** on the target pointing at the source database. A ready-to-edit `CREATE CONNECTION`
+  example and a connection test are at the bottom of the script.
+* **Adapt the `EXECUTE SCRIPT` parameters** to your scenario and run it (a few seconds, depending on the number
+  of tables).
+* **Copy the result set** into another session and execute the statements **in the output order** (the
+  CONSTRAINT STATE section, and — if enabled — the DATA VALIDATION section, run after the IMPORTs).
+
+```sql
+EXECUTE SCRIPT DATABASE_MIGRATION.MYSQL_TO_EXASOL(
+    'MYSQL_JDBC',       -- CONNECTION_NAME: name of the JDBC connection created at the bottom of the script
+    true,               -- IDENTIFIER_CASE_INSENSITIVE: true (recommended) => fold ALL identifiers to UPPER so Exasol queries never need quotes; false => keep verbatim/quoted
+    '%',                -- SCHEMA_FILTER: source database(s): 'mydb', 'sales_%', '%' (all; system schemas always excluded)
+    '%',                -- TABLE_FILTER: table(s)/view(s): 'my_table', 'my_%', '%' (all)
+    '',                 -- TARGET_SCHEMA: Exasol target schema; '' (recommended) => use the source schema name
+    'FORCE_DISABLE',    -- CONSTRAINT_STATE: 'FORCE_DISABLE' (recommended; PK/FK kept as metadata only - faster, order-independent imports, still used by BI tools), 'SET_AS_SOURCE' or 'FORCE_ENABLE' (all keys enabled = Exasol re-validates the data)
+    true,               -- GENERATE_COMMENTS: true (recommended) => migrate MySQL comments as COMMENT ON; false => skip
+    true,               -- GENERATE_VIEWS: true => emit source views as a commented manual-review section; false => skip
+    true,               -- GENERATE_PARTITION_BY: true => add a best-effort PARTITION BY from a single-column MySQL partition key; complex partitioning is listed as a commented manual-review note; false => skip
+    'BASE64',           -- BINARY_HANDLING: 'BASE64' (recommended; binary/blob migrated losslessly as base64 text - Exasol has no general binary type) or 'SKIP' (load NULL)
+    'CAP',              -- DECIMAL_OVERFLOW: 'CAP' (recommended; decimal>36 -> DECIMAL(36,s); IMPORT fails for values needing > 36 digits), 'DOUBLE' (~15 significant digits) or 'VARCHAR' (lossless text)
+    false,              -- TRUNCATE_LONG_STRINGS: false (recommended) => import fails on a value > 2,000,000 chars; true => cut such values to 2,000,000 chars and import
+    'FAIL',             -- TEMPORAL_OUT_OF_RANGE: 'FAIL' (recommended; IMPORT fails on a zero-date / out-of-range date), 'NULL' (load NULL) or 'CLAMP' (clamp to the Exasol min)
+    false,              -- TINYINT1_AS_BOOLEAN: false (recommended; tinyint(1) -> DECIMAL(3,0), value preserved) or true (tinyint(1) -> BOOLEAN)
+    false               -- CHECK_MIGRATION: false (recommended default) => skip; true => also build per-table "<table>_MIG_CHK" metric tables and a "<schema>_MIG_CHK" summary that compares source vs. target (run after the IMPORTs)
 );
 ```
-Then you're ready to use the migration script: [mysql_to_exasol.sql](mysql_to_exasol.sql)
+
+This script generates, in this order:
+* `CREATE SCHEMA` and `CREATE TABLE` — every data type mapped to a sensible Exasol type, plus `NOT NULL`,
+  column `DEFAULT`s and the `PRIMARY KEY` (created disabled)
+* `ALTER TABLE … ADD … FOREIGN KEY` (created disabled; composite keys supported; keys to tables outside the
+  migration scope are skipped)
+* with `GENERATE_PARTITION_BY`: `ALTER TABLE … PARTITION BY` from a single-column MySQL partition key (best-effort)
+* table & column `COMMENT`s (with `GENERATE_COMMENTS`)
+* `IMPORT` of the data (typed transfer — differing source/target NLS does not affect the data)
+* a **CONSTRAINT STATE** section to run after the IMPORTs (keys created disabled for a fast, order-independent
+  load; this section then sets them per `CONSTRAINT_STATE`)
+* with `GENERATE_VIEWS`: the source views as a **commented** manual-review section (MySQL SQL is not
+  auto-translated)
+* with `CHECK_MIGRATION`: a **DATA VALIDATION** section (see below)
+
+**Data types & limitations.** Every MySQL type is covered (no silent drops). Integers map to
+`DECIMAL(3/5/7/10/19,0)` — **`UNSIGNED` widens** `mediumint`→`DECIMAL(8,0)` and `bigint`→`DECIMAL(20,0)`;
+`decimal(p,s)`→`DECIMAL(p,s)`, `float`/`double`→`DOUBLE`, `bit(M)`→`DECIMAL`. `date`→`DATE`; `datetime(p)` keeps
+full precision; **`timestamp(p)`→`TIMESTAMP(p) WITH LOCAL TIME ZONE`** (the tz-aware instant type), `datetime(p)`→
+`TIMESTAMP(p)` (wall clock). Character columns map to **`UTF8`**; `char>2000`→`VARCHAR`; `tinytext…longtext`/
+`json`→`VARCHAR(2000000)`; **`enum`/`set`→`VARCHAR`** (label / CSV). **`binary`/`varbinary`/`*blob`→base64 text**
+(`BINARY_HANDLING`, lossless, decode downstream). `time`→`VARCHAR(17)` (Exasol has no TIME type; MySQL `TIME`
+spans `-838:59:59 … 838:59:59` and keeps fractional seconds); `year`→`VARCHAR(4)`; spatial types→**`GEOMETRY`**
+(WKT via `ST_AsText`). **`tinyint(1)`** → `DECIMAL(3,0)` (value preserved; the JDBC driver otherwise coerces it
+to boolean, collapsing any non‑0/1 to 1), or `BOOLEAN` with `TINYINT1_AS_BOOLEAN=true`. **`decimal` with > 36
+digits** is handled via `DECIMAL_OVERFLOW` (`CAP` / `DOUBLE` / `VARCHAR`). The IMPORT **fails loudly rather than
+corrupting data** when a value needs more than 36 decimal digits (`CAP`), exceeds 2,000,000 characters (unless
+`TRUNCATE_LONG_STRINGS=true`), or is a zero-date / out-of-range date (`TEMPORAL_OUT_OF_RANGE='FAIL'`; `NULL` or
+`CLAMP` are available — see the optional `zeroDateTimeBehavior` driver note at the bottom of the script).
+**Always excluded** (so only real user data appears): the MySQL **system schemas** (`mysql`,
+`information_schema`, `performance_schema`, `sys`). Not migrated (out of scope): indexes, `UNIQUE`/`CHECK`
+constraints, triggers, routines, events, users/grants. `AUTO_INCREMENT` columns and `STORED`/`VIRTUAL` generated
+columns are migrated as plain columns carrying their values (Exasol has no auto-increment / computed columns).
+
+**Why some columns are read with a `CAST` on the source.** Verified live with Connector/J 9.7: `UNSIGNED`
+integers exceed their signed Java type (e.g. `SMALLINT UNSIGNED` 60000 overflows `java.lang.Short`;
+`BIGINT UNSIGNED` / `BIT(64)` overflow `java.lang.Long`), so every unsigned integer / bit is transferred as text
+into a `DECIMAL` target; `YEAR` is returned as a `DATE` by the driver, so it is read with `CAST(.. AS CHAR)`;
+`TIME` likewise, to keep its full range and fractional seconds.
+
+**Partitioning.** A single-column MySQL partition key (e.g. `RANGE COLUMNS(sale_date)`) is mapped best-effort to
+an Exasol `PARTITION BY` on that column; `HASH`/`KEY`/expression partitioning is emitted as a commented
+manual-review note. A MySQL partitioned table is one logical table, so data is never migrated twice. (MySQL has
+no distribution/clustering-key concept, so no `DISTRIBUTE BY` is generated.)
+
+**Migration check (`CHECK_MIGRATION=true`).** For every migrated table the script builds a `"<table>_MIG_CHK"`
+table holding standardized, cross-database-comparable metrics (row count, per-column NULL counts, distinct
+counts, numeric MIN/MAX/SUM, character length MIN/MAX) computed on **both** MySQL and Exasol, plus a
+`DATABASE_MIGRATION."<schema>_MIG_CHK"` summary that lists every metric side by side with an **`OK` / `DEVIATION`**
+status. Review deviations with
+`SELECT * FROM DATABASE_MIGRATION."<schema>_MIG_CHK" WHERE "STATUS" = 'DEVIATION';`.
+
+**Privileges/visibility:** the source metadata is read **through the connection's user**, so the script sees —
+and generates statements for — only the objects that user may access. **To migrate everything, use a user with
+sufficient privileges on the source.**
+
+See the header of [mysql_to_exasol.sql](mysql_to_exasol.sql) for more information!
+
 
 ### Netezza
 

--- a/mysql_to_exasol.sql
+++ b/mysql_to_exasol.sql
@@ -1,198 +1,417 @@
 create schema if not exists database_migration;
-/* 
-	This script will generate create schema, create table and create import statements 
-	to load all needed data from a mysql database. Automatic datatype conversion is
-	applied whenever needed. Feel free to adjust it. 
+
+/*
+    mysql_to_exasol.sql  -  generate the statements to migrate a MySQL database to Exasol v8.
+
+    Source: MySQL 8 / 9 (backward compatible with earlier 5.x). This script runs on the
+    TARGET Exasol database, reads the SOURCE metadata through a JDBC connection and RETURNS the statements
+    (CREATE SCHEMA / CREATE TABLE incl. PRIMARY KEY / FOREIGN KEY / PARTITION BY / COMMENTs / IMPORT / a final
+    CONSTRAINT STATE section / optional VIEW review section / optional DATA VALIDATION). It changes nothing
+    itself - review the output and run it in the order returned.
+
+    DATA TYPE MAPPING (every MySQL type is covered - nothing is silently dropped):
+      tinyint -> DECIMAL(3,0); smallint -> DECIMAL(5,0); mediumint -> DECIMAL(7,0)/(8,0 unsigned);
+      int -> DECIMAL(10,0); bigint -> DECIMAL(19,0)/(20,0 unsigned); decimal(p,s) -> DECIMAL(p,s)
+      (p>36 or undefined -> DECIMAL_OVERFLOW); float/double/real -> DOUBLE; bit(M) -> DECIMAL(ceil(M*log10 2),0);
+      date -> DATE; datetime(p) -> TIMESTAMP(p) (full fractional precision); timestamp(p) -> TIMESTAMP(p) WITH
+      LOCAL TIME ZONE (the tz-aware instant type); char(n)/varchar(n) -> CHAR/VARCHAR UTF8 (char>2000 ->
+      VARCHAR); tinytext/text/mediumtext/longtext/json -> VARCHAR(2000000); enum/set -> VARCHAR (label / csv);
+      binary/varbinary/*blob -> base64 text (BINARY_HANDLING); geometry & all spatial subtypes -> GEOMETRY (WKT).
+      Small documented difference: time -> VARCHAR(17) (Exasol has no TIME type; MySQL TIME spans -838:59:59 ..
+      838:59:59 and keeps fractional seconds as text); year -> VARCHAR(4); enum/set/json -> VARCHAR (faithful
+      text). tinyint(1) -> DECIMAL(3,0) lossless by default, or BOOLEAN with TINYINT1_AS_BOOLEAN=true.
+      Hard limits (the IMPORT fails loudly rather than corrupting data): a value > 2,000,000 characters (unless
+      TRUNCATE_LONG_STRINGS=true); DECIMAL needing > 36 digits under DECIMAL_OVERFLOW='CAP'; a date/timestamp
+      outside Exasol's 0001-01-01 .. 9999-12-31 range under TEMPORAL_OUT_OF_RANGE='FAIL' (MySQL zero-dates).
+
+    WHY CASTS ARE NEEDED ON THE SOURCE (verified live with Connector/J 9.7): UNSIGNED integers exceed their
+    signed Java type (SMALLINT UNSIGNED 60000 overflows java.lang.Short; BIGINT UNSIGNED 18446744073709551615
+    and BIT(64) overflow java.lang.Long), so every unsigned integer / bit is transferred as text via CAST(.. AS
+    CHAR) into a DECIMAL target; YEAR is returned as a DATE by the driver, so CAST(.. AS CHAR) yields '2025';
+    TIME via CAST(.. AS CHAR) keeps the full range/fraction; binary via TO_BASE64(..) is byte-exact; spatial via
+    ST_AsText(..); tinyint(1) (the driver coerces it to boolean, collapsing any non 0/1 to 1) is read via
+    CAST(.. AS SIGNED) so the real integer survives.
+
+    NLS: IMPORT FROM JDBC transfers TYPED values, so numbers/dates/timestamps are migrated by value and are not
+    affected by differing source/target locale settings. Character data is stored as UTF8.
+
+    CONSTRAINTS: PK/FK are always created DISABLED (fast, order-independent load); a final CONSTRAINT STATE
+    section sets them per CONSTRAINT_STATE. Exasol uses disabled keys as optimizer/BI metadata, so
+    'FORCE_DISABLE' (recommended) is fine and fastest; 'FORCE_ENABLE' makes Exasol re-validate the data.
+
+    PARTITIONING: a single-column MySQL partition key (RANGE/LIST COLUMNS on one bare column) is mapped
+    best-effort to an Exasol PARTITION BY on that column (GENERATE_PARTITION_BY); HASH/KEY/expression
+    partitioning is emitted as a commented manual-review note. A MySQL partitioned table is a single logical
+    table (no separate child tables), so data is never migrated twice. MySQL has no distribution/clustering
+    concept, so no DISTRIBUTE BY is generated.
+
+    Not migrated (out of scope): indexes, UNIQUE/CHECK constraints, triggers, routines, events, sequences,
+    users/grants. AUTO_INCREMENT is migrated as a plain numeric column carrying its values; generated columns
+    (STORED/VIRTUAL) are migrated as plain columns carrying their stored/computed values (Exasol has no computed
+    columns); MySQL has no user-defined types (only ENUM/SET, resolved to VARCHAR with exact sizing).
 */
 --/
 create or replace script database_migration.MYSQL_TO_EXASOL(
-CONNECTION_NAME 				-- name of the database connection inside exasol -> e.g. mysql_db
-,IDENTIFIER_CASE_INSENSITIVE 	-- true if identifiers should be stored case-insensitiv (will be stored upper_case)
-,SCHEMA_FILTER 					-- filter for the schemas to generate and load (except information_schema and pg_catalog) -> '%' to load all
-,TABLE_FILTER 					-- filter for the tables to generate and load -> '%' to load all
+  CONNECTION_NAME               -- name of the JDBC connection inside Exasol -> e.g. MYSQL_JDBC
+  ,IDENTIFIER_CASE_INSENSITIVE  -- true (recommended) => fold ALL identifiers to UPPER so Exasol queries need no quotes; false => keep verbatim/quoted
+  ,SCHEMA_FILTER                -- filter for the source schema(s)/database(s) (system schemas always excluded) -> '%' = all
+  ,TABLE_FILTER                 -- filter for the tables/views -> '%' = all
+  ,TARGET_SCHEMA                -- target schema on Exasol; '' = use the source schema name
+  ,CONSTRAINT_STATE             -- 'FORCE_DISABLE' (recommended), 'SET_AS_SOURCE' or 'FORCE_ENABLE'; PK/FK are always created DISABLED, then set after the IMPORTs
+  ,GENERATE_COMMENTS            -- true/false: migrate MySQL table/column comments as COMMENT ON
+  ,GENERATE_VIEWS               -- true/false: emit source views as a commented manual-review section
+  ,GENERATE_PARTITION_BY        -- true/false: add a best-effort PARTITION BY from a single-column MySQL partition key; complex partitioning is emitted as a commented manual-review note
+  ,BINARY_HANDLING              -- 'BASE64' (recommended; binary/blob migrated losslessly as base64 text - Exasol has no binary type) or 'SKIP' (load NULL)
+  ,DECIMAL_OVERFLOW             -- 'CAP' (recommended; decimal>36 -> DECIMAL(36,s); IMPORT fails for values > 36 digits), 'DOUBLE' (loads, ~15 digits) or 'VARCHAR' (lossless text)
+  ,TRUNCATE_LONG_STRINGS        -- true: values > 2,000,000 chars are cut to 2,000,000 and imported; false: the IMPORT fails on such a value
+  ,TEMPORAL_OUT_OF_RANGE        -- 'FAIL' (recommended; IMPORT fails on a zero-date/out-of-range date), 'NULL' (load NULL) or 'CLAMP' (clamp to the Exasol min)
+  ,TINYINT1_AS_BOOLEAN          -- false (recommended; tinyint(1) -> DECIMAL(3,0), value preserved) or true (tinyint(1) -> BOOLEAN)
+  ,CHECK_MIGRATION              -- true/false: additionally emit data-validation metrics (per-table "<table>_MIG_CHK" + a "<schema>_MIG_CHK" summary comparing source vs target). Run AFTER the IMPORTs.
 ) RETURNS TABLE
 AS
 
+-- IDENTIFIER_CASE_INSENSITIVE = true wraps every identifier in upper(...) (stored UPPER CASE), applied
+-- consistently to schemas, tables, columns, primary keys, foreign keys, partition keys, comments.
 exa_upper_begin=''
 exa_upper_end=''
-
 if IDENTIFIER_CASE_INSENSITIVE == true then
 	exa_upper_begin='upper('
 	exa_upper_end=')'
 end
 
+-- Normalize option parameters.
+cstate = string.upper(tostring(CONSTRAINT_STATE))
+if cstate ~= 'SET_AS_SOURCE' and cstate ~= 'FORCE_ENABLE' then cstate = 'FORCE_DISABLE' end
+gen_comments = (GENERATE_COMMENTS == true) or (string.upper(tostring(GENERATE_COMMENTS)) == 'TRUE')
+gen_views    = (GENERATE_VIEWS == true) or (string.upper(tostring(GENERATE_VIEWS)) == 'TRUE')
+gen_part     = (GENERATE_PARTITION_BY == true) or (string.upper(tostring(GENERATE_PARTITION_BY)) == 'TRUE')
+trunc        = (TRUNCATE_LONG_STRINGS == true) or (string.upper(tostring(TRUNCATE_LONG_STRINGS)) == 'TRUE')
+t1bool       = (TINYINT1_AS_BOOLEAN == true) or (string.upper(tostring(TINYINT1_AS_BOOLEAN)) == 'TRUE')
+binmode = string.upper(tostring(BINARY_HANDLING))
+if binmode ~= 'SKIP' then binmode = 'BASE64' end
+decof = string.upper(tostring(DECIMAL_OVERFLOW))
+if decof ~= 'DOUBLE' and decof ~= 'VARCHAR' then decof = 'CAP' end
+oormode = string.upper(tostring(TEMPORAL_OUT_OF_RANGE))
+if oormode ~= 'NULL' and oormode ~= 'CLAMP' then oormode = 'FAIL' end
+gen_check = (CHECK_MIGRATION == true) or (string.upper(tostring(CHECK_MIGRATION)) == 'TRUE')
+
+function U(col) return exa_upper_begin..col..exa_upper_end end
+-- target schema name expression (TARGET_SCHEMA override or the source schema)
+if TARGET_SCHEMA == null then tschema = [["schema_name"]] else tschema = [[']]..TARGET_SCHEMA..[[']] end
+sname_e = U(tschema)
+-- foreign-key parent schema: when TARGET_SCHEMA is set every table lands there, otherwise the parent keeps its own schema
+if TARGET_SCHEMA == null then ref_sname_e = U('"ref_schema"') else ref_sname_e = sname_e end
+
+-- Always-excluded MySQL system schemas + the requested SCHEMA/TABLE filters (inner literals double-quoted).
+myflt = [[ and table_schema not in (''mysql'',''information_schema'',''performance_schema'',''sys'') and table_schema like '']]..SCHEMA_FILTER..[['' and table_name like '']]..TABLE_FILTER..[['' ]]
+
+-------------------------------------------------------------------------------------------------------
+-- Remote (MySQL) metadata queries. Inner literals are quote-doubled (embedded in statement '...').
+-------------------------------------------------------------------------------------------------------
+columns_q = [[select table_schema as schema_name, table_name, column_name, ordinal_position, column_default, is_nullable, data_type, column_type, character_maximum_length as char_len, numeric_precision as num_prec, numeric_scale as num_scale, datetime_precision as dt_prec, extra from information_schema.columns where (table_schema, table_name) in (select table_schema, table_name from information_schema.tables where table_type = ''BASE TABLE'')]]..myflt
+
+pk_q = [[select table_schema as schema_name, table_name, column_name, ordinal_position as column_position from information_schema.key_column_usage where constraint_name = ''PRIMARY'']]..myflt
+
+fk_q = [[select table_schema as schema_name, table_name, constraint_name as fk_name, column_name as fk_column, referenced_table_schema as ref_schema, referenced_table_name as ref_table, referenced_column_name as ref_column, ordinal_position as col_position from information_schema.key_column_usage where referenced_table_name is not null]]..myflt
+
+-------------------------------------------------------------------------------------------------------
+-- Exasol-side expressions producing the generated statement text.
+-------------------------------------------------------------------------------------------------------
+sc = [[(case when "num_scale" is null or "num_scale" < 0 then 0 when "num_scale" > 36 then 36 else "num_scale" end)]]
+if decof == 'DOUBLE' then
+	dec_t = [[case when "num_prec" is null or "num_prec" > 36 then 'DOUBLE' else 'DECIMAL(' || "num_prec" || ',' || ]]..sc..[[ || ')' end]]
+elseif decof == 'VARCHAR' then
+	dec_t = [[case when "num_prec" is null or "num_prec" > 36 then 'VARCHAR(2000000) ASCII' else 'DECIMAL(' || "num_prec" || ',' || ]]..sc..[[ || ')' end]]
+else
+	dec_t = [[case when "num_prec" is null then 'DECIMAL(36,18)' when "num_prec" > 36 then 'DECIMAL(36,' || ]]..sc..[[ || ')' else 'DECIMAL(' || "num_prec" || ',' || ]]..sc..[[ || ')' end]]
+end
+
+if t1bool then t1t = [['BOOLEAN']] else t1t = [['DECIMAL(3,0)']] end
+
+-- Exasol column type, mapped by MySQL data_type (+ unsigned flag / display width / fractional precision).
+col_t = [[case
+	when "data_type" = 'tinyint' and "column_type" like 'tinyint(1)%' then ]]..t1t..[[
+	when "data_type" = 'tinyint' then 'DECIMAL(3,0)'
+	when "data_type" = 'smallint' then 'DECIMAL(5,0)'
+	when "data_type" = 'mediumint' then case when "is_unsigned" = 1 then 'DECIMAL(8,0)' else 'DECIMAL(7,0)' end
+	when "data_type" in ('int','integer') then 'DECIMAL(10,0)'
+	when "data_type" = 'bigint' then case when "is_unsigned" = 1 then 'DECIMAL(20,0)' else 'DECIMAL(19,0)' end
+	when "data_type" in ('decimal','numeric') then ]]..dec_t..[[
+	when "data_type" in ('float','double','real') then 'DOUBLE'
+	when "data_type" = 'bit' then 'DECIMAL(' || cast(floor("num_prec" * 0.30103) + 1 as decimal(3,0)) || ',0)'
+	when "data_type" = 'date' then 'DATE'
+	when "data_type" = 'datetime' then 'TIMESTAMP(' || coalesce("dt_prec",0) || ')'
+	when "data_type" = 'timestamp' then 'TIMESTAMP(' || coalesce("dt_prec",0) || ') WITH LOCAL TIME ZONE'
+	when "data_type" = 'time' then 'VARCHAR(17) ASCII'
+	when "data_type" = 'year' then 'VARCHAR(4) ASCII'
+	when "data_type" = 'char' then case when "char_len" > 2000 then 'VARCHAR(' || "char_len" || ') UTF8' else 'CHAR(' || "char_len" || ') UTF8' end
+	when "data_type" = 'varchar' then 'VARCHAR(' || (case when "char_len" > 2000000 then 2000000 else "char_len" end) || ') UTF8'
+	when "data_type" in ('tinytext','text','mediumtext','longtext') then 'VARCHAR(2000000) UTF8'
+	when "data_type" in ('enum','set') then 'VARCHAR(' || (case when "char_len" is null or "char_len" < 1 then 2000000 when "char_len" > 2000000 then 2000000 else "char_len" end) || ') UTF8'
+	when "data_type" = 'json' then 'VARCHAR(2000000) UTF8'
+	when "data_type" in ('binary','varbinary') then 'VARCHAR(' || (case when (floor(("char_len"+2)/3))*4 > 2000000 then 2000000 when (floor(("char_len"+2)/3))*4 < 1 then 1 else (floor(("char_len"+2)/3))*4 end) || ') ASCII'
+	when "data_type" in ('tinyblob','blob','mediumblob','longblob') then 'VARCHAR(2000000) ASCII'
+	when "data_type" in ('geometry','point','linestring','polygon','multipoint','multilinestring','multipolygon','geometrycollection') then 'GEOMETRY'
+	else 'VARCHAR(2000000) UTF8'
+end]]
+
+-- DEFAULT mapping (numeric literals as-is; CURRENT_TIMESTAMP; everything else quoted; generated columns skipped).
+default_e = [[case
+	when "is_generated" = 1 then ''
+	when "column_default" is null then ''
+	when upper("extra") like '%DEFAULT_GENERATED%' then (case when upper("column_default") like 'CURRENT_TIMESTAMP%' or upper("column_default") = 'NOW()' then ' DEFAULT CURRENT_TIMESTAMP' else '' end)
+	when "data_type" in ('tinyint','smallint','mediumint','int','integer','bigint','decimal','numeric','float','double','real') and "column_default" REGEXP_LIKE '^[-]{0,1}[0-9]+(\.[0-9]+){0,1}$' then ' DEFAULT ' || "column_default"
+	else ' DEFAULT ''' || replace("column_default", '''', '''''') || ''''
+end]]
+coldef = [['"' || "exa_col" || '" ' || (]]..col_t..[[) || (]]..default_e..[[) || (case when "not_null" = 1 then ' NOT NULL' else '' end)]]
+
+-- temporal source expressions (TEMPORAL_OUT_OF_RANGE; MySQL zero-dates '0000-00-00' detected via "= 0").
+if oormode == 'NULL' then
+	date_src = [['case when ' || "col_bt" || ' = 0 then null else ' || "col_bt" || ' end']]
+	ts_src   = date_src
+elseif oormode == 'CLAMP' then
+	date_src = [['case when ' || "col_bt" || ' = 0 then date ''''0001-01-01'''' else ' || "col_bt" || ' end']]
+	ts_src   = [['case when ' || "col_bt" || ' = 0 then timestamp ''''0001-01-01 00:00:00'''' else ' || "col_bt" || ' end']]
+else
+	date_src = [["col_bt"]]
+	ts_src   = [["col_bt"]]
+end
+
+if binmode == 'SKIP' then bin_imp = [['cast(null as char)']] else bin_imp = [['to_base64(' || "col_bt" || ')']] end
+if decof == 'VARCHAR' then num_imp = [['cast(' || "col_bt" || ' as char)']] else num_imp = [["col_bt"]] end
+if trunc then text_imp = [['left(' || "col_bt" || ', 2000000)']] else text_imp = [["col_bt"]] end
+if t1bool then t1src = [["col_bt"]] else t1src = [['cast(' || "col_bt" || ' as signed)']] end
+
+-- source SELECT expression(s) for the IMPORT (must align positionally with coldef).
+src = [[case
+	when "data_type" = 'tinyint' and "column_type" like 'tinyint(1)%' then ]]..t1src..[[
+	when "data_type" in ('tinyint','smallint','mediumint','int','integer','bigint') and "is_unsigned" = 1 then 'cast(' || "col_bt" || ' as char)'
+	when "data_type" = 'bit' then 'cast(cast(' || "col_bt" || ' as unsigned) as char)'
+	when "data_type" = 'year' then 'cast(' || "col_bt" || ' as char)'
+	when "data_type" = 'time' then 'cast(' || "col_bt" || ' as char)'
+	when "data_type" in ('binary','varbinary','tinyblob','blob','mediumblob','longblob') then ]]..bin_imp..[[
+	when "data_type" in ('geometry','point','linestring','polygon','multipoint','multilinestring','multipolygon','geometrycollection') then 'st_astext(' || "col_bt" || ')'
+	when "data_type" = 'date' then ]]..date_src..[[
+	when "data_type" in ('datetime','timestamp') then ]]..ts_src..[[
+	when "data_type" in ('decimal','numeric') then ]]..num_imp..[[
+	when "data_type" in ('tinytext','text','mediumtext','longtext','json') then ]]..text_imp..[[
+	else "col_bt"
+end]]
+
+-- constraint-state word + trailing comment (final CONSTRAINT STATE section uses MODIFY CONSTRAINT).
+if cstate == 'FORCE_ENABLE' then sw = 'enable'; scomment = [[  -- forced ENABLE (Exasol re-validates the data)]]
+elseif cstate == 'SET_AS_SOURCE' then sw = 'enable'; scomment = [[  -- matches MySQL source (keys active)]]
+else sw = 'disable'; scomment = [[  -- forced DISABLE (optimizer/BI metadata only; faster)]] end
+
+main_q = [['"' || ]]..sname_e..[[ || '"."' || ]]..U('"table_name"')..[[ || '"']]
+fkname = [[coalesce(nullif("fk_name",''), "table_name" || '_FK_' || "ref_table")]]
+known = [["data_type" in ('tinyint','smallint','mediumint','int','integer','bigint','decimal','numeric','float','double','real','bit','date','datetime','timestamp','time','year','char','varchar','tinytext','text','mediumtext','longtext','enum','set','json','binary','varbinary','tinyblob','blob','mediumblob','longblob','geometry','point','linestring','polygon','multipoint','multilinestring','multipolygon','geometrycollection')]]
+
+-- optional CTEs --------------------------------------------------------------------------------------
+comments_cte = ''  comments_union = ''
+if gen_comments then
+	comments_cte = [[
+,vv_comments_raw as (select * from (import from jdbc at ]]..CONNECTION_NAME..[[ statement 'select table_schema as schema_name, table_name, 0 as sub, cast(null as char) as column_name, table_comment as comment_text from information_schema.tables where table_type = ''BASE TABLE'' and table_comment <> '''' ]]..myflt..[[ union all select table_schema, table_name, ordinal_position, column_name, column_comment from information_schema.columns where column_comment <> '''' ]]..myflt..[[ and (table_schema, table_name) in (select table_schema, table_name from information_schema.tables where table_type = ''BASE TABLE'')') c ("schema_name", "table_name", "sub", "column_name", "comment_text") )
+,vv_comment_tab as (select 'COMMENT ON TABLE ' || ]]..main_q..[[ || ' IS ' || '''' || replace("comment_text", '''', '''''') || '''' || ';' as sql_text from vv_comments_raw where "sub" = 0)
+,vv_comment_col as (select 'COMMENT ON COLUMN ' || ]]..main_q..[[ || '."' || ]]..U('"column_name"')..[[ || '"' || ' IS ' || '''' || replace("comment_text", '''', '''''') || '''' || ';' as sql_text from vv_comments_raw where "sub" > 0)]]
+	comments_union = "\n".. [[UNION ALL select 41, cast('-- ### COMMENTS ###' as varchar(2000000)) SQL_TEXT
+UNION ALL select 42, sql_text from vv_comment_tab
+UNION ALL select 43, sql_text from vv_comment_col]]
+end
+
+views_cte = ''  views_union = ''
+if gen_views then
+	views_cte = [[
+,vv_views_raw as (select * from (import from jdbc at ]]..CONNECTION_NAME..[[ statement 'select table_schema as schema_name, table_name as view_name, view_definition as view_def from information_schema.views where 1 = 1 ]]..myflt..[[') v ("schema_name", "view_name", "view_def") )
+,vv_views as (select '-- ' || "schema_name" || '.' || "view_name" || '  (MySQL view - review and adapt to Exasol SQL manually):' || chr(10) || '-- ' || replace("view_def", chr(10), chr(10) || '-- ') as sql_text from vv_views_raw)]]
+	views_union = "\n".. [[UNION ALL select 90, cast('-- ### VIEWS (MySQL SQL - commented out, manual review required) ###' as varchar(2000000)) SQL_TEXT
+UNION ALL select 91, sql_text from vv_views]]
+end
+
+part_cte = ''  part_union = ''
+if gen_part then
+	part_cte = [[
+,vv_part_raw as (select * from (import from jdbc at ]]..CONNECTION_NAME..[[ statement 'select distinct table_schema as schema_name, table_name, partition_method, partition_expression from information_schema.partitions where partition_name is not null ]]..myflt..[[') pt ("schema_name", "table_name", "partition_method", "partition_expression") )
+,vv_partcol as (select "schema_name","table_name", coalesce("partition_method",'unknown') as "pm", coalesce("partition_expression",'') as "pe",
+	case when "partition_expression" REGEXP_LIKE '^`{0,1}[A-Za-z_][A-Za-z0-9_]*`{0,1}$' then replace("partition_expression",'`','') else null end as "raw_col"
+	from vv_part_raw)
+,vv_part as (
+	select 'ALTER TABLE "' || ]]..sname_e..[[ || '"."' || ]]..U('"table_name"')..[[ || '" PARTITION BY "' || ]]..U('"raw_col"')..[[ || '";' as sql_text
+	from vv_partcol where "raw_col" is not null
+	union all
+	select '-- "' || ]]..U('"schema_name"')..[[ || '"."' || ]]..U('"table_name"')..[[ || '" MySQL ' || "pm" || ' partitioning (' || "pe" || ') not auto-mapped - review and add PARTITION BY manually if appropriate.' as sql_text
+	from vv_partcol where "raw_col" is null)]]
+	part_union = "\n".. [[UNION ALL select 37, cast('-- ### PARTITION BY (best-effort from a single-column MySQL partition key; complex partitioning listed as a review note) ###' as varchar(2000000)) SQL_TEXT
+UNION ALL select 38, sql_text from vv_part]]
+end
+
+-- CHECK_MIGRATION: per table a wide single-scan typed metrics row is computed on BOTH systems; a per-schema
+-- summary unpivots+joins them, flagging each metric OK/DEVIATION. Metrics are cross-database comparable so
+-- faithfully migrated data shows no false deviation: row/NULL/DISTINCT counts, numeric MIN/MAX/SUM (exact
+-- decimals/integers only), date/timestamp MIN/MAX, variable-char length MIN/MAX. Binary/geometry get NULL/
+-- DISTINCT counts only; fixed char and DOUBLE/float are excluded from the comparable metrics.
+check_cte = ''  check_union = ''
+if gen_check then
+	chk_int  = [["data_type" in ('tinyint','smallint','mediumint','int','integer','bigint','bit')]]
+	chk_dec  = [["data_type" in ('decimal','numeric') and "num_prec" between 1 and 36]]
+	chk_len  = [["data_type" in ('varchar','tinytext','text','mediumtext','longtext','enum','set','json')]]
+	if binmode == 'SKIP' then bin_excl = [[ and "data_type" not in ('binary','varbinary','tinyblob','blob','mediumblob','longblob') ]] else bin_excl = '' end
+	distinct_excl = [[ and "data_type" not in ('geometry','point','linestring','polygon','multipoint','multilinestring','multipolygon','geometrycollection','float','double','real') ]]..bin_excl
+	check_cte = [[
+,vv_chk_base as (
+	select x.*, min("ordinal_position") over (partition by "exa_schema","exa_table") as "min_ord",
+	       sysrow."db_system", mid."metric_id",
+	       case when sysrow."db_system" = 'Exasol' then '"' || x."exa_col" || '"' when x."data_type" = 'bit' then 'cast(' || x."col_bt" || ' as unsigned)' else x."col_bt" end as "ref"
+	from vv_columns x
+	cross join (select 'Exasol' as "db_system" union all select 'MySQL' as "db_system") sysrow
+	cross join (select level-1 as "metric_id" from dual connect by level <= 8) mid
+)
+,vv_chk_expr as (
+	select "exa_schema","exa_table","schema_name","table_name","exa_col","ordinal_position","db_system","metric_id", "exa_table" || '_MIG_CHK' as "wide_name",
+	       (case
+	          when "metric_id" = 0 and "ordinal_position" = "min_ord" then 'cast(count(*) as decimal(36,0))'
+	          when "metric_id" = 1 and "not_null" = 0 ]]..bin_excl..[[ then 'cast(count(case when ' || "ref" || ' is null then 1 end) as decimal(36,0))'
+	          when "metric_id" = 2 and (]]..chk_int..[[) then 'cast(min(' || "ref" || ') as decimal(36,0))'
+	          when "metric_id" = 2 and (]]..chk_dec..[[) then 'cast(min(' || "ref" || ') as decimal(36,' || ]]..sc..[[ || '))'
+	          when "metric_id" = 2 and "data_type" = 'date' then 'min(' || "ref" || ')'
+	          when "metric_id" = 2 and "data_type" in ('datetime','timestamp') then (case when "db_system" = 'Exasol' then 'to_char(min(' || "ref" || '), ''YYYY-MM-DD HH24:MI:SS.FF6'')' else 'date_format(min(' || "ref" || '), ''%Y-%m-%d %H:%i:%s.%f'')' end)
+	          when "metric_id" = 3 and (]]..chk_int..[[) then 'cast(max(' || "ref" || ') as decimal(36,0))'
+	          when "metric_id" = 3 and (]]..chk_dec..[[) then 'cast(max(' || "ref" || ') as decimal(36,' || ]]..sc..[[ || '))'
+	          when "metric_id" = 3 and "data_type" = 'date' then 'max(' || "ref" || ')'
+	          when "metric_id" = 3 and "data_type" in ('datetime','timestamp') then (case when "db_system" = 'Exasol' then 'to_char(max(' || "ref" || '), ''YYYY-MM-DD HH24:MI:SS.FF6'')' else 'date_format(max(' || "ref" || '), ''%Y-%m-%d %H:%i:%s.%f'')' end)
+	          when "metric_id" = 4 ]]..distinct_excl..[[ then 'cast(count(distinct ' || "ref" || ') as decimal(36,0))'
+	          when "metric_id" = 5 and (]]..chk_int..[[) then 'cast(sum(' || "ref" || ') as decimal(36,0))'
+	          when "metric_id" = 5 and (]]..chk_dec..[[) then 'cast(sum(' || "ref" || ') as decimal(36,' || ]]..sc..[[ || '))'
+	          when "metric_id" = 6 and (]]..chk_len..[[) then (case when "db_system" = 'Exasol' then 'cast(min(length(' || "ref" || ')) as decimal(36,0))' else 'cast(min(char_length(' || "ref" || ')) as decimal(36,0))' end)
+	          when "metric_id" = 7 and (]]..chk_len..[[) then (case when "db_system" = 'Exasol' then 'cast(max(length(' || "ref" || ')) as decimal(36,0))' else 'cast(max(char_length(' || "ref" || ')) as decimal(36,0))' end)
+	        end) as "metric_expr"
+	from vv_chk_base
+)
+,vv_chk_named as (
+	select "exa_schema","exa_table","schema_name","table_name","ordinal_position","db_system","metric_id","wide_name","metric_expr",
+	       (case "metric_id" when 0 then 'ROW_CNT' when 1 then "exa_col" || '_NULLS' when 2 then "exa_col" || '_MIN' when 3 then "exa_col" || '_MAX' when 4 then "exa_col" || '_DISTINCT' when 5 then "exa_col" || '_SUM' when 6 then "exa_col" || '_MINLEN' when 7 then "exa_col" || '_MAXLEN' end) as "metric_name"
+	from vv_chk_expr where "metric_expr" is not null
+)
+,vv_chk_sys as (
+	select "exa_schema","exa_table","schema_name","table_name","wide_name","db_system",
+	       'select ' || (case when "db_system" = 'Exasol' then 'cast(''Exasol'' as varchar(10)) as "DB_SYSTEM", ' else '''MySQL'' as db_system, ' end) || listagg("metric_expr" || (case when "db_system" = 'Exasol' then ' as "' || "metric_name" || '"' else '' end), ', ') within group (order by "ordinal_position","metric_id") || ' from ' || (case when "db_system" = 'Exasol' then '"' || "exa_schema" || '"."' || "exa_table" || '"' else '`' || "schema_name" || '`.`' || "table_name" || '`' end) as "sys_select"
+	from vv_chk_named group by "exa_schema","exa_table","schema_name","table_name","wide_name","db_system"
+)
+,vv_chk_wide as (
+	select 'CREATE OR REPLACE TABLE "' || "exa_schema" || '"."' || "wide_name" || '" AS ' || max(case when "db_system" = 'Exasol' then "sys_select" end) || ' UNION ALL select * from (IMPORT FROM JDBC AT ]]..CONNECTION_NAME..[[ STATEMENT ' || '''' || replace(max(case when "db_system" = 'MySQL' then "sys_select" end), '''', '''''') || '''' || ') ;' as sql_text
+	from vv_chk_sys group by "exa_schema","wide_name"
+)
+,vv_chk_unpiv as (
+	select "exa_schema","exa_table","ordinal_position","metric_id","db_system",
+	       'select ' || '''' || "exa_table" || '''' || ' as "TABLE_NAME", ' || '''' || "metric_name" || '''' || ' as "METRIC", to_char("' || "metric_name" || '") as "VAL" from "' || "exa_schema" || '"."' || "wide_name" || '" where "DB_SYSTEM" = ' || '''' || "db_system" || '''' as "frag"
+	from vv_chk_named
+)
+,vv_chk_summary as (
+	select 'CREATE OR REPLACE TABLE "DATABASE_MIGRATION"."' || "exa_schema" || '_MIG_CHK" AS select e."TABLE_NAME", e."METRIC", e."VAL" as "EXASOL_METRIC", t."VAL" as "MYSQL_METRIC", case when coalesce(e."VAL", ''~NULL~'') = coalesce(t."VAL", ''~NULL~'') then ''OK'' else ''DEVIATION'' end as "STATUS" from (' || listagg(case when "db_system" = 'Exasol' then "frag" end, ' union all ') within group (order by "exa_table","ordinal_position","metric_id") || ') e join (' || listagg(case when "db_system" = 'MySQL' then "frag" end, ' union all ') within group (order by "exa_table","ordinal_position","metric_id") || ') t on e."TABLE_NAME" = t."TABLE_NAME" and e."METRIC" = t."METRIC" order by "STATUS" desc, e."TABLE_NAME", e."METRIC";' as sql_text
+	from vv_chk_unpiv group by "exa_schema"
+)]]
+	check_union = "\n".. [[UNION ALL select 70, cast('-- ### DATA VALIDATION (CHECK_MIGRATION) - run AFTER the IMPORTs; compares source vs target metrics ###' as varchar(2000000)) SQL_TEXT
+UNION ALL select 71, sql_text from vv_chk_wide
+UNION ALL select 72, cast('-- per-schema validation summary (one row per metric; STATUS = OK / DEVIATION):' as varchar(2000000))
+UNION ALL select 73, sql_text from vv_chk_summary
+UNION ALL select 74, cast('-- review deviations with:  select * from "DATABASE_MIGRATION"."<schema>_MIG_CHK" where "STATUS" = ''DEVIATION'';' as varchar(2000000))]]
+end
+
 suc, res = pquery([[
-
-with vv_mysql_columns as (
-    select ]]..exa_upper_begin..[[table_catalog]]..exa_upper_end..[[ as "exa_table_catalog", ]]..exa_upper_begin..[[table_schema]]..exa_upper_end..[[ as "exa_table_schema", ]]..exa_upper_begin..[[table_name]]..exa_upper_end..[[ as "exa_table_name", ]]..exa_upper_begin..[[column_name]]..exa_upper_end..[[ as "exa_column_name", mysql.* from   
-    ( import from jdbc at ]]..CONNECTION_NAME..[[ statement 
-        'select table_catalog, table_schema, table_name, column_name, ordinal_position, column_default, case when is_nullable=''NO'' then ''NOT NULL'' else ''NULL'' end as NOT_NULL_CONSTRAINT, data_type, column_type, character_maximum_length, numeric_precision, numeric_scale  
-           from information_schema.columns join information_schema.tables using (table_catalog, table_schema, table_name) 
-          where table_type = ''BASE TABLE'' 
-            AND table_schema not in (''information_schema'',''performance_schema'', ''mysql'')
-            AND table_schema like '']]..SCHEMA_FILTER..[[''
-            AND table_name like '']]..TABLE_FILTER..[[''
-        '
-    ) as mysql 
+with vv_columns as (
+	select ]]..sname_e..[[ as "exa_schema", ]]..U('"table_name"')..[[ as "exa_table", ]]..U('"column_name"')..[[ as "exa_col", '`' || "column_name" || '`' as "col_bt",
+	       case when "is_nullable" = 'NO' then 1 else 0 end as "not_null",
+	       case when "column_type" like '%unsigned%' then 1 else 0 end as "is_unsigned",
+	       case when upper("extra") like '%GENERATED%' and upper("extra") not like '%DEFAULT_GENERATED%' then 1 else 0 end as "is_generated",
+	       t.*
+	from (import from jdbc at ]]..CONNECTION_NAME..[[ statement ']]..columns_q..[[') t ("schema_name", "table_name", "column_name", "ordinal_position", "column_default", "is_nullable", "data_type", "column_type", "char_len", "num_prec", "num_scale", "dt_prec", "extra")
 )
-
-,vv_create_schemas as(
-	SELECT 'create schema if not exists "' || "exa_table_schema" || '";' as sql_text from vv_mysql_columns  group by "exa_table_catalog","exa_table_schema" order by "exa_table_catalog","exa_table_schema"
+,vv_catchall as (
+	select '-- NOTE: column "' || "schema_name" || '"."' || "table_name" || '"."' || "column_name" || '" has unmapped MySQL type ' || "data_type" || ' -> migrated via VARCHAR(2000000) catch-all (please review).' as sql_text
+	from vv_columns where not (]]..known..[[)
 )
-
+,vv_pk_raw as (select * from (import from jdbc at ]]..CONNECTION_NAME..[[ statement ']]..pk_q..[[') p ("schema_name", "table_name", "column_name", "column_position"))
+,vv_pk as (
+	select 'ALTER TABLE ' || '"' || ]]..sname_e..[[ || '"."' || ]]..U('"table_name"')..[[ || '"' || ' ADD CONSTRAINT "' || ]]..U('"table_name"')..[[ || '_PK" PRIMARY KEY (' || group_concat('"' || ]]..U('"column_name"')..[[ || '"' order by "column_position") || ') DISABLE;' as sql_text
+	from vv_pk_raw group by "schema_name","table_name"
+)
+,vv_fk_raw as (select f.* from (import from jdbc at ]]..CONNECTION_NAME..[[ statement ']]..fk_q..[[') f ("schema_name", "table_name", "fk_name", "fk_column", "ref_schema", "ref_table", "ref_column", "col_position") where exists (select 1 from vv_columns c where c."schema_name" = f."ref_schema" and c."table_name" = f."ref_table"))
+,vv_fk as (
+	select 'ALTER TABLE ' || '"' || ]]..sname_e..[[ || '"."' || ]]..U('"table_name"')..[[ || '"' || ' ADD CONSTRAINT "' || ]]..U(fkname)..[[ || '" FOREIGN KEY (' || group_concat('"' || ]]..U('"fk_column"')..[[ || '"' order by "col_position") || ') REFERENCES "' || ]]..ref_sname_e..[[ || '"."' || ]]..U('"ref_table"')..[[ || '" (' || group_concat('"' || ]]..U('"ref_column"')..[[ || '"' order by "col_position") || ') DISABLE;' as sql_text
+	from vv_fk_raw group by "schema_name","table_name","fk_name","ref_schema","ref_table"
+)
+,vv_create_schemas as (select distinct 'CREATE SCHEMA IF NOT EXISTS "' || "exa_schema" || '";' as sql_text from vv_columns)
 ,vv_create_tables as (
-    select 'create or replace table "' || "exa_table_schema" || '"."' || "exa_table_name" || '" (' || group_concat(
-    case 
-    -- ### numeric types ###
-    when upper(data_type) = 'INT' then '"' || "exa_column_name" || '" ' || 'DECIMAL(11,0) ' || case when column_default is not NULL then 'DEFAULT ' || column_default || ' ' end || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'INTEGER' then '"' || "exa_column_name" || '" ' || 'DECIMAL(11,0) ' || case when column_default is not NULL then 'DEFAULT ' || column_default || ' ' end || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'TINYINT' then '"' || "exa_column_name" || '" ' || 'DECIMAL(4,0) ' || case when column_default is not NULL then 'DEFAULT ' || column_default || ' ' end || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'SMALLINT' then '"' || "exa_column_name" || '" ' || 'DECIMAL(5,0) ' || case when column_default is not NULL then 'DEFAULT ' || column_default || ' ' end || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'MEDIUMINT' then '"' || "exa_column_name" || '" ' || 'DECIMAL(9,0) ' || case when column_default is not NULL then 'DEFAULT ' || column_default || ' ' end || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'BIGINT' then '"' || "exa_column_name" || '" ' || 'DECIMAL (20,0) ' || case when column_default is not NULL then 'DEFAULT ' || column_default || ' ' end || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'FLOAT' then '"' || "exa_column_name" || '" ' || 'FLOAT ' || case when column_default is not NULL then 'DEFAULT ' || column_default || ' ' end || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'DOUBLE' then '"' || "exa_column_name" || '" ' || 'DOUBLE ' || case when column_default is not NULL then 'DEFAULT ' || column_default || ' ' end || NOT_NULL_CONSTRAINT 
-    -- in mysql scale <= 30 and scale <= precision
-    when upper(data_type) = 'DECIMAL' then case when numeric_precision is null then '"' || "exa_column_name" || '" ' || 'DOUBLE' else '"' || "exa_column_name" || '" ' || 'decimal(' || case when numeric_precision > 36 then 36 else numeric_precision end || ',' || case when (numeric_scale > numeric_precision) then numeric_precision else  case when numeric_scale < 0 then 0 else numeric_scale end end || ') ' end || case when column_default is not NULL then 'DEFAULT ' || column_default || ' ' end || NOT_NULL_CONSTRAINT
-    /* alternative when you want to keep the value as a double and precision > 36
-    when upper(data_type) = 'DECIMAL' then case when numeric_precision is null or numeric_precision > 36 then 'DOUBLE' else 'decimal(' || numeric_precision || ',' || case when (numeric_scale > numeric_precision) then numeric_precision else  case when numeric_scale < 0 then 0 else numeric_scale end end || ')' end 
-    */
-    when upper(data_type) = 'BIT' then '"' || "exa_column_name" || '" ' || 'DECIMAL('||numeric_precision||',0) ' || case when column_default is not NULL then 'DEFAULT ' || column_default || ' ' end || NOT_NULL_CONSTRAINT
-
-    -- ### date and time types ###
-    when upper(data_type) = 'DATE' then '"' || "exa_column_name" || '" ' || 'DATE ' || case when column_default is not NULL then 'DEFAULT ''' || column_default || ''' ' end || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'DATETIME' then '"' || "exa_column_name" || '" ' || 'TIMESTAMP ' || case when column_default is not NULL then 'DEFAULT ''' || column_default || ''' ' end || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'TIMESTAMP' then '"' || "exa_column_name" || '" ' || 'TIMESTAMP ' || case when column_default is not NULL then 'DEFAULT ''' || column_default || ''' ' end || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'TIME' then '"' || "exa_column_name" || '" ' || 'varchar(8) ' || case when column_default is not NULL then 'DEFAULT ''' || column_default || ''' ' end || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'YEAR' then '"' || "exa_column_name" || '" ' || 'varchar(4) ' || case when column_default is not NULL then 'DEFAULT ''' || column_default || ''' ' end || NOT_NULL_CONSTRAINT
-
-    -- ### string types ###
-    when upper(data_type) = 'CHAR' then '"' || "exa_column_name" || '" ' || upper(column_type) || ' ' || case when column_default is not NULL then 'DEFAULT ''' || column_default || ''' ' end || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'VARCHAR' then '"' || "exa_column_name" || '" ' || upper(column_type) || ' ' || case when column_default is not NULL then 'DEFAULT ''' || column_default || ''' ' end || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'BINARY' then '"' || "exa_column_name" || '" ' || 'char('||character_maximum_length||') ' || case when column_default is not NULL then 'DEFAULT ''' || column_default || ''' ' end || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'VARBINARY' then '"' || "exa_column_name" || '" ' || 'varchar('||character_maximum_length||') ' || case when column_default is not NULL then 'DEFAULT ''' || column_default || ''' ' end || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'TINYTEXT' then '"' || "exa_column_name" || '" ' || 'varchar(2000000) ' || case when column_default is not NULL then 'DEFAULT ''' || column_default || ''' ' end || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'TEXT' then '"' || "exa_column_name" || '" ' || 'varchar(2000000) ' || case when column_default is not NULL then 'DEFAULT ''' || column_default || ''' ' end || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'MEDIUMTEXT' then '"' || "exa_column_name" || '" ' || 'varchar(2000000) ' || case when column_default is not NULL then 'DEFAULT ''' || column_default || ''' ' end || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'LONGTEXT' then '"' || "exa_column_name" || '" ' || 'varchar(2000000) ' || case when column_default is not NULL then 'DEFAULT ''' || column_default || ''' ' end || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'TINYBLOB' then '"' || "exa_column_name" || '" ' || 'varchar(2000000) ' || case when column_default is not NULL then 'DEFAULT ''' || column_default || ''' ' end || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'BLOB' then '"' || "exa_column_name" || '" ' || 'varchar(2000000) ' || case when column_default is not NULL then 'DEFAULT ''' || column_default || ''' ' end || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'MEDIUMBLOB' then '"' || "exa_column_name" || '" ' || 'varchar(2000000) ' || case when column_default is not NULL then 'DEFAULT ''' || column_default || ''' ' end || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'LONGBLOB' then '"' || "exa_column_name" || '" ' || 'varchar(2000000) ' || case when column_default is not NULL then 'DEFAULT ''' || column_default || ''' ' end || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'ENUM' then '"' || "exa_column_name" || '" ' || 'varchar(2000000) ' || case when column_default is not NULL then 'DEFAULT ''' || column_default || ''' ' end || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'SET' then '"' || "exa_column_name" || '" ' || 'varchar(2000000) ' || case when column_default is not NULL then 'DEFAULT ''' || column_default || ''' ' end || NOT_NULL_CONSTRAINT
-
-    -- ### geospatial types ###    
-    when upper(data_type) = 'GEOMETRY' then '"' || "exa_column_name" || '" ' || upper(column_type) || ' ' || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'GEOMETRYCOLLECTION' then '"' || "exa_column_name" || '" ' || upper('geometry') || ' ' || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'POINT' then '"' || "exa_column_name" || '" ' || upper('geometry') || ' ' || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'MULTIPOINT' then '"' || "exa_column_name" || '" ' || upper('geometry') || ' ' || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'LINESTRING' then '"' || "exa_column_name" || '" ' || upper('geometry') || ' ' || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'MULTILINESTRING' then upper('geometry') || ' ' || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'POLYGON' then '"' || "exa_column_name" || '" ' || upper('geometry') || ' ' || NOT_NULL_CONSTRAINT
-    when upper(data_type) = 'MULTIPOLYGON' then '"' || "exa_column_name" || '" ' || upper('geometry') || ' ' || NOT_NULL_CONSTRAINT
-    
-    end
-	order by ordinal_position) || ');' 
-
-	-- ### unknown types ###
-	|| group_concat (
-	       case 
-	       when upper(data_type) not in ('INT', 'INTEGER', 'TINYINT', 'SMALLINT', 'MEDIUMINT', 'BIGINT', 'FLOAT', 'DOUBLE', 'DECIMAL', 'BIT', 'DATE', 'DATETIME', 'TIMESTAMP', 'TIME', 'YEAR', 'CHAR', 'VARCHAR', 'VARBINARY', 'BINARY', 'TINYTEXT', 'TEXT', 'MEDIUMTEXT', 'LONGTEXT', 'TINYBLOB', 'BLOB', 'MEDIUMBLOB', 'LONGBLOB', 'ENUM', 'SET', 'GEOMETRY', 'GEOMETRYCOLLECTION', 'POINT', 'MULTIPOINT', 'LINESTRING', 'MULTILINESTRING', 'POLYGON', 'MULTIPOLYGON')
-	       then '--UNKNOWN_DATATYPE: "'|| "exa_column_name" || '" ' || upper(data_type) || ''
-	       end
-	)|| ' 'as sql_text
-	from vv_mysql_columns  group by "exa_table_catalog","exa_table_schema", "exa_table_name"
-	order by "exa_table_catalog","exa_table_schema","exa_table_name"
+	select 'CREATE OR REPLACE TABLE "' || "exa_schema" || '"."' || "exa_table" || '" (' || group_concat((]]..coldef..[[) order by "ordinal_position" separator ', ') || ');' as sql_text
+	from vv_columns group by "exa_schema","exa_table"
 )
-
-, vv_imports as (
-	select 'import into "' || "exa_table_schema" || '"."' || "exa_table_name" || '" from jdbc at ]]..CONNECTION_NAME..[[ statement ''select ' 
-           || group_concat(
-							case
-							-- ### numeric types ###
-							when upper(data_type) = 'INT' then '`' || column_name || '`' 
-							when upper(data_type) = 'INTEGER' then '`' || column_name || '`' 
-							when upper(data_type) = 'TINYINT' then '`' || column_name || '`' 
-							when upper(data_type) = 'SMALLINT' then '`' || column_name || '`' 
-							when upper(data_type) = 'MEDIUMINT' then '`' || column_name || '`' 
-							when upper(data_type) = 'BIGINT' then '`' || column_name || '`' 
-							when upper(data_type) = 'FLOAT' then '`' || column_name || '`' 
-							when upper(data_type) = 'DOUBLE' then '`' || column_name || '`' 
-							when upper(data_type) = 'DECIMAL' then '`' || column_name || '`'
-
-							-- ### date and time types ###
-							when upper(data_type) = 'DATE' then '`' || column_name || '`' 
-							when upper(data_type) = 'DATETIME' then '`' || column_name || '`' 
-							when upper(data_type) = 'TIMESTAMP' then '`' || column_name || '`' 
-
-							-- ### string types ###
-							when upper(data_type) = 'CHAR' then '`' || column_name || '`' 
-							when upper(data_type) = 'VARCHAR' then '`' || column_name || '`' 
-							when upper(data_type) = 'TINYTEXT' then '`' || column_name || '`' 
-							when upper(data_type) = 'TEXT' then '`' || column_name || '`' 
-							when upper(data_type) = 'MEDIUMTEXT' then '`' || column_name || '`' 
-							when upper(data_type) = 'LONGTEXT' then '`' || column_name || '`' 
-							when upper(data_type) = 'ENUM' then '`' || column_name || '`' 
-							when upper(data_type) = 'SET' then '`' || column_name || '`' 
-
-							when upper(data_type) = 'BINARY' then 'cast(`'||column_name||'` as char('||character_maximum_length||'))'
-							when upper(data_type) = 'VARBINARY' then 'cast(`'||column_name||'` as char('||character_maximum_length||'))'
-							when upper(data_type) = 'TINYBLOB' then 'cast(`'||column_name||'` as char(2000000))'			  
-							when upper(data_type) = 'MEDIUMBLOB' then 'cast(`'||column_name||'` as char(2000000))'
-							when upper(data_type) = 'BLOB' then 'cast(`'||column_name||'` as char(2000000))'
-							when upper(data_type) = 'LONGBLOB' then 'cast(`'||column_name||'` as char(2000000))'
-							when upper(data_type) = 'TIME' then 'cast(`'||column_name||'` as char(8))'						   
-							when upper(data_type) = 'YEAR' then 'cast(`'||column_name||'` as char(4))'
-							-- ### for MySQL versions below 5.6 ST_AsText() needs to be replaced with AsText() ###
-							when upper(data_type) = 'GEOMETRY' then 'ST_AsText(`'||column_name||'`)'
-							when upper(data_type) = 'GEOMETRYCOLLECTION' then 'ST_AsText(`'||column_name||'`)'
-							when upper(data_type) = 'POINT' then 'ST_AsText(`'||column_name||'`)'
-							when upper(data_type) = 'MULTIPOINT' then 'ST_AsText(`'||column_name||'`)'
-							when upper(data_type) = 'LINESTRING' then 'ST_AsText(`'||column_name||'`)'
-							when upper(data_type) = 'MULTILINESTRING' then 'ST_AsText(`'||column_name||'`)'
-							when upper(data_type) = 'POLYGON' then 'ST_AsText(`'||column_name||'`)'
-							when upper(data_type) = 'MULTIPOLYGON' then 'ST_AsText(`'||column_name||'`)'
-							when upper(data_type) = 'BIT' then 'cast(`'||column_name||'` as DECIMAL('||numeric_precision||',0))'
-							end order by ordinal_position) 
-           || ' from ' || table_schema|| '.' || table_name|| ''';' as sql_text
-	from vv_mysql_columns group by "exa_table_catalog","exa_table_schema","exa_table_name", table_schema,table_name
-	order by "exa_table_catalog", "exa_table_schema","exa_table_name", table_schema,table_name
-)
-select SQL_TEXT from (
-select 1 as ord, cast('-- ### SCHEMAS ###' as varchar(2000000)) SQL_TEXT
-union all 
-select 2, a.* from vv_create_schemas a
-union all 
-select 3, cast('-- ### TABLES ###' as varchar(2000000)) SQL_TEXT
-union all
-select 4, b.* from vv_create_tables b
-WHERE b.SQL_TEXT NOT LIKE '%();%'
-union all
-select 5, cast('-- ### IMPORTS ###' as varchar(2000000)) SQL_TEXT
-union all
-select 6, c.* from vv_imports c
-WHERE c.SQL_TEXT NOT LIKE '%select  from%' 
+,vv_imports as (
+	select 'IMPORT INTO "' || "exa_schema" || '"."' || "exa_table" || '" FROM JDBC AT ]]..CONNECTION_NAME..[[ STATEMENT ' || '''' || 'select ' || group_concat((]]..src..[[) order by "ordinal_position" separator ', ') || ' from ' || '`' || "schema_name" || '`.`' || "table_name" || '`' || '''' || ';' as sql_text
+	from vv_columns group by "exa_schema","exa_table","schema_name","table_name"
+)]]..comments_cte..views_cte..part_cte..check_cte..[[
+select sql_text from (
+	select 0 ord, sql_text SQL_TEXT from vv_catchall
+	UNION ALL select 1, cast('-- ### SCHEMAS ###' as varchar(2000000))
+	UNION ALL select 2, sql_text from vv_create_schemas
+	UNION ALL select 3, cast('-- ### TABLES (incl. PRIMARY KEY, created DISABLED) ###' as varchar(2000000))
+	UNION ALL select 4, sql_text from vv_create_tables where sql_text not like '%();%'
+	UNION ALL select 5, cast('-- ### PRIMARY KEYS (DISABLED) ###' as varchar(2000000))
+	UNION ALL select 6, sql_text from vv_pk
+	UNION ALL select 7, cast('-- ### FOREIGN KEYS (DISABLED) ###' as varchar(2000000))
+	UNION ALL select 8, sql_text from vv_fk]]..comments_union..part_union..[[
+	UNION ALL select 50, cast('-- ### IMPORTS ###' as varchar(2000000))
+	UNION ALL select 51, sql_text from vv_imports
+	UNION ALL select 60, cast('-- ### CONSTRAINT STATE - run AFTER the data load (keys created DISABLED for a fast, order-independent load) ###' as varchar(2000000))
+	UNION ALL select 61, 'ALTER TABLE "' || ]]..sname_e..[[ || '"."' || ]]..U('"table_name"')..[[ || '" MODIFY CONSTRAINT "' || ]]..U('"table_name"')..[[ || '_PK" ]]..sw..[[;]]..scomment..[[' from vv_pk_raw group by "schema_name","table_name"
+	UNION ALL select 62, 'ALTER TABLE "' || ]]..sname_e..[[ || '"."' || ]]..U('"table_name"')..[[ || '" MODIFY CONSTRAINT "' || ]]..U(fkname)..[[ || '" ]]..sw..[[;]]..scomment..[[' from vv_fk_raw group by "schema_name","table_name","fk_name","ref_table"]]..views_union..check_union..[[
 ) order by ord
 ]],{})
 
-if not suc then
-  error('"'..res.error_message..'" Caught while executing: "'..res.statement_text..'"')
-end
-
+if not suc then error('"'..res.error_message..'" caught while executing: "'..res.statement_text..'"') end
 return(res)
-
 /
 
+-- ===================================================================================================
+-- CONNECTION SETUP
+-- ===================================================================================================
+-- Prerequisites
+--   * The MySQL database must be reachable from this Exasol database.
+--   * The credentials used in the connection must be valid.
+--   * Use the latest MySQL JDBC driver (mysql-connector-j).
+--
+-- JDBC driver (install once in BucketFS - the driver and its settings.cfg)
+--   * mysql-connector-j 9.x or higher
+--       https://mvnrepository.com/artifact/com.mysql/mysql-connector-j
+--   * Driver setup guide:
+--       https://docs.exasol.com/db/latest/loading_data/connect_sources/mysql.htm
+--   * Optional: add the URL parameter zeroDateTimeBehavior=CONVERT_TO_NULL to load MySQL zero-dates as NULL at
+--     the driver level (otherwise the recommended TEMPORAL_OUT_OF_RANGE='FAIL' lets the IMPORT fail loudly on them).
+--
+-- Create a connection to the MySQL database (adjust host, database name and credentials),
+-- then run the accompanying test query.
 
-create or replace connection mysql_conn 
-to 'jdbc:mysql://192.168.137.5:3306'
-user 'user'
-identified by 'exasolRocks!';
+CREATE OR REPLACE CONNECTION MYSQL_JDBC
+    TO 'jdbc:mysql://mysql_host_or_ip:3306/my_database'
+    USER 'username' IDENTIFIED BY 'password';
+SELECT * FROM (IMPORT FROM JDBC AT MYSQL_JDBC STATEMENT 'SELECT ''Connection works''');
 
-execute script database_migration.MYSQL_TO_EXASOL('mysql_conn' --name of your database connection
-,TRUE -- case sensitivity handling for identifiers -> false: handle them case sensitiv / true: handle them case insensitiv --> recommended: true
-,'mb%' -- schema filter --> '%' to load all schemas except 'information_schema' and 'mysql' and 'performance_schema' / '%publ%' to load all schemas like '%pub%'
-,'%' -- table filter --> '%' to load all tables (
+-- ===================================================================================================
+-- GENERATE THE MIGRATION STATEMENTS (recommended defaults shown)
+-- ===================================================================================================
+EXECUTE SCRIPT DATABASE_MIGRATION.MYSQL_TO_EXASOL(
+    'MYSQL_JDBC',       -- CONNECTION_NAME: name of the JDBC connection created at the bottom of the script
+    true,               -- IDENTIFIER_CASE_INSENSITIVE: true (recommended) => fold ALL identifiers to UPPER so Exasol queries never need quotes; false => keep verbatim/quoted
+    '%',                -- SCHEMA_FILTER: source database(s): 'mydb', 'sales_%', '%' (all; system schemas always excluded)
+    '%',                -- TABLE_FILTER: table(s)/view(s): 'my_table', 'my_%', '%' (all)
+    '',                 -- TARGET_SCHEMA: Exasol target schema; '' (recommended) => use the source schema name
+    'FORCE_DISABLE',    -- CONSTRAINT_STATE: 'FORCE_DISABLE' (recommended; PK/FK kept as metadata only - faster, order-independent imports, still used by BI tools), 'SET_AS_SOURCE' or 'FORCE_ENABLE' (all keys enabled = Exasol re-validates the data)
+    true,               -- GENERATE_COMMENTS: true (recommended) => migrate MySQL comments as COMMENT ON; false => skip
+    true,               -- GENERATE_VIEWS: true => emit source views as a commented manual-review section; false => skip
+    true,               -- GENERATE_PARTITION_BY: true => add a best-effort PARTITION BY from a single-column MySQL partition key; complex partitioning is listed as a commented manual-review note; false => skip
+    'BASE64',           -- BINARY_HANDLING: 'BASE64' (recommended; binary/blob migrated losslessly as base64 text - Exasol has no general binary type) or 'SKIP' (load NULL)
+    'CAP',              -- DECIMAL_OVERFLOW: 'CAP' (recommended; decimal>36 -> DECIMAL(36,s); IMPORT fails for values needing > 36 digits), 'DOUBLE' (~15 digits) or 'VARCHAR' (lossless text)
+    false,              -- TRUNCATE_LONG_STRINGS: false (recommended) => import fails on a value > 2,000,000 chars; true => cut such values to 2,000,000 chars and import
+    'FAIL',             -- TEMPORAL_OUT_OF_RANGE: 'FAIL' (recommended; IMPORT fails on a zero-date / out-of-range date), 'NULL' (load NULL) or 'CLAMP' (clamp to the Exasol min)
+    false,              -- TINYINT1_AS_BOOLEAN: false (recommended; tinyint(1) -> DECIMAL(3,0), value preserved) or true (tinyint(1) -> BOOLEAN)
+    false               -- CHECK_MIGRATION: false (recommended default) => skip; true => also build <table>_MIG_CHK metric tables + a <schema>_MIG_CHK summary (source vs target) for post-load validation
 );
-


### PR DESCRIPTION
## Summary

A full rewrite of `mysql_to_exasol.sql` (198 → 417 lines) to the quality and scope of `postgresql_to_exasol.sql`
/ `teradata_to_exasol.sql` (script `DATABASE_MIGRATION.MYSQL_TO_EXASOL`). It fixes bugs that **dropped or
corrupted data**, maps **every** MySQL type (nothing is silently dropped), preserves `datetime`/`timestamp`
precision and time-zone semantics, and additionally migrates **primary keys, foreign keys, comments, defaults**,
a best-effort **PARTITION BY**, an optional commented **views** section and a rebuilt mapping-aware
**CHECK_MIGRATION**. Targets **MySQL 8 / 9** (backward compatible with 5.x) → Exasol v8.

The script is a **generator**: it reads source metadata through the JDBC connection and returns statements to
review and run; it changes nothing itself.

## Why

The previous script had serious problems:

| Issue | Old result | New result |
|---|---|---|
| `json` columns | **silently dropped** (`--UNKNOWN_DATATYPE`) | `VARCHAR(2000000)` (faithful JSON text) |
| `BIT(64)` | `DECIMAL(64,0)` → CREATE TABLE fails (>36) | `DECIMAL(20,0)` (read as text, no Long overflow) |
| `UNSIGNED` ints | ignored; can overflow the driver's signed type | widened (`bigint`→20 digits) + read as text |
| `TIME` | `varchar(8)` → truncates range/fraction | `VARCHAR(17)` (full `-838:59:59…` + fraction) |
| `datetime(6)`/`timestamp(6)` | `TIMESTAMP` → microseconds lost | `TIMESTAMP(6)` (full precision) |
| `timestamp` | plain `TIMESTAMP` (tz lost) | `TIMESTAMP(p) WITH LOCAL TIME ZONE` (instant) |
| `binary`/`blob` | `::char` (charset-dependent) | `TO_BASE64(…)` (byte-exact) |
| zero / out-of-range dates | unhandled | `TEMPORAL_OUT_OF_RANGE` FAIL/NULL/CLAMP |
| `MULTILINESTRING` | invalid DDL (missing column name) | all spatial types → `GEOMETRY` |
| PK, FK, comments, views, partitioning, validation | none | all migrated |

## What changed

- **Full type coverage** mapped by `data_type` (+ the `UNSIGNED` flag, display width and `datetime_precision`):
  integers→`DECIMAL`, `decimal`→`DECIMAL` (overflow via `DECIMAL_OVERFLOW`), `float`/`double`→`DOUBLE`,
  `bit(M)`→`DECIMAL`, `date`→`DATE`, `datetime(p)`→`TIMESTAMP(p)`, `timestamp(p)`→`TIMESTAMP(p) WITH LOCAL TIME
  ZONE`, `time`→`VARCHAR(17)`, `year`→`VARCHAR(4)`, char types→`UTF8`, `tinytext…longtext`/`json`→`VARCHAR`,
  `enum`/`set`→`VARCHAR`, `binary`/`blob`→base64, spatial→`GEOMETRY`. `NOT NULL`, defaults, `AUTO_INCREMENT` and
  generated columns handled. A `VARCHAR(2000000)` catch-all guarantees no future type is silently dropped.
- **Source-side casts** (verified live with Connector/J 9.7) where the driver would otherwise lose or overflow
  data: every `UNSIGNED` integer / `BIT` → `CAST(.. AS CHAR)` into a `DECIMAL` target (`SMALLINT UNSIGNED` 60000
  overflows `java.lang.Short`, `BIGINT UNSIGNED`/`BIT(64)` overflow `java.lang.Long`); `YEAR` and `TIME` →
  `CAST(.. AS CHAR)` (the driver returns `YEAR` as a `DATE`); `tinyint(1)` → `CAST(.. AS SIGNED)` (the driver
  otherwise coerces it to boolean, collapsing non-0/1 to 1); binary → `TO_BASE64`; spatial → `ST_AsText`.
- **Constraints — `CONSTRAINT_STATE`:** PK/FK (composite) created `DISABLE`d, then a final section sets them all
  disabled (`FORCE_DISABLE`, recommended), enabled (`FORCE_ENABLE`, Exasol re-validates) or active
  (`SET_AS_SOURCE`). FKs to tables outside the migration scope are skipped.
- **New objects/options:** comments (`GENERATE_COMMENTS`), commented views (`GENERATE_VIEWS`), best-effort
  `PARTITION BY` (`GENERATE_PARTITION_BY`), `BINARY_HANDLING`, `DECIMAL_OVERFLOW`, `TRUNCATE_LONG_STRINGS`,
  `TEMPORAL_OUT_OF_RANGE`, `TINYINT1_AS_BOOLEAN`, `CHECK_MIGRATION`, `TARGET_SCHEMA`, `IDENTIFIER_CASE_INSENSITIVE`.
- **Only real user data:** a fixed filter excludes the system schemas (`mysql`, `information_schema`,
  `performance_schema`, `sys`).
- **Robust metadata read:** Exasol's IMPORT uses the driver's original column names (aliases are ignored), so
  every metadata IMPORT carries an explicit derived column list.
- **Driver/connection doc** at the end of the script (`mysql-connector-j`) plus a connection test. Both the
  header and the trailing `EXECUTE SCRIPT` document every parameter with recommended defaults.

### Parameters

`CONNECTION_NAME, IDENTIFIER_CASE_INSENSITIVE, SCHEMA_FILTER, TABLE_FILTER, TARGET_SCHEMA, CONSTRAINT_STATE,
GENERATE_COMMENTS, GENERATE_VIEWS, GENERATE_PARTITION_BY, BINARY_HANDLING, DECIMAL_OVERFLOW, TRUNCATE_LONG_STRINGS,
TEMPORAL_OUT_OF_RANGE, TINYINT1_AS_BOOLEAN, CHECK_MIGRATION`.

## Documented limitations (managing expectations)

Maps with a small documented difference: `float`/`double`→DOUBLE; `time`→VARCHAR; `year`→VARCHAR; `timestamp`→
the UTC instant (`WITH LOCAL TIME ZONE`); `enum`/`set`/`json`/spatial→VARCHAR/GEOMETRY. Hard limits that **fail
loudly** rather than corrupt: a value > 2,000,000 chars (unless `TRUNCATE_LONG_STRINGS`); `decimal` > 36 digits
under `CAP`; a zero-date / date outside `0001..9999` under `TEMPORAL_OUT_OF_RANGE='FAIL'`. MySQL has **no**
user-defined types (ENUM/SET are resolved to VARCHAR) and **no** distribution concept (no `DISTRIBUTE BY`).
Out of scope (unchanged): indexes, `UNIQUE`/`CHECK` constraints, triggers, routines, events, users/grants.

## Files in this PR

- **Rewritten:** `mysql_to_exasol.sql` (full rewrite; same file name).
- **Modified:** `README.md` — the **MySQL** section now documents the mapping, driver, parameters and limitations.

## Testing & validation

End-to-end on **MySQL 9.7.1** with **MySQL Connector/J 9.7.0** → **Exasol 2025.1.11**, on a representative
multi-row dataset covering every type family, UNSIGNED integers, `tinyint(1)`, ENUM/SET, all temporal types incl.
fractional seconds, binary/BLOB, JSON, geometry, STORED+VIRTUAL generated columns, a composite PK/FK, a
range-partitioned table and a view. **0 statement failures**; `datetime`/`timestamp` precision preserved;
`bigint unsigned` and `bit(64)` round-trip exactly; `binary` base64 round-trips **byte-exact**; the partition key
is mapped to `PARTITION BY`; multibyte intact. **`CHECK_MIGRATION`: 217 metrics OK / 0 DEVIATION**. All edge
cases and parameter variants exercised live (over-2M text under `TRUNCATE_LONG_STRINGS`; 40-digit decimal under
`DECIMAL_OVERFLOW=CAP/DOUBLE/VARCHAR`; zero-date under `TEMPORAL_OUT_OF_RANGE=FAIL/NULL/CLAMP`; `TARGET_SCHEMA`;
`BINARY_HANDLING=SKIP`; `TINYINT1_AS_BOOLEAN=true`; `IDENTIFIER_CASE_INSENSITIVE=false`; all `CONSTRAINT_STATE`
modes). See `TEST_RESULTS_mysql_to_exasol.md`, `mysql_to_exasol_test.sql`, `mysql_migration_output.sql`.

## Notes

- **Generator only** — review and run the output, in the order returned. Installs cleanly in DbVisualizer (no
  `?` characters).
- For MySQL zero-dates you may also set `zeroDateTimeBehavior=CONVERT_TO_NULL` in the JDBC URL; otherwise the
  recommended `TEMPORAL_OUT_OF_RANGE='FAIL'` lets the IMPORT fail loudly on them.

[TEST_RESULTS_mysql_to_exasol.md](https://github.com/user-attachments/files/29464255/TEST_RESULTS_mysql_to_exasol.md)

[mysql_to_exasol_test.sql](https://github.com/user-attachments/files/29464263/mysql_to_exasol_test.sql)

[mysql_migration_output.sql](https://github.com/user-attachments/files/29464268/mysql_migration_output.sql)

