### PR TITLE
postgresql_to_exasol: fix CHECK_MIGRATION failure on oid columns (ERROR: cannot cast type oid to numeric)

### DIFF
--- a/postgresql_to_exasol.sql
+++ b/postgresql_to_exasol.sql
@@ -299,7 +299,7 @@ if gen_check then
 ,vv_chk_base as (
 	select x.*, min("ordinal_position") over (partition by "exa_schema","exa_table") as "min_ord",
 	       sysrow."db_system", mid."metric_id",
-	       case when sysrow."db_system" = 'Exasol' then '"' || x."exa_col" || '"' else x."col_q" end as "ref"
+	       case when sysrow."db_system" = 'Exasol' then '"' || x."exa_col" || '"' when x."type_name" = 'oid' then x."col_q" || '::bigint' else x."col_q" end as "ref"  -- oid has no direct cast to numeric on PostgreSQL; ::bigint does
 	from vv_chk_cols x
 	cross join (select 'Exasol' as "db_system" union all select 'Postgres' as "db_system") sysrow
 	cross join (select level-1 as "metric_id" from dual connect by level <= 8) mid


### PR DESCRIPTION
## Summary

One-line fix in `postgresql_to_exasol.sql`: with `CHECK_MIGRATION = true`, a migrated **`oid`** column made the
generated DATA VALIDATION section fail on the PostgreSQL side with
`ERROR: cannot cast type oid to numeric`.

## Root cause

`oid` is `pg_type` category `N` (numeric), so the validation builds numeric `MIN`/`MAX`/`SUM` metrics for it
(`cast(min(<col>) as decimal(…))`). On Exasol that is fine (`oid` is migrated to `DECIMAL(10,0)`), but on the
PostgreSQL **source** `oid` has **no direct cast to `numeric`** — it must go via `bigint` first. The generated
`cast(min(the_oid) as decimal(…))` therefore errored, so the `<table>_MIG_CHK` / `<schema>_MIG_CHK` statements
could not be built (the migration itself — CREATE TABLE / IMPORT — was never affected).

## Fix

In the CHECK_MIGRATION metric builder, the PostgreSQL-side column reference for an `oid` column is now cast to
`bigint` (`<col>::bigint`), which casts cleanly to `numeric`. The Exasol side is unchanged. All other types are
unaffected. One changed line:

```sql
-- vv_chk_base."ref"
case when sysrow."db_system" = 'Exasol' then '"' || x."exa_col" || '"'
     when x."type_name" = 'oid' then x."col_q" || '::bigint'   -- NEW: oid -> bigint so it can cast to numeric
     else x."col_q" end as "ref"
```

## Testing

Verified live on **PostgreSQL 18.4 → Exasol 2025.1.11** with a table containing an `oid` column (plus the full
type zoo). Before: the DATA VALIDATION section failed (`cannot cast type oid to numeric`). After: **0 statement
failures**, the per-schema summary reports **all metrics `OK` / 0 `DEVIATION`**, and the `oid` metrics compute
correctly on both systems (`C_OID_MIN/MAX/SUM`, `DISTINCT`, `NULLS` all matched). The script remains
DbVisualizer-clean (no `?` characters).

## Files in this PR

- **Modified:** `postgresql_to_exasol.sql` (one line in the `CHECK_MIGRATION` metric builder).

## Notes

- Generator only — review and run the output, in the order returned.
- Found while reviewing issue #8; unrelated to that issue (which was closed separately).

[TEST_RESULTS_postgresql_to_exasol.md](https://github.com/user-attachments/files/29510951/TEST_RESULTS_postgresql_to_exasol.md)

[postgresql_to_exasol_test.sql](https://github.com/user-attachments/files/29510958/postgresql_to_exasol_test.sql)

[postgresql_migration_output.sql](https://github.com/user-attachments/files/29510962/postgresql_migration_output.sql)

